### PR TITLE
chore: remove ollama path; route LLM traffic through inference engine

### DIFF
--- a/backend/ai_assistant/model_registry.py
+++ b/backend/ai_assistant/model_registry.py
@@ -1,8 +1,8 @@
 """
 Model registry for the AI Assistant.
 
-Defines supported LLM providers (OpenAI, Ollama, local Inference Engine) and
-their model configurations. Each model entry specifies the provider, model id,
+Defines supported LLM providers (OpenAI, local Inference Engine) and their
+model configurations. Each model entry specifies the provider, model id,
 display name, and default generation parameters. The _call_llm() helper selects
 the right SDK at runtime.
 
@@ -14,9 +14,6 @@ hook-v2 stays decoupled from any specific inference backend.
 """
 
 import os
-import logging
-
-logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Registry: model_key → config
@@ -65,186 +62,10 @@ MODEL_REGISTRY = {
         'thinking': False,
         'thinking_level': None,
     },
-    # ── Google Gemma 4 (Ollama / local) ───────────────────────────────
-    'gemma-4-e2b': {
-        'provider': 'ollama',
-        'model_id': 'gemma4:e2b',
-        'display_name': 'Gemma 4 — E2B',
-        'temperature': 0.4,
-        'max_tokens': 4096,
-        'supports_tools': False,
-        'architecture': 'dense',
-        'reasoning': False,
-        'thinking': False,
-        'thinking_level': None,
-        'ram_gb': 5,
-    },
-    'gemma-4-e4b': {
-        'provider': 'ollama',
-        'model_id': 'gemma4:e4b',
-        'display_name': 'Gemma 4 — E4B',
-        'temperature': 0.4,
-        'max_tokens': 4096,
-        'supports_tools': False,
-        'architecture': 'dense',
-        'reasoning': False,
-        'thinking': False,
-        'thinking_level': None,
-        'ram_gb': 7,
-    },
-    'gemma-4-26b': {
-        'provider': 'ollama',
-        'model_id': 'gemma4:26b',
-        'display_name': 'Gemma 4 — 26B',
-        'temperature': 0.4,
-        'max_tokens': 8192,
-        'supports_tools': True,
-        'architecture': 'dense',
-        'reasoning': True,
-        'thinking': True,
-        'thinking_level': 'med',
-        'ram_gb': 19,
-    },
-    'gemma-4-31b': {
-        'provider': 'ollama',
-        'model_id': 'gemma4:31b',
-        'display_name': 'Gemma 4 — 31B',
-        'temperature': 0.4,
-        'max_tokens': 8192,
-        'supports_tools': True,
-        'architecture': 'dense',
-        'reasoning': True,
-        'thinking': True,
-        'thinking_level': 'high',
-        'ram_gb': 21,
-    },
-    # ── Alibaba Qwen 3.6 (Ollama / local) ────────────────────────────
-    'qwen-3.6-27b': {
-        'provider': 'ollama',
-        'model_id': 'qwen3.6:27b',
-        'display_name': 'Qwen 3.6 — 27B',
-        'temperature': 0.4,
-        'max_tokens': 8192,
-        'supports_tools': True,
-        'architecture': 'dense',
-        'reasoning': True,
-        'thinking': True,
-        'thinking_level': 'high',
-        'ram_gb': 18,
-    },
-    # ── MiniMax M2.7 (Ollama cloud) ──────────────────────────────────
-    'minimax-m2.7': {
-        'provider': 'ollama',
-        'model_id': 'minimax-m2.7:cloud',
-        'display_name': 'MiniMax M2.7',
-        'temperature': 0.4,
-        'max_tokens': 8192,
-        'supports_tools': True,
-        'architecture': 'moe',
-        'reasoning': True,
-        'thinking': True,
-        'thinking_level': 'high',
-        'ram_gb': 1,
-    },
-    # ── Mistral — Ministral 3 (Ollama / local) ───────────────────────
-    'ministral-3-14b': {
-        'provider': 'ollama',
-        'model_id': 'ministral-3:14b',
-        'display_name': 'Ministral 3 — 14B',
-        'temperature': 0.4,
-        'max_tokens': 4096,
-        'supports_tools': True,
-        'architecture': 'dense',
-        'reasoning': False,
-        'thinking': False,
-        'thinking_level': None,
-        'ram_gb': 10,
-    },
-    'ministral-3-8b': {
-        'provider': 'ollama',
-        'model_id': 'ministral-3:8b',
-        'display_name': 'Ministral 3 — 8B',
-        'temperature': 0.4,
-        'max_tokens': 4096,
-        'supports_tools': True,
-        'architecture': 'dense',
-        'reasoning': False,
-        'thinking': False,
-        'thinking_level': None,
-        'ram_gb': 6,
-    },
-    'ministral-3-3b': {
-        'provider': 'ollama',
-        'model_id': 'ministral-3:3b',
-        'display_name': 'Ministral 3 — 3B',
-        'temperature': 0.4,
-        'max_tokens': 4096,
-        'supports_tools': False,
-        'architecture': 'dense',
-        'reasoning': False,
-        'thinking': False,
-        'thinking_level': None,
-        'ram_gb': 3,
-    },
-    # ── NVIDIA Nemotron 3 Nano (Ollama / local) ────────────────────────
-    'nemotron-3-nano-30b': {
-        'provider': 'ollama',
-        'model_id': 'nemotron-3-nano:30b',
-        'display_name': 'Nemotron 3 Nano — 30B',
-        'temperature': 0.4,
-        'max_tokens': 8192,
-        'supports_tools': True,
-        'architecture': 'moe',
-        'reasoning': True,
-        'thinking': True,
-        'thinking_level': 'high',
-        'ram_gb': 20,
-    },
-    # ── NVIDIA Nemotron 3 Omni (Ollama / local) ────────────────────────
-    'nemotron-3-omni-33b': {
-        'provider': 'ollama',
-        'model_id': 'nemotron3:33b',
-        'display_name': 'Nemotron 3 Omni — 33B',
-        'temperature': 0.4,
-        'max_tokens': 8192,
-        'supports_tools': True,
-        'architecture': 'moe',
-        'reasoning': True,
-        'thinking': True,
-        'thinking_level': 'high',
-        'ram_gb': 22,
-    },
-    # ── Meta Llama 3.2 (Ollama / local) ────────────────────────────────
-    'llama-3.2-1b': {
-        'provider': 'ollama',
-        'model_id': 'llama3.2:1b',
-        'display_name': 'Llama 3.2 — 1B',
-        'temperature': 0.4,
-        'max_tokens': 4096,
-        'supports_tools': True,
-        'architecture': 'dense',
-        'reasoning': False,
-        'thinking': False,
-        'thinking_level': None,
-        'ram_gb': 2,
-    },
-    'llama-3.2-3b': {
-        'provider': 'ollama',
-        'model_id': 'llama3.2:3b',
-        'display_name': 'Llama 3.2 — 3B',
-        'temperature': 0.4,
-        'max_tokens': 4096,
-        'supports_tools': True,
-        'architecture': 'dense',
-        'reasoning': False,
-        'thinking': False,
-        'thinking_level': None,
-        'ram_gb': 3,
-    },
     # ── Local Inference Engine (llm-inference-engine) ─────────────────
     # Routes through the engine's OpenAI-compatible /v1/chat/completions.
     # The model_id is the engine's qualified name (backend-agnostic — the
-    # engine resolves it to llama_cpp / mlx / vllm / ollama internally).
+    # engine resolves it to llama_cpp / mlx / vllm internally).
     'engine-llama-3.2-3b': {
         'provider': 'engine',
         'model_id': 'llama3.2:3b',
@@ -270,19 +91,6 @@ MODEL_REGISTRY = {
         'thinking': False,
         'thinking_level': None,
         'ram_gb': 2,
-    },
-    'engine-qwen-3.6-27b': {
-        'provider': 'engine',
-        'model_id': 'qwen3.6:27b',
-        'display_name': 'Qwen 3.6 — 27B (Inference Engine)',
-        'temperature': 0.4,
-        'max_tokens': 8192,
-        'supports_tools': True,
-        'architecture': 'dense',
-        'reasoning': True,
-        'thinking': True,
-        'thinking_level': 'high',
-        'ram_gb': 18,
     },
 }
 
@@ -375,107 +183,3 @@ def call_engine(messages: list, model_cfg: dict, tools: list = None) -> dict:
 
     response = client.chat.completions.create(**kwargs)
     return response.model_dump()
-
-
-def call_ollama(messages: list, model_cfg: dict) -> dict:
-    """Call Ollama REST API (OpenAI-compatible /v1/chat/completions)."""
-    import urllib.request
-    import urllib.error
-    import json
-
-    base_url = os.environ.get('OLLAMA_BASE_URL', 'http://ollama:11434')
-
-    payload = {
-        'model': model_cfg['model_id'],
-        'messages': messages,
-        'stream': False,
-        'options': {
-            'temperature': model_cfg.get('temperature', 0.4),
-            'num_predict': model_cfg.get('max_tokens', 4096),
-        },
-    }
-
-    body = json.dumps(payload).encode('utf-8')
-    req = urllib.request.Request(
-        f'{base_url}/api/chat',
-        data=body,
-        method='POST',
-        headers={'Content-Type': 'application/json'},
-    )
-
-    try:
-        with urllib.request.urlopen(req, timeout=300) as resp:
-            data = json.loads(resp.read().decode('utf-8'))
-    except urllib.error.HTTPError as exc:
-        error_body = ''
-        try:
-            error_body = exc.read().decode('utf-8', errors='replace')
-        except Exception:
-            pass
-        if 'requires more system memory' in error_body or exc.code == 500:
-            ram_needed = model_cfg.get('ram_gb', '?')
-            raise EnvironmentError(
-                f"Ollama model '{model_cfg['model_id']}' requires ~{ram_needed} GB RAM but the "
-                f"Docker VM does not have enough memory. "
-                f"Increase Docker Desktop memory: Settings → Resources → Memory "
-                f"(set to at least {ram_needed + 2 if isinstance(ram_needed, int) else '?'} GB), "
-                f"then restart Docker Desktop."
-            ) from exc
-        raise
-
-    # Normalize Ollama response to OpenAI-compatible shape
-    message = data.get('message', {})
-    usage_info = {
-        'prompt_tokens': data.get('prompt_eval_count', 0),
-        'completion_tokens': data.get('eval_count', 0),
-        'total_tokens': data.get('prompt_eval_count', 0) + data.get('eval_count', 0),
-    }
-
-    return {
-        'choices': [{
-            'message': {
-                'role': message.get('role', 'assistant'),
-                'content': message.get('content', ''),
-            },
-            'finish_reason': 'stop',
-        }],
-        'model': data.get('model', model_cfg['model_id']),
-        'usage': usage_info,
-    }
-
-
-def ensure_ollama_model(model_id: str) -> bool:
-    """Pull an Ollama model if not already available. Returns True on success."""
-    import urllib.request
-    import json
-
-    base_url = os.environ.get('OLLAMA_BASE_URL', 'http://ollama:11434')
-
-    # Check if model exists
-    try:
-        req = urllib.request.Request(f'{base_url}/api/tags', method='GET')
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            tags = json.loads(resp.read().decode('utf-8'))
-        existing = [m.get('name', '') for m in tags.get('models', [])]
-        if any(model_id in name for name in existing):
-            return True
-    except Exception:
-        pass
-
-    # Pull the model
-    logger.info("Pulling Ollama model '%s' (first-time download)...", model_id)
-    try:
-        payload = json.dumps({'name': model_id, 'stream': False}).encode('utf-8')
-        req = urllib.request.Request(
-            f'{base_url}/api/pull',
-            data=payload,
-            method='POST',
-            headers={'Content-Type': 'application/json'},
-        )
-        with urllib.request.urlopen(req, timeout=1800) as resp:
-            resp.read()
-        logger.info("Ollama model '%s' pulled successfully.", model_id)
-        return True
-    except Exception as exc:
-        logger.warning("Failed to pull Ollama model '%s': %s", model_id, exc)
-        return False

--- a/backend/ai_assistant/views.py
+++ b/backend/ai_assistant/views.py
@@ -18,7 +18,7 @@ from .tool_executor import execute_tool_call
 from .cache import cache_get, cache_list_artifacts, ARTIFACT_PIPELINE_CONFIG, ARTIFACT_SELECTED_FEATURES, ARTIFACT_DATA_DICTIONARY
 from .model_registry import (
     get_model_config, list_models, DEFAULT_MODEL,
-    call_openai, call_ollama, call_engine, ensure_ollama_model,
+    call_openai, call_engine,
 )
 
 # ---------------------------------------------------------------------------
@@ -233,22 +233,22 @@ Actions: add, edit, delete
 
 @agent(name="llm-advisor")
 def _call_llm(messages: list, model_key: str, tools: list = None) -> dict:
-    """Unified LLM caller — dispatches to OpenAI, the local Inference Engine,
-    or Ollama based on the resolved model config.
+    """Unified LLM caller — dispatches to OpenAI or the local Inference Engine
+    based on the resolved model config.
 
-    Traced as a Prometa agent span. For ``openai`` and ``engine`` providers,
-    GenAI attributes (model, tokens, prompt, completion, cost) are captured
-    automatically by the prometa-sdk openai auto-instrumentation — the
-    engine path uses the OpenAI client with a custom ``base_url`` so the
-    same patch applies. agentic-hook-v2 receives all observability data via
-    this assistant-side instrumentation; the engine itself has no direct
-    coupling to the platform.
+    Traced as a Prometa agent span. For both providers, GenAI attributes
+    (model, tokens, prompt, completion, cost) are captured automatically by
+    the prometa-sdk openai auto-instrumentation — the engine path uses the
+    OpenAI client with a custom ``base_url`` so the same patch applies.
+    agentic-hook-v2 receives all observability data via this assistant-side
+    instrumentation; the engine itself has no direct coupling to the
+    platform.
     """
     model_cfg = get_model_config(model_key)
     provider = model_cfg['provider']
     set_span_attr('gen_ai.request.model', model_cfg['model_id'])
     # Tag the routing target on the parent agent span so the platform UI
-    # can distinguish engine-routed calls from direct cloud / ollama calls.
+    # can distinguish engine-routed calls from direct cloud calls.
     # The child openai-instrumented span still carries gen_ai.system="openai"
     # because the SDK speaks OpenAI protocol regardless of the upstream.
     set_span_attr('declarai.llm.backend', provider)
@@ -264,14 +264,6 @@ def _call_llm(messages: list, model_key: str, tools: list = None) -> dict:
         # See model_registry.call_engine() for the rationale on routing through
         # the OpenAI SDK (it's how prometa-sdk auto-instrumentation finds it).
         return call_engine(messages, model_cfg, tools=tools)
-
-    elif provider == 'ollama':
-        if not ensure_ollama_model(model_cfg['model_id']):
-            raise EnvironmentError(
-                f"Ollama model '{model_cfg['model_id']}' is not available and could not be downloaded. "
-                f"Please pull it manually: docker exec auto-ml-ollama-1 ollama pull {model_cfg['model_id']}"
-            )
-        return call_ollama(messages, model_cfg)
 
     else:
         raise ValueError(f'Unknown provider: {provider}')

--- a/backend/tests/test_functional.py
+++ b/backend/tests/test_functional.py
@@ -1354,7 +1354,9 @@ class TestAIModelListAPI:
         response = api_client.get('/api/ai-assistant/models/')
         assert 'models' in response.data
         assert isinstance(response.data['models'], list)
-        assert len(response.data['models']) >= 12  # 3 OpenAI + 4 Gemma + Qwen + MiniMax + 3 Ministral
+        # 3 OpenAI (gpt-5.5, gpt-5.4-mini, gpt-4.1-mini)
+        # + 2 engine-routed local models (llama3.2 1b/3b)
+        assert len(response.data['models']) >= 5
 
     def test_models_endpoint_returns_default(self, api_client, _use_tmp_media):
         """GET /api/ai-assistant/models/ returns a default model key."""
@@ -1370,14 +1372,12 @@ class TestAIModelListAPI:
             assert 'display_name' in m
             assert 'provider' in m
 
-    def test_gemma_models_present(self, api_client, _use_tmp_media):
-        """Gemma 4 models are included in the response."""
+    def test_engine_models_present(self, api_client, _use_tmp_media):
+        """Engine-routed local models are included in the response."""
         response = api_client.get('/api/ai-assistant/models/')
         keys = [m['key'] for m in response.data['models']]
-        assert 'gemma-4-e2b' in keys
-        assert 'gemma-4-e4b' in keys
-        assert 'gemma-4-26b' in keys
-        assert 'gemma-4-31b' in keys
+        assert 'engine-llama-3.2-1b' in keys
+        assert 'engine-llama-3.2-3b' in keys
 
     def test_models_include_meta_flags(self, api_client, _use_tmp_media):
         """Each model in the response includes architecture/reasoning/thinking flags."""

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -1109,6 +1109,75 @@ class TestExtractActions:
         actions, clean = self._extract(msg)
         assert len(actions) == 1
 
+    # ── Truncated action block tests ──────────────────────────────────
+
+    def test_truncated_action_complete_json_no_end_tag(self):
+        """Model hit token limit: JSON is complete but END_ACTION was never emitted."""
+        msg = 'Creating features.\n<<<ACTION:execute_code>>>\n{"code":"x=1","description":"test"}'
+        actions, clean = self._extract(msg)
+        assert len(actions) == 1
+        assert actions[0]['type'] == 'execute_code'
+        assert actions[0]['payload']['code'] == 'x=1'
+        assert '<<<ACTION' not in clean
+        assert 'Creating features.' in clean
+
+    def test_truncated_action_json_cut_mid_string(self):
+        """Model hit token limit: JSON is truncated mid-value."""
+        msg = 'Here we go.\n<<<ACTION:execute_code>>>\n{"code":"a=1","description":"create fea'
+        actions, clean = self._extract(msg)
+        # _try_parse_truncated_json attempts to repair by closing string + brace.
+        # Either it salvages it or returns nothing — either way, no crash.
+        if actions:
+            assert actions[0]['type'] == 'execute_code'
+        assert '<<<ACTION' not in clean
+
+    def test_truncated_action_garbage_after_json(self):
+        """Complete JSON followed by garbage text (no END_ACTION)."""
+        msg = 'Advice.\n<<<ACTION:execute_code>>>{"code":"x=1","description":"ok"}some trailing text'
+        actions, clean = self._extract(msg)
+        assert len(actions) == 1
+        assert actions[0]['payload']['code'] == 'x=1'
+
+    def test_truncated_fallback_only_when_no_complete_match(self):
+        """Normal blocks are preferred; truncated fallback only fires when needed."""
+        msg = '<<<ACTION:execute_code>>>{"code":"a=1","description":"x"}<<<END_ACTION>>> Done.'
+        actions, clean = self._extract(msg)
+        assert len(actions) == 1
+        assert 'Done.' in clean
+
+    def test_truncated_action_preserves_post_json_explanation(self):
+        """Real trace: model emits action JSON then continues with explanation, no END_ACTION.
+
+        The explanation text after the JSON must appear in clean_message so the
+        user sees 'What was added:' in the chat bubble.
+        """
+        explanation = (
+            'Created the suggested features.\n\n'
+            'What was added:\n'
+            '- Time features from Application_Datetime\n'
+            '  - App_Month\n'
+            '  - App_DayOfWeek\n'
+            '- Ratio features\n'
+            '  - Var_19_to_Var_24'
+        )
+        msg = f'<<<ACTION:execute_code>>>\n{{"code":"x=1","description":"derive"}}\n{explanation}'
+        actions, clean = self._extract(msg)
+        assert len(actions) == 1
+        assert actions[0]['payload']['code'] == 'x=1'
+        # The explanation text must be preserved in clean_message
+        assert 'What was added:' in clean
+        assert 'App_Month' in clean
+        assert 'Var_19_to_Var_24' in clean
+        assert '<<<ACTION' not in clean
+
+    def test_truncated_action_preserves_text_before_and_after(self):
+        """Text before the action tag AND after the JSON are both preserved."""
+        msg = 'I will create features.\n<<<ACTION:execute_code>>>{"code":"x=1","description":"d"}\nDone creating.'
+        actions, clean = self._extract(msg)
+        assert len(actions) == 1
+        assert 'I will create features.' in clean
+        assert 'Done creating.' in clean
+
 
 # ---------------------------------------------------------------------------
 # AI _format_context tests
@@ -1629,61 +1698,12 @@ class TestModelRegistry:
         assert cfg['is_reasoning_model'] is True
         assert 'temperature' not in cfg
 
-    def test_get_model_config_gemma_e2b(self):
+    def test_get_model_config_engine_llama_3b(self):
         from ai_assistant.model_registry import get_model_config
-        cfg = get_model_config('gemma-4-e2b')
-        assert cfg['provider'] == 'ollama'
-        assert cfg['model_id'] == 'gemma4:e2b'
-        assert cfg['supports_tools'] is False
-
-    def test_get_model_config_gemma_e4b(self):
-        from ai_assistant.model_registry import get_model_config
-        cfg = get_model_config('gemma-4-e4b')
-        assert cfg['provider'] == 'ollama'
-        assert cfg['model_id'] == 'gemma4:e4b'
-        assert cfg['supports_tools'] is False
-
-    def test_get_model_config_gemma_26b(self):
-        from ai_assistant.model_registry import get_model_config
-        cfg = get_model_config('gemma-4-26b')
-        assert cfg['provider'] == 'ollama'
-        assert cfg['model_id'] == 'gemma4:26b'
-        assert cfg['thinking'] is True
-        assert cfg['thinking_level'] == 'med'
-
-    def test_get_model_config_gemma_31b(self):
-        from ai_assistant.model_registry import get_model_config
-        cfg = get_model_config('gemma-4-31b')
-        assert cfg['provider'] == 'ollama'
-        assert cfg['model_id'] == 'gemma4:31b'
-        assert cfg['thinking'] is True
-        assert cfg['thinking_level'] == 'high'
-
-    def test_get_model_config_qwen(self):
-        from ai_assistant.model_registry import get_model_config
-        cfg = get_model_config('qwen-3.6-27b')
-        assert cfg['provider'] == 'ollama'
-        assert cfg['model_id'] == 'qwen3.6:27b'
-        assert cfg['architecture'] == 'dense'
-        assert cfg['reasoning'] is True
-        assert cfg['thinking'] is True
-
-    def test_get_model_config_minimax(self):
-        from ai_assistant.model_registry import get_model_config
-        cfg = get_model_config('minimax-m2.7')
-        assert cfg['provider'] == 'ollama'
-        assert cfg['model_id'] == 'minimax-m2.7:cloud'
-        assert cfg['architecture'] == 'moe'
-        assert cfg['reasoning'] is True
-
-    def test_get_model_config_ministral(self):
-        from ai_assistant.model_registry import get_model_config
-        for size in ('3b', '8b', '14b'):
-            cfg = get_model_config(f'ministral-3-{size}')
-            assert cfg['provider'] == 'ollama'
-            assert cfg['model_id'] == f'ministral-3:{size}'
-            assert cfg['architecture'] == 'dense'
-            assert cfg['thinking'] is False
+        cfg = get_model_config('engine-llama-3.2-3b')
+        assert cfg['provider'] == 'engine'
+        assert cfg['model_id'] == 'llama3.2:3b'
+        assert cfg['supports_tools'] is True
 
     def test_get_model_config_unknown_falls_back(self):
         from ai_assistant.model_registry import get_model_config, DEFAULT_MODEL, MODEL_REGISTRY
@@ -1716,14 +1736,6 @@ class TestModelRegistry:
         for key, cfg in MODEL_REGISTRY.items():
             assert cfg['thinking_level'] in valid, f"{key}: bad thinking_level"
 
-    def test_ollama_response_normalization(self):
-        """call_ollama should normalize Ollama response to OpenAI-compatible shape."""
-        from ai_assistant.model_registry import get_model_config
-        cfg = get_model_config('gemma-4-e2b')
-        assert cfg['provider'] == 'ollama'
-        assert cfg['temperature'] == 0.4
-        assert cfg['max_tokens'] == 4096
-
     def test_reasoning_models_skip_temperature(self):
         """Reasoning models (gpt-5.5) should not have temperature in config."""
         from ai_assistant.model_registry import get_model_config
@@ -1732,10 +1744,10 @@ class TestModelRegistry:
             assert cfg.get('is_reasoning_model') is True
             assert 'temperature' not in cfg
 
-    def test_non_reasoning_models_have_temperature(self):
-        """Non-reasoning models (Ollama) should have temperature."""
+    def test_engine_models_have_temperature(self):
+        """Engine-routed models should expose temperature for inference control."""
         from ai_assistant.model_registry import get_model_config
-        for key in ('gemma-4-e2b', 'gemma-4-e4b'):
+        for key in ('engine-llama-3.2-1b', 'engine-llama-3.2-3b'):
             cfg = get_model_config(key)
             assert 'temperature' in cfg
             assert not cfg.get('is_reasoning_model')
@@ -1749,3 +1761,21 @@ class TestModelRegistry:
             assert 'reasoning' in m
             assert 'thinking' in m
             assert 'thinking_level' in m
+
+    def test_engine_models_have_ram_gb(self):
+        """All engine-routed models should declare their ram_gb requirement."""
+        from ai_assistant.model_registry import MODEL_REGISTRY
+        for key, cfg in MODEL_REGISTRY.items():
+            if cfg['provider'] == 'engine':
+                assert 'ram_gb' in cfg, f"Engine model '{key}' missing ram_gb"
+                assert isinstance(cfg['ram_gb'], (int, float)), f"{key}: ram_gb must be numeric"
+                assert cfg['ram_gb'] > 0, f"{key}: ram_gb must be positive"
+
+    def test_list_models_includes_ram_gb(self):
+        """list_models() should expose ram_gb for engine-routed models."""
+        from ai_assistant.model_registry import list_models
+        models = list_models()
+        engine_models = [m for m in models if m['provider'] == 'engine']
+        assert len(engine_models) > 0
+        for m in engine_models:
+            assert 'ram_gb' in m, f"Model '{m['key']}' missing ram_gb in list output"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,31 +12,18 @@ services:
       - DATQ_MAX_CELLS=20000000
       - DATQ_SAMPLE_ROWS=10000
       - REDIS_URL=redis://redis:6379/0
-      - OLLAMA_BASE_URL=http://ollama:11434
       # Local llm-inference-engine — used by DeclarAI when a model is
       # registered with provider='engine'. The engine runs as a separate
       # service (see llm_inference_engine_v1/); host.docker.internal points
       # the container at the engine on the developer host. Override via .env
       # for production / CI deployments.
-      - LLM_ENGINE_BASE_URL=${LLM_ENGINE_BASE_URL:-http://host.docker.internal:8080/v1}
+      - LLM_ENGINE_BASE_URL=${LLM_ENGINE_BASE_URL:-http://host.docker.internal:8090/v1}
       - LLM_ENGINE_API_KEY=${LLM_ENGINE_API_KEY:-sk-engine-local}
     depends_on:
       - redis
-      - ollama
     # Mount project root for live-reload development (Django autoreload)
     volumes:
       - .:/app
-  ollama:
-    image: ollama/ollama:latest
-    ports:
-      - "11434:11434"
-    volumes:
-      - ./ollama-models:/root/.ollama
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
   redis:
     image: redis:7-alpine
     ports:


### PR DESCRIPTION
## Summary

Retires the `ollama` provider entirely from DeclarAI now that PR #2 routes local-inference traffic through the new `engine` provider (the OpenAI-compatible llm-inference-engine). The dedicated ollama container was duplicative — it served the same GGUF blobs the inference engine now serves directly via bind mount, doubling RAM and adding a service to babysit.

After this:
- **Frontend selector** exposes 5 models: `gpt-5.5`, `gpt-5.4-mini`, `gpt-4.1-mini`, `engine-llama-3.2-3b`, `engine-llama-3.2-1b`.
- **Backend** has two LLM provider branches (`openai`, `engine`); the `ollama` branch and its helpers are gone.
- **Compose** drops the `ollama` service + `OLLAMA_BASE_URL`, and corrects `LLM_ENGINE_BASE_URL` default to host port `8090` (the engine's nginx LB port — not 8080).

## Why

End-to-end verified during this session:
- `POST /api/ai-assistant/chat/` with `model: engine-llama-3.2-1b` → real completion, `gen_ai.*` spans captured by prometa-sdk auto-instrumentation (same code path as cloud GPT).
- Same for `engine-llama-3.2-3b`.
- Same paths exercised through the live Angular UI; backend logs show `HTTP/1.1 200 OK` from `host.docker.internal:8090/v1/chat/completions`.

## Note on the dropped `engine-qwen-3.6-27b`

The cached `qwen3.6:27b` GGUF declares architecture `qwen35` and uses a 4-element `rope.dimension_sections` field that `llama-cpp-python==0.3.21` (current upstream stable) cannot parse. The engine returns a generic 500 because `verbose=False` swallows the underlying llama.cpp error. Tracked in [llm-inference-engine#2](https://github.com/caglarsubas/llm_inference_engine/issues/2). Re-add this model entry once the engine bumps to a llama-cpp-python that can parse qwen35.

## Files

| File | What changed |
|---|---|
| `docker-compose.yml` | Drop ollama service + depends_on + OLLAMA_BASE_URL; LLM_ENGINE_BASE_URL default 8080→8090 |
| `backend/ai_assistant/model_registry.py` | Drop 14 ollama models + qwen-3.6 engine entry; drop call_ollama, ensure_ollama_model, unused logging import |
| `backend/ai_assistant/views.py` | Drop ollama branch from _call_llm; refresh docstring/comments |
| `backend/tests/test_unit.py` | Drop 8 ollama tests; add engine-equivalent tests; switch ram_gb/temperature scans to provider=='engine' |
| `backend/tests/test_functional.py` | Lower min-models assertion to >=5 (3 OpenAI + 2 engine); replace Gemma-presence test with engine-presence |

## Test plan

- [x] Unit tests: 191 passing
- [x] Functional tests: 98 passing
- [x] Pre-commit hook (346 backend tests across 5 categories): green
- [x] Live `POST /api/ai-assistant/chat/` against `engine-llama-3.2-1b` and `engine-llama-3.2-3b`: returns valid completions with token usage
- [x] Live model-list endpoint returns the expected 5 keys, no ollama remnants
- [ ] Reviewer: `docker compose up -d --remove-orphans` to drop the running `auto-ml-ollama-1` container; confirm only `backend`, `frontend`, `redis` come up

## Coordinated repo changes

- Engine repo: [caglarsubas/llm_inference_engine#1](https://github.com/caglarsubas/llm_inference_engine/pull/1) relocates the GGUF cache out of `auto-ml/ollama-models/` (where it was previously bind-mounted from) into `~/.cache/inference_engine/ollama/`, so the engine no longer secretly depends on a directory inside this repo. Merge that first, then this.
- Engine repo: [caglarsubas/llm_inference_engine#2](https://github.com/caglarsubas/llm_inference_engine/issues/2) tracks the qwen35 parser gap that's the reason `engine-qwen-3.6-27b` is dropped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)