### PR TITLE
feat: dynamic engine model discovery; default to native engine port

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ backend/db.sqlite3
 **/.DS_Store
 datasets
 backend/media
+ollama-models

--- a/backend/ai_assistant/model_registry.py
+++ b/backend/ai_assistant/model_registry.py
@@ -11,9 +11,19 @@ via its OpenAI-compatible ``/v1/chat/completions`` endpoint. We intentionally
 talk to it through the OpenAI Python SDK so the prometa-sdk's openai
 auto-instrumentation captures gen_ai.* spans on the assistant side — agentic-
 hook-v2 stays decoupled from any specific inference backend.
+
+Engine models are **discovered dynamically** from the engine's
+``GET /v1/models`` endpoint rather than hard-coded.  The engine itself
+probe-loads each GGUF and only lists ones llama.cpp can actually open, so
+DeclarAI's UI surfaces only models that will actually answer.  A small
+in-process TTL cache keeps Django request latency unaffected by the extra
+RTT.
 """
 
+import logging
 import os
+import threading
+import time
 
 # ---------------------------------------------------------------------------
 # Registry: model_key → config
@@ -62,36 +72,10 @@ MODEL_REGISTRY = {
         'thinking': False,
         'thinking_level': None,
     },
-    # ── Local Inference Engine (llm-inference-engine) ─────────────────
-    # Routes through the engine's OpenAI-compatible /v1/chat/completions.
-    # The model_id is the engine's qualified name (backend-agnostic — the
-    # engine resolves it to llama_cpp / mlx / vllm internally).
-    'engine-llama-3.2-3b': {
-        'provider': 'engine',
-        'model_id': 'llama3.2:3b',
-        'display_name': 'Llama 3.2 — 3B (Inference Engine)',
-        'temperature': 0.4,
-        'max_tokens': 4096,
-        'supports_tools': True,
-        'architecture': 'dense',
-        'reasoning': False,
-        'thinking': False,
-        'thinking_level': None,
-        'ram_gb': 3,
-    },
-    'engine-llama-3.2-1b': {
-        'provider': 'engine',
-        'model_id': 'llama3.2:1b',
-        'display_name': 'Llama 3.2 — 1B (Inference Engine)',
-        'temperature': 0.4,
-        'max_tokens': 4096,
-        'supports_tools': True,
-        'architecture': 'dense',
-        'reasoning': False,
-        'thinking': False,
-        'thinking_level': None,
-        'ram_gb': 2,
-    },
+    # Engine entries (provider='engine') are populated dynamically from
+    # ``GET {LLM_ENGINE_BASE_URL}/models`` — see ``_refresh_engine_models()``.
+    # Keys follow the convention ``engine-{engine_id_with_colons_dashed}``,
+    # so ``llama3.2:3b`` becomes ``engine-llama3.2-3b``.
 }
 
 DEFAULT_MODEL = 'gpt-5.5'
@@ -101,14 +85,173 @@ _MODEL_META_KEYS = (
     'architecture', 'reasoning', 'thinking', 'thinking_level', 'ram_gb',
 )
 
+# Registry shape kept identical to the static entries above so the rest of
+# the code (views, tests, frontend payloads) doesn't need to know whether a
+# given engine entry was hard-coded or fetched.
+_logger = logging.getLogger(__name__)
+
+# TTL controls how often we re-poll the engine's /v1/models endpoint.  Long
+# enough to make repeated Django requests free, short enough that pulling a
+# new ollama model becomes visible to DeclarAI within a minute without a
+# server restart.  Override via env for tests.
+_ENGINE_MODELS_TTL_SECONDS = float(os.environ.get('LLM_ENGINE_MODELS_TTL', '60'))
+_ENGINE_MODELS_TIMEOUT = float(os.environ.get('LLM_ENGINE_MODELS_TIMEOUT', '5.0'))
+
+_engine_cache_lock = threading.Lock()
+_engine_cache: dict[str, dict] = {}
+_engine_cache_expires_at: float = 0.0
+
+
+def _engine_key(engine_id: str) -> str:
+    """Map an engine model id (e.g. ``llama3.2:3b``) to a DeclarAI key.
+
+    Convention: prefix with ``engine-`` and replace ``:`` separators with
+    ``-`` so the key is URL/path safe, while preserving the original ``id``
+    structure so the round-trip is unambiguous (no two distinct ollama tags
+    can collide after the substitution because ``-`` is otherwise legal).
+    """
+    return f"engine-{engine_id.replace(':', '-')}"
+
+
+def _display_name_for(engine_id: str) -> str:
+    """Pretty label shown in the model selector — derived, not configured.
+
+    Operators can pull arbitrary models into ollama; we don't get to write a
+    bespoke display string for each one.  Keeping the engine id verbatim is
+    honest and makes provenance obvious to users (they can grep it against
+    ``ollama list``).
+    """
+    return f"{engine_id} (Inference Engine)"
+
+
+def _ram_gb_estimate(size_bytes: int) -> int:
+    """Coarse RAM hint shown in the UI.
+
+    The engine reports ``size_bytes`` (the GGUF blob size).  Resident
+    footprint at runtime is dominated by weights + KV cache; for a quick UI
+    hint we use ceil(size_bytes / 1 GB) which over-estimates slightly on
+    quantised weights — preferable to under-estimating and OOM-ing the host.
+    """
+    if size_bytes <= 0:
+        return 0
+    gb = size_bytes / (1024 ** 3)
+    return max(1, int(gb + 0.999))
+
+
+def _build_engine_entry(model_data: dict) -> dict:
+    """Translate one entry from the engine's ``/v1/models`` payload.
+
+    Capability metadata (architecture, reasoning, thinking_level) isn't
+    surfaced by the engine today, so we fill safe defaults that match the
+    historical hard-coded entries: dense, non-reasoning, non-thinking, tools
+    on (the engine routes tool calls through the same code path regardless
+    of whether the underlying model supports them).
+    """
+    engine_id = model_data['id']
+    return {
+        'provider': 'engine',
+        'model_id': engine_id,
+        'display_name': _display_name_for(engine_id),
+        'temperature': 0.4,
+        'max_tokens': 4096,
+        'supports_tools': True,
+        'architecture': 'dense',
+        'reasoning': False,
+        'thinking': False,
+        'thinking_level': None,
+        'ram_gb': _ram_gb_estimate(int(model_data.get('size_bytes', 0))),
+    }
+
+
+def _fetch_engine_models() -> dict[str, dict] | None:
+    """Hit ``GET {LLM_ENGINE_BASE_URL}/models`` and translate the response.
+
+    Returns ``None`` (not ``{}``) on failure so the caller can keep serving
+    the previous cached snapshot rather than wiping the UI when the engine
+    is briefly unreachable.
+    """
+    base_url = os.environ.get('LLM_ENGINE_BASE_URL', 'http://llm-engine:8080/v1')
+    api_key = os.environ.get('LLM_ENGINE_API_KEY', 'sk-engine-local')
+    url = base_url.rstrip('/') + '/models'
+
+    # Use the stdlib HTTP client to avoid pulling httpx into Django's import
+    # graph — DeclarAI already imports openai for the actual chat path.
+    import urllib.request
+    import urllib.error
+    import json
+    req = urllib.request.Request(url, headers={'Authorization': f'Bearer {api_key}'})
+    try:
+        with urllib.request.urlopen(req, timeout=_ENGINE_MODELS_TIMEOUT) as resp:
+            payload = json.loads(resp.read().decode('utf-8'))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+        _logger.warning("engine /v1/models fetch failed: %s", exc)
+        return None
+
+    out: dict[str, dict] = {}
+    for entry in payload.get('data') or []:
+        try:
+            cfg = _build_engine_entry(entry)
+        except (KeyError, TypeError, ValueError) as exc:
+            _logger.warning("engine model entry malformed (%s): %r", exc, entry)
+            continue
+        out[_engine_key(cfg['model_id'])] = cfg
+
+    unavailable = payload.get('unavailable') or []
+    if unavailable:
+        _logger.info(
+            "engine reports %d unavailable model(s): %s",
+            len(unavailable),
+            ", ".join(f"{u.get('id')} ({u.get('reason')})" for u in unavailable),
+        )
+    return out
+
+
+def _refresh_engine_models(force: bool = False) -> dict[str, dict]:
+    """Return the engine entries, refreshing the cache if the TTL elapsed.
+
+    On a fetch failure we return the previous snapshot (possibly empty on
+    cold boot) — DeclarAI degrades to "no engine models" but stays up.  The
+    OpenAI block in ``MODEL_REGISTRY`` keeps the assistant usable.
+    """
+    global _engine_cache, _engine_cache_expires_at
+    now = time.monotonic()
+    with _engine_cache_lock:
+        if not force and now < _engine_cache_expires_at:
+            return _engine_cache
+
+        fetched = _fetch_engine_models()
+        if fetched is None:
+            # Keep the old cache but back off briefly so we don't hammer a
+            # restarting engine on every Django request.
+            _engine_cache_expires_at = now + min(_ENGINE_MODELS_TTL_SECONDS, 5.0)
+            return _engine_cache
+
+        _engine_cache = fetched
+        _engine_cache_expires_at = now + _ENGINE_MODELS_TTL_SECONDS
+        return _engine_cache
+
+
+def _registry_snapshot() -> dict[str, dict]:
+    """Merged view: static cloud entries + dynamic engine entries.
+
+    Keyed by DeclarAI key.  Cloud entries always win on collision since the
+    engine is unlikely to ever advertise a key starting with ``gpt-``; we
+    enforce it anyway as defense-in-depth.
+    """
+    snapshot = dict(_refresh_engine_models())
+    snapshot.update(MODEL_REGISTRY)
+    return snapshot
+
 
 def get_model_config(model_key: str) -> dict:
     """Return config for a model key, falling back to default."""
-    return MODEL_REGISTRY.get(model_key, MODEL_REGISTRY[DEFAULT_MODEL])
+    snapshot = _registry_snapshot()
+    return snapshot.get(model_key, snapshot[DEFAULT_MODEL])
 
 
 def list_models() -> list:
     """Return list of available models for the frontend selector."""
+    snapshot = _registry_snapshot()
     return [
         {
             'key': k,
@@ -116,8 +259,15 @@ def list_models() -> list:
             'provider': v['provider'],
             **{mk: v.get(mk) for mk in _MODEL_META_KEYS},
         }
-        for k, v in MODEL_REGISTRY.items()
+        for k, v in snapshot.items()
     ]
+
+
+def invalidate_engine_cache() -> None:
+    """Drop the engine model cache — useful for tests and ops poking."""
+    global _engine_cache_expires_at
+    with _engine_cache_lock:
+        _engine_cache_expires_at = 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_functional.py
+++ b/backend/tests/test_functional.py
@@ -1354,9 +1354,10 @@ class TestAIModelListAPI:
         response = api_client.get('/api/ai-assistant/models/')
         assert 'models' in response.data
         assert isinstance(response.data['models'], list)
-        # 3 OpenAI (gpt-5.5, gpt-5.4-mini, gpt-4.1-mini)
-        # + 2 engine-routed local models (llama3.2 1b/3b)
-        assert len(response.data['models']) >= 5
+        # 3 OpenAI (gpt-5.5, gpt-5.4-mini, gpt-4.1-mini) — engine entries are
+        # now discovered dynamically and may or may not be present in the
+        # test environment depending on whether the engine is reachable.
+        assert len(response.data['models']) >= 3
 
     def test_models_endpoint_returns_default(self, api_client, _use_tmp_media):
         """GET /api/ai-assistant/models/ returns a default model key."""
@@ -1373,11 +1374,21 @@ class TestAIModelListAPI:
             assert 'provider' in m
 
     def test_engine_models_present(self, api_client, _use_tmp_media):
-        """Engine-routed local models are included in the response."""
+        """Engine-routed local models are included in the response.
+
+        Engine entries are now discovered dynamically from the engine's
+        ``/v1/models`` endpoint, so this test only asserts that *some*
+        engine-routed models show up — naming follows the
+        ``engine-{id with ':' → '-'}`` convention.  Asserting specific keys
+        would couple the test to whichever ollama models happen to be on
+        the engine's disk in CI.
+        """
         response = api_client.get('/api/ai-assistant/models/')
-        keys = [m['key'] for m in response.data['models']]
-        assert 'engine-llama-3.2-1b' in keys
-        assert 'engine-llama-3.2-3b' in keys
+        engine_keys = [m['key'] for m in response.data['models']
+                       if m['provider'] == 'engine']
+        assert engine_keys, "expected at least one engine-routed model"
+        for k in engine_keys:
+            assert k.startswith('engine-')
 
     def test_models_include_meta_flags(self, api_client, _use_tmp_media):
         """Each model in the response includes architecture/reasoning/thinking flags."""

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -1660,19 +1660,64 @@ class TestToolExecutor:
 # ---------------------------------------------------------------------------
 # Model registry tests
 # ---------------------------------------------------------------------------
+@pytest.fixture
+def _stub_engine_models(monkeypatch):
+    """Inject a deterministic engine /v1/models payload so tests don't need a
+    live engine.  Mirrors the previous hard-coded ``llama3.2:3b`` /
+    ``llama3.2:1b`` pair so historical assertions still mean something —
+    just routed through the dynamic-discovery code path."""
+    from ai_assistant import model_registry as mr
+    fake = {
+        'engine-llama3.2-3b': {
+            'provider': 'engine',
+            'model_id': 'llama3.2:3b',
+            'display_name': 'llama3.2:3b (Inference Engine)',
+            'temperature': 0.4,
+            'max_tokens': 4096,
+            'supports_tools': True,
+            'architecture': 'dense',
+            'reasoning': False,
+            'thinking': False,
+            'thinking_level': None,
+            'ram_gb': 3,
+        },
+        'engine-llama3.2-1b': {
+            'provider': 'engine',
+            'model_id': 'llama3.2:1b',
+            'display_name': 'llama3.2:1b (Inference Engine)',
+            'temperature': 0.4,
+            'max_tokens': 4096,
+            'supports_tools': True,
+            'architecture': 'dense',
+            'reasoning': False,
+            'thinking': False,
+            'thinking_level': None,
+            'ram_gb': 2,
+        },
+    }
+    monkeypatch.setattr(mr, '_fetch_engine_models', lambda: fake)
+    mr.invalidate_engine_cache()
+    yield fake
+    mr.invalidate_engine_cache()
+
+
 @pytest.mark.unit
 class TestModelRegistry:
     """Test the model_registry module — model configs, list, and defaults."""
 
-    def test_list_models_returns_all(self):
+    def test_list_models_returns_all(self, _stub_engine_models):
         from ai_assistant.model_registry import list_models, MODEL_REGISTRY
         models = list_models()
-        assert len(models) == len(MODEL_REGISTRY)
+        # Cloud entries (static) + engine entries (dynamic stub)
+        expected_count = len(MODEL_REGISTRY) + len(_stub_engine_models)
+        assert len(models) == expected_count
         keys = [m['key'] for m in models]
         for k in MODEL_REGISTRY:
             assert k in keys
+        for k in _stub_engine_models:
+            assert k in keys
 
-    def test_list_models_structure(self):
+    def test_list_models_structure(self, _stub_engine_models):
         from ai_assistant.model_registry import list_models
         models = list_models()
         for m in models:
@@ -1698,9 +1743,10 @@ class TestModelRegistry:
         assert cfg['is_reasoning_model'] is True
         assert 'temperature' not in cfg
 
-    def test_get_model_config_engine_llama_3b(self):
+    def test_get_model_config_engine_llama_3b(self, _stub_engine_models):
         from ai_assistant.model_registry import get_model_config
-        cfg = get_model_config('engine-llama-3.2-3b')
+        # Dynamic-discovery key: engine-{id with ':' replaced by '-'}
+        cfg = get_model_config('engine-llama3.2-3b')
         assert cfg['provider'] == 'engine'
         assert cfg['model_id'] == 'llama3.2:3b'
         assert cfg['supports_tools'] is True
@@ -1744,10 +1790,10 @@ class TestModelRegistry:
             assert cfg.get('is_reasoning_model') is True
             assert 'temperature' not in cfg
 
-    def test_engine_models_have_temperature(self):
+    def test_engine_models_have_temperature(self, _stub_engine_models):
         """Engine-routed models should expose temperature for inference control."""
         from ai_assistant.model_registry import get_model_config
-        for key in ('engine-llama-3.2-1b', 'engine-llama-3.2-3b'):
+        for key in ('engine-llama3.2-1b', 'engine-llama3.2-3b'):
             cfg = get_model_config(key)
             assert 'temperature' in cfg
             assert not cfg.get('is_reasoning_model')
@@ -1762,16 +1808,16 @@ class TestModelRegistry:
             assert 'thinking' in m
             assert 'thinking_level' in m
 
-    def test_engine_models_have_ram_gb(self):
+    def test_engine_models_have_ram_gb(self, _stub_engine_models):
         """All engine-routed models should declare their ram_gb requirement."""
-        from ai_assistant.model_registry import MODEL_REGISTRY
-        for key, cfg in MODEL_REGISTRY.items():
+        from ai_assistant.model_registry import _registry_snapshot
+        for key, cfg in _registry_snapshot().items():
             if cfg['provider'] == 'engine':
                 assert 'ram_gb' in cfg, f"Engine model '{key}' missing ram_gb"
                 assert isinstance(cfg['ram_gb'], (int, float)), f"{key}: ram_gb must be numeric"
                 assert cfg['ram_gb'] > 0, f"{key}: ram_gb must be positive"
 
-    def test_list_models_includes_ram_gb(self):
+    def test_list_models_includes_ram_gb(self, _stub_engine_models):
         """list_models() should expose ram_gb for engine-routed models."""
         from ai_assistant.model_registry import list_models
         models = list_models()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,11 @@ services:
       # service (see llm_inference_engine_v1/); host.docker.internal points
       # the container at the engine on the developer host. Override via .env
       # for production / CI deployments.
-      - LLM_ENGINE_BASE_URL=${LLM_ENGINE_BASE_URL:-http://host.docker.internal:8090/v1}
+      #
+      # Default port 8080 = native (Metal) engine binding directly on the
+      # host. Use 8090 if you're running the containerised topology with
+      # nginx in front of multiple engine replicas.
+      - LLM_ENGINE_BASE_URL=${LLM_ENGINE_BASE_URL:-http://host.docker.internal:8080/v1}
       - LLM_ENGINE_API_KEY=${LLM_ENGINE_API_KEY:-sk-engine-local}
     depends_on:
       - redis

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.css
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.css
@@ -129,6 +129,15 @@
   font-weight: 500;
 }
 
+.model-option-ram {
+  font-size: 9px;
+  background: rgba(255, 255, 255, 0.12);
+  padding: 1px 5px;
+  border-radius: 3px;
+  opacity: 0.7;
+  white-space: nowrap;
+}
+
 .model-option-provider {
   font-size: 10px;
   opacity: 0.5;

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.html
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.html
@@ -20,6 +20,7 @@
             (click)="selectModel(m.key)"
           >
             <span class="model-option-name">{{ m.display_name }}</span>
+            <span class="model-option-ram" *ngIf="m.ram_gb">{{ m.ram_gb }} GB</span>
             <span class="model-option-provider">{{ m.provider }}</span>
             <span class="model-option-check" *ngIf="m.key === selectedModel">&#10003;</span>
           </button>

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
@@ -21,7 +21,7 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
   private shouldScrollToBottom = false;
 
   // Model selector
-  availableModels: Array<{key: string; display_name: string; provider: string}> = [];
+  availableModels: Array<{key: string; display_name: string; provider: string; ram_gb?: number}> = [];
   selectedModel: string = 'gpt-5.5';
   showModelSelector: boolean = false;
 
@@ -133,7 +133,10 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
           payload: a.payload,
           applied: false,
         }));
-        this.aiService.updateLastMessage(resp.message || 'No response received.', actions);
+        const fallbackMsg = actions.length > 0
+          ? 'I\'ve prepared the following operation for you. Review the details below and click **Apply** to execute.'
+          : 'No response received.';
+        this.aiService.updateLastMessage(resp.message || fallbackMsg, actions);
         this.isLoading = false;
       },
       error: (err: any) => {
@@ -409,7 +412,10 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
           payload: a.payload,
           applied: false,
         }));
-        this.aiService.updateLastMessage(resp.message || 'No response received.', actions);
+        const correctionFallback = actions.length > 0
+          ? 'I\'ve prepared a corrected operation. Review the details below and click **Apply** to execute.'
+          : 'No response received.';
+        this.aiService.updateLastMessage(resp.message || correctionFallback, actions);
         this.isLoading = false;
         // Clear the error since the AI has provided a correction
         this.actionError = null;


### PR DESCRIPTION
## Summary

DeclarAI's engine-routed model list is now discovered dynamically from the inference engine's `/v1/models` endpoint, so any model pulled into the on-prem Ollama store is automatically available in the AI Assistant — no code change in this repo per new model.

- **Backend**: `MODEL_REGISTRY` keeps the static OpenAI entries; engine entries are fetched via `GET {LLM_ENGINE_BASE_URL}/v1/models` with a 60 s in-process TTL cache. Convention: `engine-{id with ':' → '-'}` (so `llama3.2:3b` → `engine-llama3.2-3b`). Surfaces the engine's `unavailable` list as a single info log so operators see why models they expect are missing.
- **Default endpoint**: `LLM_ENGINE_BASE_URL` flipped from `:8090` (containerised LB) to `:8080` (native Metal engine on the host). Pairs with the inference-engine PR that ships the native topology.
- **Frontend**: model selector type widened to include `ram_gb?: number` (the dynamic engine entries carry a derived RAM hint from the engine's reported `size_bytes`). Cleaner fallback message when the assistant returns actions but no body text.

## Why

Previously only `engine-llama-3.2-3b` and `engine-llama-3.2-1b` were exposed — out of the 12 reachable models in the Ollama store, the UI surfaced 2. Adding a model meant editing this repo. The engine now probe-gates `/v1/models` so it only lists what's actually loadable, and DeclarAI inherits that truth.

End-to-end against the native Metal engine: 12 / 12 engine-routed models reachable from the assistant.

## Behaviour on engine unreachable

Falls back to the previous snapshot (possibly empty on cold boot), logs a warn, never crashes Django. The OpenAI block in `MODEL_REGISTRY` keeps the assistant usable.

## Tests

- `tests/test_unit.py::TestModelRegistry` — new `_stub_engine_models` fixture so registry tests don't need a live engine. Assertions on `engine-llama-3.2-3b` updated to the dynamic-discovery key shape (`engine-llama3.2-3b`). 15/15 pass.
- `tests/test_functional.py` — `test_engine_models_present` asserts \"at least one engine-routed model with the `engine-` prefix\" instead of specific names. 13/13 pass.
- Pre-commit hook ran the full 346-test backend suite + frontend Karma + build — all green.

## Compatibility

- `MODEL_REGISTRY` keeps the same dict shape so any external reader works unchanged.
- `LLM_ENGINE_BASE_URL` is overridable via `.env` — operators on the containerised topology set it back to `:8090`.
- The frontend type widening is additive (`ram_gb?` is optional); existing model entries without it continue to render.

## Test plan

- [x] Backend unit + functional tests pass
- [x] DeclarAI lists 12 engine-routed models matching what the engine reports as reachable
- [x] Round-trip chat completion succeeds for every listed model
- [x] Frontend builds (Karma + ng build)
- [ ] Manual sanity: model selector dropdown shows the new entries with RAM hints

## Companion PR

Pairs with [llm_inference_engine#3](https://github.com/caglarsubas/llm_inference_engine/pull/3) which ships the probe-gated `/v1/models` endpoint and the native Metal topology this PR's `:8080` default points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)