### PR TITLE
feat(v2.21.0): AI assistant skills system + multi-model UX

### DIFF
--- a/backend/ai_assistant/model_registry.py
+++ b/backend/ai_assistant/model_registry.py
@@ -47,6 +47,7 @@ MODEL_REGISTRY = {
         'reasoning': True,
         'thinking': True,
         'thinking_level': 'high',
+        'tool_calling_mode': 'native',
     },
     'gpt-5.4-mini': {
         'provider': 'openai',
@@ -59,6 +60,7 @@ MODEL_REGISTRY = {
         'reasoning': True,
         'thinking': True,
         'thinking_level': 'med',
+        'tool_calling_mode': 'native',
     },
     'gpt-4.1-mini': {
         'provider': 'openai',
@@ -71,6 +73,7 @@ MODEL_REGISTRY = {
         'reasoning': False,
         'thinking': False,
         'thinking_level': None,
+        'tool_calling_mode': 'native',
     },
     # Engine entries (provider='engine') are populated dynamically from
     # ``GET {LLM_ENGINE_BASE_URL}/models`` — see ``_refresh_engine_models()``.
@@ -83,6 +86,7 @@ DEFAULT_MODEL = 'gpt-5.5'
 # Metadata keys surfaced to the frontend model selector
 _MODEL_META_KEYS = (
     'architecture', 'reasoning', 'thinking', 'thinking_level', 'ram_gb',
+    'tool_calling_mode',
 )
 
 # Registry shape kept identical to the static entries above so the rest of
@@ -148,6 +152,9 @@ def _build_engine_entry(model_data: dict) -> dict:
     of whether the underlying model supports them).
     """
     engine_id = model_data['id']
+    # The engine may surface tool_calling_mode per model; default to 'text'
+    # since most open-source models use text-based action blocks.
+    tcm = model_data.get('tool_calling_mode', 'text')
     return {
         'provider': 'engine',
         'model_id': engine_id,
@@ -160,6 +167,7 @@ def _build_engine_entry(model_data: dict) -> dict:
         'thinking': False,
         'thinking_level': None,
         'ram_gb': _ram_gb_estimate(int(model_data.get('size_bytes', 0))),
+        'tool_calling_mode': tcm,
     }
 
 

--- a/backend/ai_assistant/skill_registry.py
+++ b/backend/ai_assistant/skill_registry.py
@@ -1,0 +1,241 @@
+"""
+Skill registry — discover and load bundled AI-assistant skills.
+
+A skill is a directory under :data:`SKILLS_DIR` that contains a ``SKILL.md``
+file with YAML frontmatter (``name`` and ``description``) followed by a
+markdown body.  The body is the actual guidance the LLM consumes when the
+skill is invoked via the ``invoke_skill`` tool.
+
+Skills are discovered eagerly on first access and cached for the process
+lifetime.  Bodies are loaded lazily.
+
+Frontmatter parser is intentionally minimal so we don't add a PyYAML
+dependency for two-line headers (``key: value`` or ``key: "value"``).
+
+Example layout::
+
+    backend/ai_assistant/skills/
+        feature-engineering/
+            SKILL.md          ← required, registered as a skill
+            references/...    ← optional supplementary files
+            scripts/...
+            templates/...
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Directory that holds bundled skills.  Override with PROMETA_SKILLS_DIR if
+# the operator wants to mount external skills at runtime (advanced).
+SKILLS_DIR = os.environ.get(
+    'PROMETA_SKILLS_DIR',
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), 'skills'),
+)
+
+
+# Supplementary skill files larger than this are truncated to keep the LLM
+# context budget bounded.  100 KB is plenty for a markdown reference doc.
+MAX_SKILL_FILE_BYTES = 100_000
+
+# Only files matching these suffixes are exposed via read_file().  We allow
+# typical skill payload formats and reject anything that smells binary.
+ALLOWED_SKILL_FILE_SUFFIXES = ('.md', '.txt', '.py', '.json', '.yml', '.yaml')
+
+
+@dataclass
+class Skill:
+    """A discovered skill — frontmatter metadata + lazy body loader."""
+    name: str
+    description: str
+    path: str  # absolute path to the skill directory
+
+    @property
+    def skill_md_path(self) -> str:
+        return os.path.join(self.path, 'SKILL.md')
+
+    def body(self) -> str:
+        """Return the markdown body of SKILL.md (everything after frontmatter)."""
+        try:
+            with open(self.skill_md_path, 'r', encoding='utf-8') as fh:
+                _, body = _split_frontmatter(fh.read())
+            return body.strip()
+        except OSError as exc:
+            logger.warning("Failed to read skill body for %s: %s", self.name, exc)
+            return ''
+
+    # ------------------------------------------------------------------
+    # Supplementary file access (references/, scripts/, templates/, ...)
+    # ------------------------------------------------------------------
+
+    def list_files(self) -> list[str]:
+        """Return relative paths of all readable files inside the skill dir
+        EXCEPT ``SKILL.md`` (which is delivered via :meth:`body`).
+
+        Paths are POSIX-style (forward slashes) and sorted for stable output.
+        Filtered to :data:`ALLOWED_SKILL_FILE_SUFFIXES`.
+        """
+        out: list[str] = []
+        for root, _dirs, files in os.walk(self.path):
+            for fname in files:
+                if fname == 'SKILL.md' and root == self.path:
+                    continue
+                if not fname.lower().endswith(ALLOWED_SKILL_FILE_SUFFIXES):
+                    continue
+                abs_path = os.path.join(root, fname)
+                rel = os.path.relpath(abs_path, self.path)
+                out.append(rel.replace(os.sep, '/'))
+        return sorted(out)
+
+    def read_file(self, rel_path: str) -> tuple[str, Optional[str]]:
+        """Read a supplementary file from inside the skill directory.
+
+        Returns ``(content, error)``.  On success ``error`` is ``None``.
+        Enforces:
+          • no absolute paths
+          • no ``..`` traversal (the resolved path must stay under ``self.path``)
+          • allowed suffix only
+          • payload truncated to :data:`MAX_SKILL_FILE_BYTES` bytes
+
+        ``rel_path`` may be supplied with forward slashes; native separators
+        also work.
+        """
+        if not rel_path:
+            return '', "rel_path is required"
+        # Normalize and reject obviously malicious inputs
+        norm = rel_path.replace('\\', '/').lstrip('/')
+        if os.path.isabs(rel_path) or '..' in norm.split('/'):
+            return '', f"refusing to read '{rel_path}': path traversal not allowed"
+        if not norm.lower().endswith(ALLOWED_SKILL_FILE_SUFFIXES):
+            allowed = ', '.join(ALLOWED_SKILL_FILE_SUFFIXES)
+            return '', f"refusing to read '{rel_path}': only files ending in {allowed} are exposed"
+        # Resolve and confirm containment
+        skill_root = os.path.realpath(self.path)
+        target = os.path.realpath(os.path.join(skill_root, norm))
+        if os.path.commonpath([skill_root, target]) != skill_root:
+            return '', f"refusing to read '{rel_path}': resolves outside the skill directory"
+        if not os.path.isfile(target):
+            return '', f"file '{rel_path}' not found in skill '{self.name}'"
+        try:
+            with open(target, 'rb') as fh:
+                raw = fh.read(MAX_SKILL_FILE_BYTES + 1)
+        except OSError as exc:
+            return '', f"read error: {exc}"
+        truncated = len(raw) > MAX_SKILL_FILE_BYTES
+        if truncated:
+            raw = raw[:MAX_SKILL_FILE_BYTES]
+        try:
+            text = raw.decode('utf-8')
+        except UnicodeDecodeError:
+            return '', f"file '{rel_path}' is not valid UTF-8 text"
+        if truncated:
+            text += f"\n\n…[truncated to {MAX_SKILL_FILE_BYTES} bytes]"
+        return text, None
+
+    def to_dict(self) -> dict:
+        return {'name': self.name, 'description': self.description, 'path': self.path}
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parser (no PyYAML dependency)
+# ---------------------------------------------------------------------------
+
+def _split_frontmatter(text: str) -> tuple[dict, str]:
+    """Split a markdown file with YAML-ish frontmatter into ``(meta, body)``.
+
+    Accepts only flat ``key: value`` pairs.  Quotes around values are
+    stripped.  Returns an empty meta dict if no frontmatter is present.
+    """
+    if not text.startswith('---'):
+        return {}, text
+    # Skip the opening fence (handle both \n and \r\n)
+    rest = text[3:].lstrip('\n').lstrip('\r')
+    end = rest.find('\n---')
+    if end < 0:
+        return {}, text
+    header = rest[:end]
+    # body starts after the closing fence + newline
+    body_start = end + len('\n---')
+    body = rest[body_start:].lstrip('\n').lstrip('\r')
+    meta: Dict[str, str] = {}
+    for line in header.splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if ':' not in line:
+            continue
+        key, _, value = line.partition(':')
+        value = value.strip()
+        # Strip surrounding quotes if present
+        if (value.startswith('"') and value.endswith('"')) or \
+           (value.startswith("'") and value.endswith("'")):
+            value = value[1:-1]
+        meta[key.strip()] = value
+    return meta, body
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+_cache_lock = threading.Lock()
+_skills_cache: Optional[Dict[str, Skill]] = None
+
+
+def _discover() -> Dict[str, Skill]:
+    out: Dict[str, Skill] = {}
+    if not os.path.isdir(SKILLS_DIR):
+        logger.info("Skills directory does not exist: %s", SKILLS_DIR)
+        return out
+    for entry in sorted(os.listdir(SKILLS_DIR)):
+        sk_dir = os.path.join(SKILLS_DIR, entry)
+        sk_md = os.path.join(sk_dir, 'SKILL.md')
+        if not os.path.isdir(sk_dir) or not os.path.isfile(sk_md):
+            continue
+        try:
+            with open(sk_md, 'r', encoding='utf-8') as fh:
+                meta, _ = _split_frontmatter(fh.read())
+        except OSError as exc:
+            logger.warning("Skipping skill %s (read error: %s)", entry, exc)
+            continue
+        name = (meta.get('name') or entry).strip()
+        description = (meta.get('description') or '').strip()
+        if not description:
+            logger.warning("Skill %s has no description; using directory name.", name)
+            description = f"Skill: {name}"
+        out[name] = Skill(name=name, description=description, path=sk_dir)
+    return out
+
+
+def list_skills(refresh: bool = False) -> Dict[str, Skill]:
+    """Return the registry of available skills (cached)."""
+    global _skills_cache
+    with _cache_lock:
+        if _skills_cache is None or refresh:
+            _skills_cache = _discover()
+        return dict(_skills_cache)
+
+
+def get_skill(name: str) -> Optional[Skill]:
+    """Look up a single skill by name (case-insensitive)."""
+    skills = list_skills()
+    if name in skills:
+        return skills[name]
+    lowered = name.lower()
+    for k, v in skills.items():
+        if k.lower() == lowered:
+            return v
+    return None
+
+
+def invalidate_cache() -> None:
+    """Force re-discovery on the next call (used in tests)."""
+    global _skills_cache
+    with _cache_lock:
+        _skills_cache = None

--- a/backend/ai_assistant/skills/__init__.py
+++ b/backend/ai_assistant/skills/__init__.py
@@ -1,0 +1,8 @@
+"""Bundled AI assistant skills.
+
+Each skill lives in its own subdirectory containing at least a ``SKILL.md``
+file with YAML frontmatter (``name``, ``description``) and a markdown body
+that the LLM reads when the skill is invoked.
+
+The registry in :mod:`ai_assistant.skill_registry` discovers and loads them.
+"""

--- a/backend/ai_assistant/skills/feature-engineering/SKILL.md
+++ b/backend/ai_assistant/skills/feature-engineering/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: feature-engineering
+description: "Comprehensive best practices, formulas, and strategies for generating new features from existing data. Use for: tabular data modeling, automated feature generation, domain-specific feature design (banking, fraud, telecom, insurance, healthcare, trading), and avoiding data leakage."
+license: Complete terms in LICENSE.txt
+---
+
+# Feature Engineering Guide
+
+This skill provides a structured, point-in-time-safe catalogue of reusable feature patterns. It is designed to guide automated feature generation by providing domain-specific transformations, cross-cutting universal patterns, and strict leakage-prevention rules.
+
+## Core Principles
+
+1. **Domain-Aware First**: Domain-aware feature generation outperforms model tuning for tabular problems. Apply domain-specific ratios, aggregations, and interactions before resorting to complex model architectures.
+2. **Leakage is the Silent Killer**: Features must be defined with explicit event time, retrieval time, and as-of join semantics.
+3. **Cardinality Dictates Encoding**: Low cardinality (<20) uses one-hot; medium uses target/frequency; high uses embeddings or Weight of Evidence (WOE).
+
+## Cross-Cutting Universal Feature Patterns
+
+These patterns apply across nearly all tabular machine learning tasks.
+
+### 1. Temporal and Aggregate Features
+- **RFM (Recency, Frequency, Monetary)**:
+  - Recency: Days since last event.
+  - Frequency: Count of events in a window (e.g., 7d, 30d, 90d).
+  - Monetary: Sum, mean, max, or median of transaction amounts.
+- **Lags and Rolling Windows**:
+  - `lag_k(x)`: Value at time $t-k$. Shift by $\ge$ forecast horizon to avoid leakage.
+  - Rolling mean/std/sum over windows (7, 14, 30, 60, 90 days).
+  - EWMA (Exponentially Weighted Moving Average): $\text{EWMA}_{\lambda}(x_t)=\sum_{k=0}^{K}\lambda^k x_{t-k}$.
+
+### 2. Ratio and Interaction Features
+- Ratios linearize monotone-but-nonlinear relationships and are scale-invariant.
+- **Velocity Ratios**: Compare short-term activity to long-term baseline (e.g., last 1h count vs. last 30d average).
+- **Utilization**: $\frac{\text{balance}}{\max(\text{credit\_limit},\epsilon)}$.
+- **Interactions**: Products of informative features (e.g., age $\times$ tenure).
+
+### 3. Categorical Encoding and Binning
+- **Weight of Evidence (WOE) & Information Value (IV)** (Standard in credit risk):
+  - $\text{WOE}_i = \ln\left(\frac{\% \text{non-events}_i}{\% \text{events}_i}\right)$
+  - $IV = \sum_i (\% \text{non-events}_i - \% \text{events}_i) \cdot \text{WOE}_i$
+  - IV interpretation: <0.02 (useless), 0.02–0.1 (weak), 0.1–0.3 (medium), 0.3–0.5 (strong), >0.5 (suspicious, check for leakage).
+- **Target Encoding**: Must use out-of-fold or smoothing to avoid leakage.
+
+### 4. Network and Graph Features
+- Degree (in/out), weighted degree (sum amounts).
+- PageRank, centrality, community ID.
+- Shared-attribute features: Number of accounts sharing a device, IP, or email.
+
+## Industry-Specific Patterns
+
+### Banking & Credit Scoring
+- **Goal**: Predict default risk.
+- **Core Features**:
+  - Credit-to-Income: `AMT_CREDIT / AMT_INCOME_TOTAL`
+  - Annuity-to-Income: `AMT_ANNUITY / AMT_INCOME_TOTAL`
+  - Years Employed: `DAYS_EMPLOYED / 365`
+  - Income per Family Member: `AMT_INCOME_TOTAL / (CNT_FAM_MEMBERS + 1)`
+- **Techniques**: Heavy use of WOE/IV binning to ensure monotonicity and interpretability.
+
+### Fraud Detection (Payments & E-commerce)
+- **Goal**: Detect anomalous transactions.
+- **Core Features**:
+  - Velocity: $\frac{\text{Count(Tx}_{1h}\text{)}}{\text{Avg(Tx}_{1h\_over\_30d}\text{)}}$
+  - Aggregations: Count/amount in rolling windows by card, account, device, or IP.
+  - Behavioral: Device/IP changes, email domain score, essential vs. non-essential spend patterns.
+  - Graph: Shared devices or payment methods between accounts.
+
+### Telecom Churn & Propensity
+- **Goal**: Predict churn or offer acceptance.
+- **Core Features**:
+  - Average Monthly Charges: `TotalCharges / tenure`
+  - Service Aggregates: Count of additional services (e.g., DeviceProtection + TechSupport).
+  - Monthly Charges Ratio: `MonthlyCharges / TotalCharges`
+  - Behavioral: Number of services (high = sticky, low = churn risk).
+
+### Insurance (Claims & Pricing)
+- **Goal**: Assess claim severity, frequency, and price elasticity.
+- **Core Features**:
+  - Claim frequency: `count_ClaimID_perProvider`
+  - Mean hospital days per provider, third parties involved per claim.
+  - Temporal: Days since policy start, days between loss date and policy alteration.
+  - Price Elasticity: $\text{PED} = \frac{\Delta Q / Q}{\Delta P / P}$
+
+### Trading & Price Sensitivity
+- **Goal**: Predict price direction or volatility.
+- **Core Features**:
+  - Returns: $r_t = \frac{P_t - P_{t-1}}{P_{t-1}}$
+  - Trend: SMA, EMA, MACD, RSI.
+  - Volatility: Standard deviation, Average True Range (ATR), Realized Volatility (RV).
+
+### Healthcare Risk Modeling
+- **Goal**: Predict disease risk, readmission, or adherence.
+- **Core Features**:
+  - Clinical Aggregates: Age, obesity (BMI>30), cardiovascular risk flags.
+  - Temporal Trends: Vitals deltas, medication possession ratios, lab-value trends.
+  - Behavioral: Visit frequency, appointment no-show history.
+
+## Using Bundled Resources
+
+This skill includes comprehensive scripts and references to accelerate feature engineering workflows.
+
+### Scripts
+
+**feature_engineering_pipeline.py** automates the complete feature engineering workflow. Initialize with your target column and task type (classification or regression), then call the `run()` method to execute data loading, cleaning, categorical encoding, feature creation, feature selection, and model training in sequence.
+
+**feature_importance_analyzer.py** analyzes feature importance using multiple techniques including tree-based importance, permutation importance, and correlation analysis. It provides normalized importance scores across methods and identifies your top features for the model.
+
+**data_visualizer.py** generates comprehensive visualizations including feature distributions, correlation heatmaps, target relationships, missing value patterns, box plots, and summary statistics. All plots are automatically saved to your specified output directory.
+
+**feature_store_integration.py** manages the complete feature lifecycle with support for local or cloud-based feature stores. Register features, publish feature groups, and retrieve features for specific entities with point-in-time correctness guarantees.
+
+### References
+
+**feature_engineering_best_practices.md** provides detailed guidance on encoding methods (one-hot, label, target, WOE), scaling techniques (standardization, min-max, log, Box-Cox), feature selection algorithms (filter, wrapper, embedded), and feature creation techniques (temporal, interaction, aggregation, domain-specific).
+
+**error_handling_guide.md** offers practical solutions for common feature engineering errors including data type mismatches, missing values, outliers, division by zero, categorical encoding errors, scaling issues, memory problems, and temporal leakage prevention.
+
+## Leakage Prevention Checklist
+
+1. **Time-Ordered Splits**: Ensure training data strictly precedes test data chronologically.
+2. **Point-in-Time Correctness**: Use as-of joins; never aggregate future events relative to the prediction time.
+3. **Fold-Aware Encoding**: When target encoding, compute means out-of-fold.
+4. **Domain Traps**:
+   - Fraud: Label delay (chargebacks take weeks to arrive).
+   - Credit: Post-decision variables or future bureau updates.
+   - Graph: Edges from the future relative to prediction time.

--- a/backend/ai_assistant/skills/feature-engineering/references/README.md
+++ b/backend/ai_assistant/skills/feature-engineering/references/README.md
@@ -1,0 +1,8 @@
+# References
+
+Bundled resources for feature-engineering-toolkit skill
+
+- [ ] feature_engineering_best_practices.md: A comprehensive guide to feature engineering techniques, including encoding methods, scaling methods, and feature selection algorithms.
+- [ ] scikit_learn_api_reference.md: A subset of the scikit-learn API documentation relevant to feature engineering tasks, providing details on the functions and classes used in the skill.
+- [ ] feature_store_api_documentation.md: Documentation for interacting with popular feature stores, enabling Claude to retrieve and store features effectively.
+- [ ] error_handling_guide.md: Detailed guide on handling common errors during feature engineering, including data type mismatches, missing values, and outliers.

--- a/backend/ai_assistant/skills/feature-engineering/references/api_reference.md
+++ b/backend/ai_assistant/skills/feature-engineering/references/api_reference.md
@@ -1,0 +1,34 @@
+# Reference Documentation for Feature Engineering
+
+This is a placeholder for detailed reference documentation.
+Replace with actual reference content or delete if not needed.
+
+Example real reference docs from other skills:
+- product-management/references/communication.md - Comprehensive guide for status updates
+- product-management/references/context_building.md - Deep-dive on gathering context
+- bigquery/references/ - API references and query examples
+
+## When Reference Docs Are Useful
+
+Reference docs are ideal for:
+- Comprehensive API documentation
+- Detailed workflow guides
+- Complex multi-step processes
+- Information too lengthy for main SKILL.md
+- Content that's only needed for specific use cases
+
+## Structure Suggestions
+
+### API Reference Example
+- Overview
+- Authentication
+- Endpoints with examples
+- Error codes
+- Rate limits
+
+### Workflow Guide Example
+- Prerequisites
+- Step-by-step instructions
+- Common patterns
+- Troubleshooting
+- Best practices

--- a/backend/ai_assistant/skills/feature-engineering/references/error_handling_guide.md
+++ b/backend/ai_assistant/skills/feature-engineering/references/error_handling_guide.md
@@ -1,0 +1,295 @@
+# Feature Engineering Error Handling Guide
+
+## Overview
+
+This guide covers common errors encountered during feature engineering and provides practical solutions for handling them effectively.
+
+## Data Type Mismatches
+
+### Problem: Incompatible Data Types
+When features have unexpected data types (e.g., numeric column stored as string), operations fail.
+
+**Common Causes:**
+- Data imported with incorrect dtypes
+- Mixed types in a single column
+- String representations of numbers
+
+**Solutions:**
+
+```python
+# Convert column to numeric, coercing errors
+df['feature'] = pd.to_numeric(df['feature'], errors='coerce')
+
+# Handle mixed types
+df['feature'] = df['feature'].astype(str).str.replace(',', '').astype(float)
+
+# Check dtypes before operations
+assert df['feature'].dtype in [np.float64, np.int64], "Expected numeric type"
+```
+
+### Prevention:
+- Validate data types after loading
+- Use `df.info()` and `df.dtypes` to inspect
+- Document expected types in data schema
+
+## Missing Values
+
+### Problem: NaN and Null Values
+Missing values cause operations to fail or produce incorrect results.
+
+**Common Causes:**
+- Data collection gaps
+- Data entry errors
+- Intentional missing indicators
+
+**Solutions:**
+
+```python
+# Check missing values
+print(df.isnull().sum())
+print(df.isnull().sum() / len(df) * 100)  # Percentage
+
+# Handle missing values by strategy
+# 1. Deletion (if < 5% missing)
+df = df.dropna(subset=['feature'])
+
+# 2. Mean/Median imputation (numeric)
+df['feature'].fillna(df['feature'].median(), inplace=True)
+
+# 3. Mode imputation (categorical)
+df['feature'].fillna(df['feature'].mode()[0], inplace=True)
+
+# 4. Forward/Backward fill (time-series)
+df['feature'].fillna(method='ffill', inplace=True)
+
+# 5. Create missing indicator
+df['feature_missing'] = df['feature'].isnull().astype(int)
+df['feature'].fillna(df['feature'].median(), inplace=True)
+
+# 6. KNN imputation
+from sklearn.impute import KNNImputer
+imputer = KNNImputer(n_neighbors=5)
+df[['feature1', 'feature2']] = imputer.fit_transform(df[['feature1', 'feature2']])
+```
+
+### Prevention:
+- Understand missing data patterns
+- Document missing data handling strategy
+- Create missing indicators for important features
+- Validate imputation doesn't introduce bias
+
+## Outliers
+
+### Problem: Extreme Values
+Outliers can distort statistics and model performance.
+
+**Detection Methods:**
+
+```python
+# Z-score method
+from scipy import stats
+z_scores = np.abs(stats.zscore(df['feature']))
+outliers = df[z_scores > 3]
+
+# IQR method
+Q1 = df['feature'].quantile(0.25)
+Q3 = df['feature'].quantile(0.75)
+IQR = Q3 - Q1
+outliers = df[(df['feature'] < Q1 - 1.5*IQR) | (df['feature'] > Q3 + 1.5*IQR)]
+
+# Isolation Forest
+from sklearn.ensemble import IsolationForest
+iso_forest = IsolationForest(contamination=0.05)
+outlier_labels = iso_forest.fit_predict(df[['feature']])
+```
+
+**Handling Strategies:**
+
+```python
+# 1. Remove outliers
+df = df[~((df['feature'] < lower_bound) | (df['feature'] > upper_bound))]
+
+# 2. Cap/Winsorize
+df['feature'] = df['feature'].clip(lower=lower_bound, upper=upper_bound)
+
+# 3. Transform
+df['feature'] = np.log1p(df['feature'])
+
+# 4. Create outlier flag
+df['feature_outlier'] = ((df['feature'] < lower_bound) | (df['feature'] > upper_bound)).astype(int)
+```
+
+### Prevention:
+- Understand domain-specific acceptable ranges
+- Document outlier handling decisions
+- Validate outlier removal doesn't remove important information
+
+## Division by Zero
+
+### Problem: Invalid Operations
+Division by zero or invalid mathematical operations cause errors.
+
+**Solutions:**
+
+```python
+# Safe division
+df['ratio'] = df['numerator'] / (df['denominator'] + 1e-8)
+
+# Conditional division
+df['ratio'] = np.where(df['denominator'] != 0, 
+                       df['numerator'] / df['denominator'], 
+                       0)
+
+# Replace infinite values
+df['ratio'] = df['ratio'].replace([np.inf, -np.inf], 0)
+```
+
+## Categorical Encoding Errors
+
+### Problem: Unseen Categories
+During prediction, new categories not seen in training appear.
+
+**Solutions:**
+
+```python
+# 1. One-hot encoding with handle_unknown
+from sklearn.preprocessing import OneHotEncoder
+encoder = OneHotEncoder(handle_unknown='ignore', sparse=False)
+
+# 2. Target encoding with smoothing
+def target_encode(train_df, test_df, col, target):
+    global_mean = train_df[target].mean()
+    stats = train_df.groupby(col)[target].agg(['sum', 'count'])
+    
+    # Smoothing
+    m = 1  # Smoothing parameter
+    stats['encoded'] = (stats['sum'] + m * global_mean) / (stats['count'] + m)
+    
+    # Map to test data
+    test_df[f'{col}_encoded'] = test_df[col].map(stats['encoded']).fillna(global_mean)
+    return test_df
+
+# 3. Frequency encoding
+freq_map = train_df[col].value_counts().to_dict()
+test_df[f'{col}_freq'] = test_df[col].map(freq_map).fillna(0)
+```
+
+## Feature Scaling Issues
+
+### Problem: Inconsistent Scaling
+Training and test data scaled differently causes model performance degradation.
+
+**Solutions:**
+
+```python
+# Fit scaler on training data only
+from sklearn.preprocessing import StandardScaler
+scaler = StandardScaler()
+X_train_scaled = scaler.fit_transform(X_train)
+X_test_scaled = scaler.transform(X_test)  # Use fit parameters
+
+# Save scaler for production
+import joblib
+joblib.dump(scaler, 'scaler.pkl')
+scaler = joblib.load('scaler.pkl')
+```
+
+### Prevention:
+- Always fit scalers on training data only
+- Save and version scalers with models
+- Document scaling parameters
+
+## Memory Issues
+
+### Problem: Large Datasets
+Feature engineering on large datasets can cause memory errors.
+
+**Solutions:**
+
+```python
+# Process in chunks
+chunk_size = 10000
+for chunk in pd.read_csv('large_file.csv', chunksize=chunk_size):
+    # Process chunk
+    processed_chunk = feature_engineering_function(chunk)
+    # Save or aggregate
+
+# Use efficient dtypes
+df['int_col'] = df['int_col'].astype('int32')  # Instead of int64
+df['float_col'] = df['float_col'].astype('float32')  # Instead of float64
+
+# Drop unnecessary columns
+df = df.drop(columns=['unused_col1', 'unused_col2'])
+
+# Use sparse matrices for categorical features
+from scipy.sparse import csr_matrix
+sparse_matrix = csr_matrix(encoded_features)
+```
+
+## Time Series Feature Errors
+
+### Problem: Temporal Leakage
+Using future information to predict the past.
+
+**Solutions:**
+
+```python
+# Ensure proper time ordering
+df = df.sort_values('date')
+
+# Use expanding windows (not rolling into future)
+df['rolling_mean'] = df['value'].rolling(window=7, min_periods=1).mean()
+
+# Shift features to avoid leakage
+df['lagged_feature'] = df['feature'].shift(1)  # Previous day's value
+
+# Validate no future data in features
+assert df['date'].max() <= prediction_date, "Future data detected"
+```
+
+## Validation Checklist
+
+- [ ] All data types are correct
+- [ ] Missing values handled appropriately
+- [ ] Outliers identified and addressed
+- [ ] No division by zero errors
+- [ ] Categorical encoding handles unseen categories
+- [ ] Scaling fitted on training data only
+- [ ] No temporal leakage in time-series features
+- [ ] Memory usage is acceptable
+- [ ] Features are documented
+- [ ] Error handling is tested
+
+## Debugging Tips
+
+1. **Use assertions**: Validate assumptions at each step
+   ```python
+   assert df.shape[0] > 0, "Empty dataframe"
+   assert df[col].dtype == 'float64', "Wrong dtype"
+   ```
+
+2. **Log intermediate results**: Track data shape and statistics
+   ```python
+   print(f"Shape: {df.shape}, Missing: {df.isnull().sum().sum()}")
+   ```
+
+3. **Validate with domain experts**: Ensure features make sense
+   ```python
+   # Review top/bottom values
+   print(df['feature'].describe())
+   print(df['feature'].nlargest(5))
+   ```
+
+4. **Test on small samples**: Debug faster on subsets
+   ```python
+   df_sample = df.sample(n=1000, random_state=42)
+   ```
+
+5. **Use try-except blocks**: Graceful error handling
+   ```python
+   try:
+       result = operation(data)
+   except ValueError as e:
+       print(f"Error: {e}")
+       result = fallback_value
+   ```

--- a/backend/ai_assistant/skills/feature-engineering/references/feature_engineering_best_practices.md
+++ b/backend/ai_assistant/skills/feature-engineering/references/feature_engineering_best_practices.md
@@ -1,0 +1,185 @@
+# Feature Engineering Best Practices
+
+## Overview
+
+This guide covers proven techniques for feature engineering across multiple domains and use cases. Feature engineering is often the most impactful step in the machine learning pipeline, frequently outperforming model tuning and hyperparameter optimization.
+
+## Core Principles
+
+### 1. Domain Knowledge First
+- Leverage domain expertise to create meaningful features
+- Understand the business problem and data context
+- Validate features with domain experts
+
+### 2. Simplicity Over Complexity
+- Start with simple, interpretable features
+- Add complexity only when justified by performance gains
+- Avoid over-engineering features
+
+### 3. Data Quality Foundation
+- Clean data before feature engineering
+- Handle missing values appropriately
+- Remove or flag outliers based on domain context
+
+## Encoding Methods
+
+### Categorical Encoding
+
+#### One-Hot Encoding
+- **Use case**: Low cardinality features (<20 categories)
+- **Pros**: Works well with linear models, interpretable
+- **Cons**: Creates many columns for high cardinality
+- **Implementation**: `pd.get_dummies()`, `sklearn.preprocessing.OneHotEncoder`
+
+#### Label Encoding
+- **Use case**: Tree-based models, ordinal categories
+- **Pros**: Maintains order information
+- **Cons**: Implies false ordering for nominal categories
+- **Implementation**: `sklearn.preprocessing.LabelEncoder`
+
+#### Target Encoding
+- **Use case**: High cardinality features
+- **Pros**: Captures relationship with target, reduces dimensionality
+- **Cons**: Risk of leakage if not done carefully
+- **Implementation**: Out-of-fold encoding, smoothing with global mean
+- **Formula**: `enc(c) = (n_c · mean_c + m · global_mean) / (n_c + m)`
+
+#### Weight of Evidence (WOE)
+- **Use case**: Credit risk, regulated domains
+- **Pros**: Monotonic relationship to log-odds, handles missing as separate bin
+- **Cons**: Requires binning, more complex
+- **Formula**: `WOE_i = ln(% non-events_i / % events_i)`
+
+### Numerical Scaling
+
+#### Standardization (Z-score)
+- **Formula**: `(x - mean) / std`
+- **Use case**: Linear models, distance-based algorithms
+- **Implementation**: `sklearn.preprocessing.StandardScaler`
+
+#### Min-Max Scaling
+- **Formula**: `(x - min) / (max - min)`
+- **Use case**: Bounded features, neural networks
+- **Implementation**: `sklearn.preprocessing.MinMaxScaler`
+
+#### Log Transformation
+- **Use case**: Skewed distributions, monetary values
+- **Formula**: `log(x + 1)` (add 1 to handle zeros)
+- **Implementation**: `np.log1p()`
+
+#### Box-Cox Transformation
+- **Use case**: Normalizing distributions
+- **Pros**: Automatically finds optimal transformation
+- **Implementation**: `scipy.stats.boxcox`
+
+## Feature Selection Algorithms
+
+### Filter Methods
+- **Variance Threshold**: Remove low-variance features
+- **Correlation Analysis**: Remove highly correlated features
+- **Statistical Tests**: Chi-square, ANOVA, mutual information
+- **Pros**: Fast, independent of model
+- **Cons**: Doesn't consider feature interactions
+
+### Wrapper Methods
+- **Forward Selection**: Add features one by one
+- **Backward Elimination**: Remove features one by one
+- **Recursive Feature Elimination (RFE)**: Recursive removal based on importance
+- **Pros**: Considers feature interactions
+- **Cons**: Computationally expensive
+
+### Embedded Methods
+- **Tree-Based Importance**: Random Forest, XGBoost feature importance
+- **Regularization**: L1 (Lasso), L2 (Ridge) penalties
+- **Pros**: Fast, considers model performance
+- **Cons**: Model-specific
+
+## Feature Creation Techniques
+
+### Temporal Features
+- **Time-Since**: Days since last event, account opening
+- **Lag Features**: Previous values at different time steps
+- **Rolling Statistics**: Mean, std, min, max over windows
+- **Seasonal Features**: Day of week, month, quarter, holiday flags
+
+### Interaction Features
+- **Multiplication**: `feature_1 * feature_2`
+- **Division**: `feature_1 / feature_2` (with safe handling)
+- **Addition/Subtraction**: `feature_1 + feature_2`, `feature_1 - feature_2`
+- **Polynomial**: `feature_1^2`, `feature_1^3`
+
+### Aggregation Features
+- **Group-By Aggregations**: Count, sum, mean, std by category
+- **Entity-Level Aggregates**: Customer-level, merchant-level statistics
+- **Time-Window Aggregates**: Last 7 days, 30 days, 90 days
+
+### Domain-Specific Features
+- **Financial Ratios**: DTI, LTV, utilization
+- **Behavioral Scores**: RFM (Recency, Frequency, Monetary)
+- **Network Features**: Degree, centrality, community ID
+- **Text Features**: TF-IDF, topic modeling, embeddings
+
+## Data Leakage Prevention
+
+### Common Leakage Scenarios
+
+1. **Time Leakage**
+   - Using future information to predict the past
+   - Solution: Strict time-ordered splits, as-of joins
+
+2. **Target Leakage**
+   - Using post-decision variables
+   - Solution: Only use information available at prediction time
+
+3. **Encoding Leakage**
+   - Computing statistics on entire dataset
+   - Solution: Out-of-fold encoding, fit on training data only
+
+4. **Shared Entity Leakage**
+   - Same entity appearing in train and test
+   - Solution: Group-aware cross-validation
+
+### Prevention Checklist
+
+- [ ] Ensure training data precedes test data chronologically
+- [ ] Use as-of joins for temporal data
+- [ ] Compute statistics on training data only
+- [ ] Use out-of-fold encoding for categorical variables
+- [ ] Validate with domain experts
+- [ ] Monitor for train-serve skew in production
+
+## Feature Monitoring
+
+### Key Metrics
+
+- **Feature Drift**: Distribution changes over time
+- **Missing Rate**: Percentage of missing values
+- **Cardinality**: Number of unique values
+- **Correlation Changes**: Relationships with target changing
+
+### Production Considerations
+
+- **Feature Versioning**: Track feature definitions over time
+- **Feature Documentation**: Document creation logic and ownership
+- **Automated Retraining**: Trigger retraining on significant drift
+- **A/B Testing**: Validate feature impact in production
+
+## Tools and Libraries
+
+### Python Libraries
+- **scikit-learn**: Preprocessing, feature selection
+- **pandas**: Data manipulation, aggregations
+- **featuretools**: Automated feature engineering
+- **tsfresh**: Time-series feature extraction
+- **category_encoders**: Advanced categorical encoding
+
+### Feature Stores
+- **Feast**: Open-source feature store
+- **Tecton**: Enterprise feature platform
+- **Hopsworks**: Feature store with ML capabilities
+
+## References
+
+- Kaggle Competitions: Winning solutions often detail feature engineering approaches
+- Feature Engineering for Machine Learning (O'Reilly)
+- Domain-specific papers and industry guidelines

--- a/backend/ai_assistant/skills/feature-engineering/scripts/README.md
+++ b/backend/ai_assistant/skills/feature-engineering/scripts/README.md
@@ -1,0 +1,8 @@
+# Scripts
+
+Bundled resources for feature-engineering-toolkit skill
+
+- [ ] feature_engineering_pipeline.py: Automates the entire feature engineering process, including data loading, cleaning, transformation, selection, and model training.
+- [ ] feature_importance_analyzer.py: Analyzes feature importance using various techniques (e.g., permutation importance, SHAP values) and provides insights into which features are most influential.
+- [ ] data_visualizer.py: Generates visualizations of features and their relationships to the target variable, aiding in understanding data patterns.
+- [ ] feature_store_integration.py: Integrates with feature stores (e.g., Feast, Tecton) to manage and serve features for online and offline model deployment.

--- a/backend/ai_assistant/skills/feature-engineering/scripts/data_visualizer.py
+++ b/backend/ai_assistant/skills/feature-engineering/scripts/data_visualizer.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Data Visualizer
+
+Generates visualizations of features and their relationships to the target variable,
+aiding in understanding data patterns and feature distributions.
+"""
+
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+from sklearn.preprocessing import StandardScaler
+import warnings
+
+warnings.filterwarnings('ignore')
+
+# Set style
+sns.set_style("whitegrid")
+plt.rcParams['figure.figsize'] = (14, 10)
+
+
+class DataVisualizer:
+    """Comprehensive data visualization for feature analysis."""
+
+    def __init__(self, df, target_col, output_dir='./visualizations'):
+        """
+        Initialize the visualizer.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input dataframe
+        target_col : str
+            Name of target column
+        output_dir : str
+            Directory to save visualizations
+        """
+        self.df = df
+        self.target_col = target_col
+        self.output_dir = output_dir
+        self.numeric_cols = df.select_dtypes(include=[np.number]).columns.tolist()
+        if self.target_col in self.numeric_cols:
+            self.numeric_cols.remove(self.target_col)
+
+    def plot_feature_distributions(self, n_cols=4):
+        """Plot distributions of numeric features."""
+        n_features = len(self.numeric_cols)
+        n_rows = (n_features + n_cols - 1) // n_cols
+
+        fig, axes = plt.subplots(n_rows, n_cols, figsize=(16, 4 * n_rows))
+        axes = axes.flatten()
+
+        for idx, col in enumerate(self.numeric_cols):
+            axes[idx].hist(self.df[col], bins=30, edgecolor='black', alpha=0.7)
+            axes[idx].set_title(f'Distribution of {col}')
+            axes[idx].set_xlabel(col)
+            axes[idx].set_ylabel('Frequency')
+
+        # Hide unused subplots
+        for idx in range(n_features, len(axes)):
+            axes[idx].set_visible(False)
+
+        plt.tight_layout()
+        filepath = f'{self.output_dir}/feature_distributions.png'
+        plt.savefig(filepath, dpi=100, bbox_inches='tight')
+        print(f"✓ Saved: {filepath}")
+        plt.close()
+
+    def plot_correlation_heatmap(self):
+        """Plot correlation heatmap of numeric features."""
+        numeric_data = self.df[self.numeric_cols + [self.target_col]].select_dtypes(include=[np.number])
+
+        fig, ax = plt.subplots(figsize=(12, 10))
+        correlation_matrix = numeric_data.corr()
+
+        sns.heatmap(correlation_matrix, annot=True, fmt='.2f', cmap='coolwarm',
+                    center=0, square=True, ax=ax, cbar_kws={'label': 'Correlation'})
+        ax.set_title('Feature Correlation Heatmap')
+
+        plt.tight_layout()
+        filepath = f'{self.output_dir}/correlation_heatmap.png'
+        plt.savefig(filepath, dpi=100, bbox_inches='tight')
+        print(f"✓ Saved: {filepath}")
+        plt.close()
+
+    def plot_feature_target_relationship(self, n_cols=3):
+        """Plot relationship between features and target."""
+        n_features = len(self.numeric_cols)
+        n_rows = (n_features + n_cols - 1) // n_cols
+
+        fig, axes = plt.subplots(n_rows, n_cols, figsize=(15, 5 * n_rows))
+        axes = axes.flatten()
+
+        for idx, col in enumerate(self.numeric_cols):
+            # Scatter plot with target
+            scatter = axes[idx].scatter(self.df[col], self.df[self.target_col],
+                                       alpha=0.5, c=self.df[self.target_col], cmap='viridis')
+            axes[idx].set_xlabel(col)
+            axes[idx].set_ylabel(self.target_col)
+            axes[idx].set_title(f'{col} vs {self.target_col}')
+            plt.colorbar(scatter, ax=axes[idx])
+
+        # Hide unused subplots
+        for idx in range(n_features, len(axes)):
+            axes[idx].set_visible(False)
+
+        plt.tight_layout()
+        filepath = f'{self.output_dir}/feature_target_relationships.png'
+        plt.savefig(filepath, dpi=100, bbox_inches='tight')
+        print(f"✓ Saved: {filepath}")
+        plt.close()
+
+    def plot_missing_values(self):
+        """Plot missing values heatmap."""
+        missing_data = self.df.isnull()
+
+        fig, ax = plt.subplots(figsize=(12, 6))
+        sns.heatmap(missing_data, yticklabels=False, cbar=True, cmap='viridis', ax=ax)
+        ax.set_title('Missing Values Heatmap')
+
+        plt.tight_layout()
+        filepath = f'{self.output_dir}/missing_values.png'
+        plt.savefig(filepath, dpi=100, bbox_inches='tight')
+        print(f"✓ Saved: {filepath}")
+        plt.close()
+
+    def plot_feature_statistics(self):
+        """Plot box plots for feature statistics."""
+        n_features = len(self.numeric_cols)
+        n_cols = 4
+        n_rows = (n_features + n_cols - 1) // n_cols
+
+        fig, axes = plt.subplots(n_rows, n_cols, figsize=(16, 4 * n_rows))
+        axes = axes.flatten()
+
+        for idx, col in enumerate(self.numeric_cols):
+            axes[idx].boxplot(self.df[col].dropna())
+            axes[idx].set_title(f'Box Plot of {col}')
+            axes[idx].set_ylabel(col)
+
+        # Hide unused subplots
+        for idx in range(n_features, len(axes)):
+            axes[idx].set_visible(False)
+
+        plt.tight_layout()
+        filepath = f'{self.output_dir}/feature_statistics.png'
+        plt.savefig(filepath, dpi=100, bbox_inches='tight')
+        print(f"✓ Saved: {filepath}")
+        plt.close()
+
+    def plot_target_distribution(self):
+        """Plot target variable distribution."""
+        fig, ax = plt.subplots(figsize=(10, 6))
+
+        if self.df[self.target_col].dtype == 'object' or self.df[self.target_col].nunique() < 20:
+            # Categorical target
+            self.df[self.target_col].value_counts().plot(kind='bar', ax=ax, color='steelblue')
+            ax.set_title(f'Distribution of {self.target_col}')
+            ax.set_xlabel(self.target_col)
+            ax.set_ylabel('Count')
+        else:
+            # Continuous target
+            ax.hist(self.df[self.target_col], bins=30, edgecolor='black', alpha=0.7, color='steelblue')
+            ax.set_title(f'Distribution of {self.target_col}')
+            ax.set_xlabel(self.target_col)
+            ax.set_ylabel('Frequency')
+
+        plt.tight_layout()
+        filepath = f'{self.output_dir}/target_distribution.png'
+        plt.savefig(filepath, dpi=100, bbox_inches='tight')
+        print(f"✓ Saved: {filepath}")
+        plt.close()
+
+    def generate_summary_report(self):
+        """Generate summary statistics report."""
+        summary = self.df.describe().T
+
+        fig, ax = plt.subplots(figsize=(12, 8))
+        ax.axis('tight')
+        ax.axis('off')
+
+        table = ax.table(cellText=summary.round(3).values,
+                        colLabels=summary.columns,
+                        rowLabels=summary.index,
+                        cellLoc='center',
+                        loc='center')
+        table.auto_set_font_size(False)
+        table.set_fontsize(8)
+        table.scale(1, 1.5)
+
+        ax.set_title('Data Summary Statistics', fontsize=14, fontweight='bold', pad=20)
+
+        plt.tight_layout()
+        filepath = f'{self.output_dir}/summary_statistics.png'
+        plt.savefig(filepath, dpi=100, bbox_inches='tight')
+        print(f"✓ Saved: {filepath}")
+        plt.close()
+
+    def visualize_all(self):
+        """Generate all visualizations."""
+        import os
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        print(f"\n📊 Generating visualizations in {self.output_dir}...\n")
+
+        self.plot_target_distribution()
+        self.plot_feature_distributions()
+        self.plot_feature_target_relationship()
+        self.plot_correlation_heatmap()
+        self.plot_feature_statistics()
+        self.plot_missing_values()
+        self.generate_summary_report()
+
+        print(f"\n✅ All visualizations generated!\n")
+
+
+if __name__ == "__main__":
+    # Example usage
+    from sklearn.datasets import make_classification
+
+    X, y = make_classification(n_samples=500, n_features=10, n_informative=5, random_state=42)
+    df = pd.DataFrame(X, columns=[f'Feature_{i}' for i in range(10)])
+    df['target'] = y
+
+    visualizer = DataVisualizer(df, 'target', output_dir='./visualizations')
+    visualizer.visualize_all()

--- a/backend/ai_assistant/skills/feature-engineering/scripts/example.py
+++ b/backend/ai_assistant/skills/feature-engineering/scripts/example.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+Example helper script for feature-engineering
+
+This is a placeholder script that can be executed directly.
+Replace with actual implementation or delete if not needed.
+
+Example real scripts from other skills:
+- pdf/scripts/fill_fillable_fields.py - Fills PDF form fields
+- pdf/scripts/convert_pdf_to_images.py - Converts PDF pages to images
+"""
+
+def main():
+    print("This is an example script for feature-engineering")
+    # TODO: Add actual script logic here
+    # This could be data processing, file conversion, API calls, etc.
+
+if __name__ == "__main__":
+    main()

--- a/backend/ai_assistant/skills/feature-engineering/scripts/feature_engineering_pipeline.py
+++ b/backend/ai_assistant/skills/feature-engineering/scripts/feature_engineering_pipeline.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Feature Engineering Pipeline
+
+Automates the entire feature engineering process including data loading, cleaning,
+transformation, selection, and model evaluation.
+"""
+
+import pandas as pd
+import numpy as np
+from sklearn.preprocessing import StandardScaler, LabelEncoder
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.metrics import mean_squared_error, r2_score, accuracy_score, f1_score
+import warnings
+
+warnings.filterwarnings('ignore')
+
+
+class FeatureEngineeringPipeline:
+    """Comprehensive feature engineering pipeline for ML models."""
+
+    def __init__(self, target_col, task_type='classification', test_size=0.2, random_state=42):
+        """
+        Initialize the pipeline.
+
+        Parameters:
+        -----------
+        target_col : str
+            Name of the target column
+        task_type : str
+            'classification' or 'regression'
+        test_size : float
+            Proportion of data for testing
+        random_state : int
+            Random seed for reproducibility
+        """
+        self.target_col = target_col
+        self.task_type = task_type
+        self.test_size = test_size
+        self.random_state = random_state
+        self.df = None
+        self.X_train = None
+        self.X_test = None
+        self.y_train = None
+        self.y_test = None
+        self.model = None
+        self.scaler = StandardScaler()
+        self.label_encoders = {}
+
+    def load_data(self, filepath):
+        """Load data from CSV file."""
+        self.df = pd.read_csv(filepath)
+        print(f"✓ Data loaded: {self.df.shape[0]} rows, {self.df.shape[1]} columns")
+        return self
+
+    def clean_data(self):
+        """Handle missing values and basic data cleaning."""
+        # Handle missing values
+        numeric_cols = self.df.select_dtypes(include=[np.number]).columns
+        categorical_cols = self.df.select_dtypes(include=['object']).columns
+
+        for col in numeric_cols:
+            self.df[col].fillna(self.df[col].median(), inplace=True)
+
+        for col in categorical_cols:
+            self.df[col].fillna(self.df[col].mode()[0] if len(self.df[col].mode()) > 0 else 'Unknown', inplace=True)
+
+        print(f"✓ Data cleaned: Missing values handled")
+        return self
+
+    def encode_categorical(self):
+        """Encode categorical variables."""
+        categorical_cols = self.df.select_dtypes(include=['object']).columns
+
+        for col in categorical_cols:
+            if col != self.target_col:
+                le = LabelEncoder()
+                self.df[col] = le.fit_transform(self.df[col].astype(str))
+                self.label_encoders[col] = le
+
+        # Encode target if classification
+        if self.task_type == 'classification' and self.df[self.target_col].dtype == 'object':
+            le = LabelEncoder()
+            self.df[self.target_col] = le.fit_transform(self.df[self.target_col].astype(str))
+            self.label_encoders[self.target_col] = le
+
+        print(f"✓ Categorical encoding: {len(self.label_encoders)} columns encoded")
+        return self
+
+    def create_features(self):
+        """Create interaction and polynomial features."""
+        numeric_cols = self.df.select_dtypes(include=[np.number]).columns.tolist()
+
+        # Remove target from feature list
+        if self.target_col in numeric_cols:
+            numeric_cols.remove(self.target_col)
+
+        # Create ratio features for pairs of numeric columns
+        if len(numeric_cols) >= 2:
+            for i in range(len(numeric_cols)):
+                for j in range(i + 1, min(i + 3, len(numeric_cols))):
+                    col1, col2 = numeric_cols[i], numeric_cols[j]
+                    # Avoid division by zero
+                    if (self.df[col2] != 0).all():
+                        self.df[f'{col1}_div_{col2}'] = self.df[col1] / (self.df[col2] + 1e-8)
+                    self.df[f'{col1}_mul_{col2}'] = self.df[col1] * self.df[col2]
+
+        print(f"✓ Feature creation: Interaction features created")
+        return self
+
+    def select_features(self, n_features=None):
+        """Select top features using Random Forest importance."""
+        X = self.df.drop(columns=[self.target_col])
+        y = self.df[self.target_col]
+
+        if self.task_type == 'classification':
+            model = RandomForestClassifier(n_estimators=100, random_state=self.random_state, n_jobs=-1)
+        else:
+            model = RandomForestRegressor(n_estimators=100, random_state=self.random_state, n_jobs=-1)
+
+        model.fit(X, y)
+
+        # Get feature importance
+        importance_df = pd.DataFrame({
+            'feature': X.columns,
+            'importance': model.feature_importances_
+        }).sort_values('importance', ascending=False)
+
+        if n_features is None:
+            n_features = max(1, len(X.columns) // 2)
+
+        top_features = importance_df.head(n_features)['feature'].tolist()
+        self.df = self.df[[self.target_col] + top_features]
+
+        print(f"✓ Feature selection: Top {n_features} features selected")
+        return self
+
+    def split_data(self):
+        """Split data into train and test sets."""
+        X = self.df.drop(columns=[self.target_col])
+        y = self.df[self.target_col]
+
+        self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(
+            X, y, test_size=self.test_size, random_state=self.random_state
+        )
+
+        # Scale features
+        self.X_train = self.scaler.fit_transform(self.X_train)
+        self.X_test = self.scaler.transform(self.X_test)
+
+        print(f"✓ Data split: Train {self.X_train.shape[0]}, Test {self.X_test.shape[0]}")
+        return self
+
+    def train_model(self):
+        """Train the model."""
+        if self.task_type == 'classification':
+            self.model = RandomForestClassifier(n_estimators=100, random_state=self.random_state, n_jobs=-1)
+        else:
+            self.model = RandomForestRegressor(n_estimators=100, random_state=self.random_state, n_jobs=-1)
+
+        self.model.fit(self.X_train, self.y_train)
+        print(f"✓ Model trained: {self.model.__class__.__name__}")
+        return self
+
+    def evaluate_model(self):
+        """Evaluate model performance."""
+        y_pred = self.model.predict(self.X_test)
+
+        if self.task_type == 'classification':
+            accuracy = accuracy_score(self.y_test, y_pred)
+            f1 = f1_score(self.y_test, y_pred, average='weighted', zero_division=0)
+            print(f"✓ Model evaluation:")
+            print(f"  - Accuracy: {accuracy:.4f}")
+            print(f"  - F1-Score: {f1:.4f}")
+            return {'accuracy': accuracy, 'f1_score': f1}
+        else:
+            mse = mean_squared_error(self.y_test, y_pred)
+            r2 = r2_score(self.y_test, y_pred)
+            print(f"✓ Model evaluation:")
+            print(f"  - MSE: {mse:.4f}")
+            print(f"  - R² Score: {r2:.4f}")
+            return {'mse': mse, 'r2_score': r2}
+
+    def run(self, filepath, n_features=None):
+        """Run the complete pipeline."""
+        print("\n🚀 Starting Feature Engineering Pipeline...\n")
+        self.load_data(filepath)
+        self.clean_data()
+        self.encode_categorical()
+        self.create_features()
+        self.select_features(n_features)
+        self.split_data()
+        self.train_model()
+        metrics = self.evaluate_model()
+        print("\n✅ Pipeline completed!\n")
+        return metrics
+
+
+if __name__ == "__main__":
+    # Example usage
+    pipeline = FeatureEngineeringPipeline(
+        target_col='target',
+        task_type='classification',
+        test_size=0.2,
+        random_state=42
+    )
+    # pipeline.run('data.csv', n_features=10)

--- a/backend/ai_assistant/skills/feature-engineering/scripts/feature_importance_analyzer.py
+++ b/backend/ai_assistant/skills/feature-engineering/scripts/feature_importance_analyzer.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Feature Importance Analyzer
+
+Analyzes feature importance using multiple techniques including permutation importance,
+SHAP values, and tree-based importance to provide comprehensive feature insights.
+"""
+
+import pandas as pd
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.inspection import permutation_importance
+import warnings
+
+warnings.filterwarnings('ignore')
+
+
+class FeatureImportanceAnalyzer:
+    """Comprehensive feature importance analysis."""
+
+    def __init__(self, model, X_train, X_test, y_train, y_test, feature_names=None):
+        """
+        Initialize the analyzer.
+
+        Parameters:
+        -----------
+        model : sklearn model
+            Trained model
+        X_train : array-like
+            Training features
+        X_test : array-like
+            Test features
+        y_train : array-like
+            Training target
+        y_test : array-like
+            Test target
+        feature_names : list
+            Names of features
+        """
+        self.model = model
+        self.X_train = X_train
+        self.X_test = X_test
+        self.y_train = y_train
+        self.y_test = y_test
+        self.feature_names = feature_names or [f'Feature_{i}' for i in range(X_train.shape[1])]
+        self.importance_results = {}
+
+    def get_tree_importance(self):
+        """Get importance from tree-based models."""
+        if hasattr(self.model, 'feature_importances_'):
+            importances = self.model.feature_importances_
+            importance_df = pd.DataFrame({
+                'feature': self.feature_names,
+                'importance': importances,
+                'method': 'Tree-Based'
+            }).sort_values('importance', ascending=False)
+
+            self.importance_results['tree_based'] = importance_df
+            return importance_df
+        return None
+
+    def get_permutation_importance(self, n_repeats=10):
+        """Calculate permutation importance."""
+        result = permutation_importance(
+            self.model, self.X_test, self.y_test,
+            n_repeats=n_repeats, random_state=42, n_jobs=-1
+        )
+
+        importance_df = pd.DataFrame({
+            'feature': self.feature_names,
+            'importance': result.importances_mean,
+            'std': result.importances_std,
+            'method': 'Permutation'
+        }).sort_values('importance', ascending=False)
+
+        self.importance_results['permutation'] = importance_df
+        return importance_df
+
+    def get_correlation_importance(self, target):
+        """Calculate correlation-based importance."""
+        # Combine features and target
+        data = np.column_stack([self.X_train, target])
+        df = pd.DataFrame(data, columns=self.feature_names + ['target'])
+
+        correlations = df.corr()['target'].drop('target').abs().sort_values(ascending=False)
+
+        importance_df = pd.DataFrame({
+            'feature': correlations.index,
+            'importance': correlations.values,
+            'method': 'Correlation'
+        })
+
+        self.importance_results['correlation'] = importance_df
+        return importance_df
+
+    def summarize_importance(self):
+        """Summarize importance across all methods."""
+        if not self.importance_results:
+            return None
+
+        # Normalize importances to 0-1 scale
+        normalized_results = {}
+        for method, df in self.importance_results.items():
+            df_copy = df.copy()
+            max_imp = df_copy['importance'].max()
+            if max_imp > 0:
+                df_copy['importance'] = df_copy['importance'] / max_imp
+            normalized_results[method] = df_copy.set_index('feature')['importance']
+
+        # Average across methods
+        summary_df = pd.DataFrame(normalized_results).mean(axis=1).sort_values(ascending=False)
+
+        return pd.DataFrame({
+            'feature': summary_df.index,
+            'average_importance': summary_df.values
+        })
+
+    def print_report(self):
+        """Print comprehensive importance report."""
+        print("\n" + "=" * 80)
+        print("FEATURE IMPORTANCE ANALYSIS REPORT")
+        print("=" * 80 + "\n")
+
+        for method, df in self.importance_results.items():
+            print(f"\n{method.upper()} IMPORTANCE:")
+            print("-" * 80)
+            print(df.to_string(index=False))
+
+        summary = self.summarize_importance()
+        if summary is not None:
+            print(f"\n\nAVERAGE IMPORTANCE (Normalized):")
+            print("-" * 80)
+            print(summary.to_string(index=False))
+
+        print("\n" + "=" * 80 + "\n")
+
+    def get_top_features(self, n=10):
+        """Get top N features based on average importance."""
+        summary = self.summarize_importance()
+        if summary is not None:
+            return summary.head(n)['feature'].tolist()
+        return []
+
+    def analyze(self, target=None, n_repeats=10):
+        """Run complete analysis."""
+        print("\n🔍 Starting Feature Importance Analysis...\n")
+
+        # Tree-based importance
+        tree_imp = self.get_tree_importance()
+        if tree_imp is not None:
+            print(f"✓ Tree-based importance calculated")
+
+        # Permutation importance
+        perm_imp = self.get_permutation_importance(n_repeats=n_repeats)
+        print(f"✓ Permutation importance calculated")
+
+        # Correlation importance
+        if target is not None:
+            corr_imp = self.get_correlation_importance(target)
+            print(f"✓ Correlation importance calculated")
+
+        self.print_report()
+
+        top_features = self.get_top_features(n=10)
+        print(f"✓ Top 10 features: {top_features}")
+
+        return self.importance_results
+
+
+if __name__ == "__main__":
+    # Example usage
+    from sklearn.datasets import make_classification
+    from sklearn.model_selection import train_test_split
+
+    X, y = make_classification(n_samples=1000, n_features=20, n_informative=10, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+
+    model = RandomForestClassifier(n_estimators=100, random_state=42)
+    model.fit(X_train, y_train)
+
+    analyzer = FeatureImportanceAnalyzer(
+        model, X_train, X_test, y_train, y_test,
+        feature_names=[f'Feature_{i}' for i in range(20)]
+    )
+    analyzer.analyze(target=y_train)

--- a/backend/ai_assistant/skills/feature-engineering/scripts/feature_store_integration.py
+++ b/backend/ai_assistant/skills/feature-engineering/scripts/feature_store_integration.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Feature Store Integration
+
+Integrates with feature stores (e.g., Feast, Tecton) to manage and serve features
+for online and offline model deployment.
+"""
+
+import pandas as pd
+import json
+from datetime import datetime
+from typing import Dict, List, Optional
+import warnings
+
+warnings.filterwarnings('ignore')
+
+
+class FeatureStoreConnector:
+    """Base connector for feature store integration."""
+
+    def __init__(self, store_type='local', config=None):
+        """
+        Initialize feature store connector.
+
+        Parameters:
+        -----------
+        store_type : str
+            Type of feature store ('local', 'feast', 'tecton')
+        config : dict
+            Configuration for the feature store
+        """
+        self.store_type = store_type
+        self.config = config or {}
+        self.features = {}
+        self.metadata = {}
+
+    def register_feature(self, feature_name: str, feature_type: str, description: str = ""):
+        """Register a feature in the store."""
+        self.features[feature_name] = {
+            'type': feature_type,
+            'description': description,
+            'registered_at': datetime.now().isoformat()
+        }
+        print(f"✓ Feature registered: {feature_name}")
+
+    def register_feature_group(self, group_name: str, features: List[Dict]):
+        """Register a group of related features."""
+        self.metadata[group_name] = {
+            'features': features,
+            'created_at': datetime.now().isoformat()
+        }
+        print(f"✓ Feature group registered: {group_name}")
+
+    def store_features(self, df: pd.DataFrame, entity_id_col: str, feature_group: str):
+        """Store features for entities."""
+        if feature_group not in self.metadata:
+            self.metadata[feature_group] = {
+                'features': [],
+                'created_at': datetime.now().isoformat()
+            }
+
+        self.metadata[feature_group]['data'] = df.to_dict('records')
+        self.metadata[feature_group]['entity_id_col'] = entity_id_col
+        print(f"✓ Features stored for group: {feature_group}")
+
+    def retrieve_features(self, entity_ids: List, feature_group: str) -> Optional[pd.DataFrame]:
+        """Retrieve features for specific entities."""
+        if feature_group not in self.metadata or 'data' not in self.metadata[feature_group]:
+            print(f"✗ Feature group not found: {feature_group}")
+            return None
+
+        data = self.metadata[feature_group]['data']
+        entity_id_col = self.metadata[feature_group].get('entity_id_col', 'entity_id')
+
+        # Filter data for requested entities
+        filtered_data = [record for record in data if record.get(entity_id_col) in entity_ids]
+
+        if filtered_data:
+            df = pd.DataFrame(filtered_data)
+            print(f"✓ Retrieved {len(df)} records from {feature_group}")
+            return df
+        else:
+            print(f"✗ No records found for entities in {feature_group}")
+            return None
+
+    def list_features(self) -> pd.DataFrame:
+        """List all registered features."""
+        features_list = []
+        for name, info in self.features.items():
+            features_list.append({
+                'feature_name': name,
+                'type': info['type'],
+                'description': info['description'],
+                'registered_at': info['registered_at']
+            })
+
+        return pd.DataFrame(features_list)
+
+    def export_metadata(self, filepath: str):
+        """Export feature metadata to JSON."""
+        metadata = {
+            'store_type': self.store_type,
+            'features': self.features,
+            'feature_groups': self.metadata,
+            'exported_at': datetime.now().isoformat()
+        }
+
+        with open(filepath, 'w') as f:
+            json.dump(metadata, f, indent=2)
+
+        print(f"✓ Metadata exported to: {filepath}")
+
+    def import_metadata(self, filepath: str):
+        """Import feature metadata from JSON."""
+        with open(filepath, 'r') as f:
+            metadata = json.load(f)
+
+        self.features = metadata.get('features', {})
+        self.metadata = metadata.get('feature_groups', {})
+
+        print(f"✓ Metadata imported from: {filepath}")
+
+
+class LocalFeatureStore(FeatureStoreConnector):
+    """Local file-based feature store implementation."""
+
+    def __init__(self, base_path='./feature_store'):
+        """Initialize local feature store."""
+        super().__init__(store_type='local', config={'base_path': base_path})
+        self.base_path = base_path
+        import os
+        os.makedirs(base_path, exist_ok=True)
+
+    def store_features(self, df: pd.DataFrame, entity_id_col: str, feature_group: str):
+        """Store features to CSV file."""
+        super().store_features(df, entity_id_col, feature_group)
+
+        filepath = f"{self.base_path}/{feature_group}.csv"
+        df.to_csv(filepath, index=False)
+        print(f"✓ Features saved to: {filepath}")
+
+    def retrieve_features(self, entity_ids: List, feature_group: str) -> Optional[pd.DataFrame]:
+        """Retrieve features from CSV file."""
+        filepath = f"{self.base_path}/{feature_group}.csv"
+
+        try:
+            df = pd.read_csv(filepath)
+            entity_id_col = self.metadata.get(feature_group, {}).get('entity_id_col', 'entity_id')
+
+            if entity_id_col in df.columns:
+                filtered_df = df[df[entity_id_col].isin(entity_ids)]
+                print(f"✓ Retrieved {len(filtered_df)} records from {feature_group}")
+                return filtered_df
+            else:
+                print(f"✗ Entity ID column '{entity_id_col}' not found in {feature_group}")
+                return None
+        except FileNotFoundError:
+            print(f"✗ Feature group file not found: {filepath}")
+            return None
+
+
+class FeatureStoreManager:
+    """Manager for feature store operations."""
+
+    def __init__(self, store: FeatureStoreConnector):
+        """Initialize manager."""
+        self.store = store
+
+    def create_feature_catalog(self, features_dict: Dict[str, Dict]):
+        """Create a catalog of features."""
+        print("\n📚 Creating Feature Catalog...\n")
+
+        for feature_name, feature_info in features_dict.items():
+            self.store.register_feature(
+                feature_name=feature_name,
+                feature_type=feature_info.get('type', 'numeric'),
+                description=feature_info.get('description', '')
+            )
+
+        print(f"\n✓ Catalog created with {len(features_dict)} features\n")
+
+    def publish_features(self, df: pd.DataFrame, entity_id_col: str, feature_group: str):
+        """Publish features to the store."""
+        print(f"\n📤 Publishing features for group: {feature_group}...\n")
+        self.store.store_features(df, entity_id_col, feature_group)
+        print(f"\n✓ Features published\n")
+
+    def get_features(self, entity_ids: List, feature_group: str) -> Optional[pd.DataFrame]:
+        """Get features for entities."""
+        print(f"\n📥 Retrieving features for {len(entity_ids)} entities from {feature_group}...\n")
+        return self.store.retrieve_features(entity_ids, feature_group)
+
+    def print_catalog(self):
+        """Print feature catalog."""
+        catalog = self.store.list_features()
+        print("\n" + "=" * 80)
+        print("FEATURE CATALOG")
+        print("=" * 80 + "\n")
+        print(catalog.to_string(index=False))
+        print("\n" + "=" * 80 + "\n")
+
+
+if __name__ == "__main__":
+    # Example usage
+    from sklearn.datasets import make_classification
+
+    # Create sample data
+    X, y = make_classification(n_samples=100, n_features=5, random_state=42)
+    df = pd.DataFrame(X, columns=[f'feature_{i}' for i in range(5)])
+    df['entity_id'] = range(100)
+    df['target'] = y
+
+    # Initialize local feature store
+    store = LocalFeatureStore(base_path='./feature_store')
+    manager = FeatureStoreManager(store)
+
+    # Create feature catalog
+    features_dict = {
+        f'feature_{i}': {'type': 'numeric', 'description': f'Feature {i}'}
+        for i in range(5)
+    }
+    manager.create_feature_catalog(features_dict)
+
+    # Publish features
+    manager.publish_features(df, 'entity_id', 'sample_features')
+
+    # Print catalog
+    manager.print_catalog()
+
+    # Retrieve features
+    retrieved_df = manager.get_features([0, 1, 2, 3, 4], 'sample_features')
+    if retrieved_df is not None:
+        print(retrieved_df.head())

--- a/backend/ai_assistant/skills/feature-engineering/templates/example_template.txt
+++ b/backend/ai_assistant/skills/feature-engineering/templates/example_template.txt
@@ -1,0 +1,24 @@
+# Example Template File
+
+This placeholder represents where template files would be stored.
+Replace with actual template files (templates, images, fonts, etc.) or delete if not needed.
+
+Template files are NOT intended to be loaded into context, but rather used within
+the output Manus produces.
+
+Example template files from other skills:
+- Brand guidelines: logo.png, slides_template.pptx
+- Frontend builder: hello-world/ directory with HTML/React boilerplate
+- Typography: custom-font.ttf, font-family.woff2
+- Data: sample_data.csv, test_dataset.json
+
+## Common Template Types
+
+- Templates: .pptx, .docx, boilerplate directories
+- Images: .png, .jpg, .svg, .gif
+- Fonts: .ttf, .otf, .woff, .woff2
+- Boilerplate code: Project directories, starter files
+- Icons: .ico, .svg
+- Data files: .csv, .json, .xml, .yaml
+
+Note: This is a text placeholder. Actual templates can be any file type.

--- a/backend/ai_assistant/tool_definitions.py
+++ b/backend/ai_assistant/tool_definitions.py
@@ -4,7 +4,111 @@ OpenAI function-calling tool definitions for the AI Assistant.
 Each tool maps to a pipeline artifact stored in Redis.  The LLM decides
 which tools to call based on the user's question and the slim context
 manifest it receives.
+
+The list also exposes ``invoke_skill`` which returns the markdown body of
+a bundled domain-knowledge skill (see :mod:`ai_assistant.skill_registry`).
+Skill bodies are large authoritative references (e.g. a feature-engineering
+playbook) that the LLM should consult on demand rather than carry in every
+system prompt.
 """
+
+from .skill_registry import list_skills
+
+
+def _invoke_skill_definition() -> dict:
+    """Build the OpenAI tool definition for ``invoke_skill``.
+
+    The description enumerates the discovered skills so the LLM knows which
+    names are valid even without seeing the registry directly.
+    """
+    skills = list_skills()
+    if skills:
+        catalogue = '; '.join(f"{name}: {sk.description}" for name, sk in skills.items())
+        skill_names = sorted(skills.keys())
+    else:
+        catalogue = '(no skills bundled yet)'
+        skill_names = []
+    return {
+        "type": "function",
+        "function": {
+            "name": "invoke_skill",
+            "description": (
+                "Invoke a bundled domain-knowledge skill and receive its full "
+                "guidance text plus a listing of supplementary files.  Skills "
+                "encode best practices that are too long to ship in every "
+                "system prompt.  Call this BEFORE proposing domain-specific "
+                "feature engineering, encoding strategies, or anti-leakage "
+                "rules so your suggestions reflect the latest playbook.  "
+                "After this returns, call ``get_skill_file`` to fetch any "
+                "supplementary file you need.  Available skills — " + catalogue
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "skill_name": {
+                        "type": "string",
+                        "description": "Name of the skill to invoke.",
+                        **({"enum": skill_names} if skill_names else {}),
+                    },
+                },
+                "required": ["skill_name"],
+            },
+        },
+    }
+
+
+def _get_skill_file_definition() -> dict:
+    """Build the OpenAI tool definition for ``get_skill_file``.
+
+    The description lists every supplementary file that ships with each
+    bundled skill so the LLM can pick a file in one shot — without having
+    to call ``invoke_skill`` first if it already knows what it needs.
+    """
+    skills = list_skills()
+    file_catalogue_lines = []
+    skill_names = sorted(skills.keys())
+    for name in skill_names:
+        files = skills[name].list_files()
+        if files:
+            file_catalogue_lines.append(f"  • {name}: {', '.join(files)}")
+        else:
+            file_catalogue_lines.append(f"  • {name}: (no supplementary files)")
+    catalogue = '\n'.join(file_catalogue_lines) if file_catalogue_lines else '  (no skills bundled yet)'
+    return {
+        "type": "function",
+        "function": {
+            "name": "get_skill_file",
+            "description": (
+                "Read a supplementary file from a bundled skill (e.g., a "
+                "best-practices reference, an example pipeline script, an "
+                "error-handling guide).  Use this AFTER ``invoke_skill`` to "
+                "pull deeper material on demand without bloating the system "
+                "prompt.  Path is the relative path inside the skill "
+                "directory; only files ending in .md, .txt, .py, .json, "
+                ".yml, .yaml are exposed.\n\n"
+                f"Available files per skill:\n{catalogue}"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "skill_name": {
+                        "type": "string",
+                        "description": "Name of the skill that owns the file.",
+                        **({"enum": skill_names} if skill_names else {}),
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": (
+                            "Relative path of the file inside the skill "
+                            "directory (e.g., 'references/feature_engineering_best_practices.md')."
+                        ),
+                    },
+                },
+                "required": ["skill_name", "path"],
+            },
+        },
+    }
+
 
 PIPELINE_TOOLS = [
     {
@@ -243,4 +347,6 @@ PIPELINE_TOOLS = [
             },
         },
     },
+    _invoke_skill_definition(),
+    _get_skill_file_definition(),
 ]

--- a/backend/ai_assistant/tool_executor.py
+++ b/backend/ai_assistant/tool_executor.py
@@ -10,7 +10,8 @@ import json
 import logging
 from typing import Any, Optional
 
-from .prometa_config import tool as prometa_tool
+from .prometa_config import tool as prometa_tool, set_span_attr
+from .skill_registry import get_skill, list_skills
 
 from .cache import (
     cache_get,
@@ -271,6 +272,14 @@ def _handle_get_data_dictionary(file_id: int, args: dict) -> str:
     if not data:
         return _not_available("data dictionary")
     features = data if isinstance(data, list) else data.get('features', [])
+    # Backfill missing Feature_Description from the DataDictionary DB
+    # (single source of truth) so stale cache entries don't hide
+    # business descriptions from the assistant.
+    try:
+        from ai_assistant.views import _enrich_dd_with_descriptions
+        features = _enrich_dd_with_descriptions(file_id, features)
+    except Exception:
+        pass  # Non-fatal: continue with whatever cache had
     feature_filter = args.get('feature')
     if feature_filter:
         features = [f for f in features if f.get('Feature_Name', f.get('feature', '')) == feature_filter]
@@ -287,6 +296,100 @@ def _handle_get_data_dictionary(file_id: int, args: dict) -> str:
         usage = 'EXCLUDED' if excluded else 'included'
         lines.append(f"  {name}: {desc} (type={dtype}, nunique={nunique}, lom={lom}, {usage})")
     return '\n'.join(lines)
+
+
+@prometa_tool(name="skill-invoke")
+def _load_skill_traced(skill_name: str) -> str:
+    """Load a skill's markdown body inside its own Prometa tool span.
+
+    Each invocation produces a distinct child span in the trace so platform
+    operators can see exactly when (and which) skill the assistant pulled.
+    Span attributes:
+      - declarai.skill.name         requested skill name
+      - declarai.skill.found        whether the skill resolved
+      - declarai.skill.body_chars   payload size when found
+      - declarai.skill.path         on-disk location when found
+      - declarai.skill.file_count   number of supplementary files discovered
+    """
+    set_span_attr('declarai.skill.name', skill_name)
+    skill = get_skill(skill_name)
+    if not skill:
+        set_span_attr('declarai.skill.found', False)
+        available = ', '.join(sorted(list_skills().keys())) or '(none)'
+        return (f"Skill '{skill_name}' is not bundled. "
+                f"Available skills: {available}.")
+    body = skill.body()
+    files = skill.list_files()
+    set_span_attr('declarai.skill.found', True)
+    set_span_attr('declarai.skill.path', skill.path)
+    set_span_attr('declarai.skill.body_chars', len(body))
+    set_span_attr('declarai.skill.file_count', len(files))
+    if not body:
+        return f"Skill '{skill.name}' is registered but its body is empty."
+    file_list = ''
+    if files:
+        file_list = (
+            "\n\nSupplementary files (request via get_skill_file when needed):\n"
+            + '\n'.join(f"  - {p}" for p in files)
+        )
+    return (
+        f"Skill: {skill.name}\n"
+        f"Description: {skill.description}\n"
+        f"--- BEGIN SKILL CONTENT ---\n"
+        f"{body}\n"
+        f"--- END SKILL CONTENT ---"
+        f"{file_list}"
+    )
+
+
+def _handle_invoke_skill(file_id: int, args: dict) -> str:
+    skill_name = (args.get('skill_name') or args.get('name') or '').strip()
+    if not skill_name:
+        available = ', '.join(sorted(list_skills().keys())) or '(none)'
+        return f"invoke_skill requires 'skill_name'. Available skills: {available}."
+    return _load_skill_traced(skill_name)
+
+
+@prometa_tool(name="skill-file-read")
+def _load_skill_file_traced(skill_name: str, rel_path: str) -> str:
+    """Read a supplementary file from a skill bundle, in its own span.
+
+    Span attributes:
+      - declarai.skill.name           skill name requested
+      - declarai.skill.file_path      relative path requested
+      - declarai.skill.file_found     whether the read succeeded
+      - declarai.skill.file_chars     payload size when found
+    """
+    set_span_attr('declarai.skill.name', skill_name)
+    set_span_attr('declarai.skill.file_path', rel_path)
+    skill = get_skill(skill_name)
+    if not skill:
+        set_span_attr('declarai.skill.file_found', False)
+        available = ', '.join(sorted(list_skills().keys())) or '(none)'
+        return f"Skill '{skill_name}' is not bundled. Available skills: {available}."
+    text, err = skill.read_file(rel_path)
+    if err:
+        set_span_attr('declarai.skill.file_found', False)
+        listing = ', '.join(skill.list_files()) or '(none)'
+        return f"Cannot read '{rel_path}' from skill '{skill.name}': {err}. Available files: {listing}."
+    set_span_attr('declarai.skill.file_found', True)
+    set_span_attr('declarai.skill.file_chars', len(text))
+    return (
+        f"Skill: {skill.name}\n"
+        f"File: {rel_path}\n"
+        f"--- BEGIN FILE CONTENT ---\n"
+        f"{text}\n"
+        f"--- END FILE CONTENT ---"
+    )
+
+
+def _handle_get_skill_file(file_id: int, args: dict) -> str:
+    skill_name = (args.get('skill_name') or args.get('name') or '').strip()
+    rel_path = (args.get('path') or args.get('file_path') or args.get('rel_path') or '').strip()
+    if not skill_name or not rel_path:
+        return ("get_skill_file requires both 'skill_name' and 'path'. "
+                "Call invoke_skill first to see the file listing.")
+    return _load_skill_file_traced(skill_name, rel_path)
 
 
 # ---------------------------------------------------------------------------
@@ -306,6 +409,8 @@ _HANDLERS = {
     'get_pipeline_notes': _handle_get_pipeline_notes,
     'get_pipeline_config': _handle_get_pipeline_config,
     'get_data_dictionary': _handle_get_data_dictionary,
+    'invoke_skill': _handle_invoke_skill,
+    'get_skill_file': _handle_get_skill_file,
 }
 
 

--- a/backend/ai_assistant/views.py
+++ b/backend/ai_assistant/views.py
@@ -4,7 +4,9 @@ and returns advisory, insight-rich responses.
 """
 import json
 import os
+import re as _re
 import traceback
+from typing import Optional
 
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -14,7 +16,8 @@ from rest_framework.views import APIView
 
 from .prometa_config import workflow, agent, tool, flush as prometa_flush, set_span_attr, set_session_id
 from .tool_definitions import PIPELINE_TOOLS
-from .tool_executor import execute_tool_call
+from .tool_executor import execute_tool_call, _load_skill_traced
+from .skill_registry import get_skill
 from .cache import cache_get, cache_list_artifacts, ARTIFACT_PIPELINE_CONFIG, ARTIFACT_SELECTED_FEATURES, ARTIFACT_DATA_DICTIONARY
 from .model_registry import (
     get_model_config, list_models, DEFAULT_MODEL,
@@ -153,6 +156,33 @@ READING SFS RESULTS:
 • ALWAYS reference the actual metric values and stopping config when analyzing results.
   Never guess how many features are "left" — read it from the data.
 
+═══ DOMAIN SKILLS (invoke_skill / get_skill_file tools) ═══
+You have access to bundled domain-knowledge skills via two tools:
+• ``invoke_skill(skill_name)`` — returns the skill's main playbook PLUS a
+  listing of supplementary files (references, scripts, templates).
+• ``get_skill_file(skill_name, path)`` — returns the contents of one of those
+  supplementary files (e.g., ``references/feature_engineering_best_practices.md``,
+  ``scripts/feature_engineering_pipeline.py``).  Only call this if you actually
+  need the deeper material; the main playbook is usually enough.
+
+WHEN TO INVOKE A SKILL:
+• ``feature-engineering`` — Call this skill BEFORE proposing or executing any
+  feature-engineering action (creating new columns, ratios, aggregations,
+  WOE/IV bins, RFM, velocity features, etc.).  The skill ships authoritative
+  patterns by domain (banking/credit, fraud, telecom, insurance, trading,
+  healthcare) and a leakage-prevention checklist.  After receiving the skill
+  body, ground your suggestions in the patterns it lists and cite the
+  domain-specific section you're applying.  Use ``get_skill_file`` when you
+  need a longer reference or an example implementation script.
+
+GENERAL RULES:
+• A single ``invoke_skill`` call per user turn is enough — its content stays
+  in the conversation for the rest of the multi-turn loop.
+• Prefer ``get_skill_file`` over speculating; the file you ask for is small
+  and bounded.  If the user explicitly asks for a different methodology,
+  follow the user.
+• Prefer skills over your own intuition when they conflict.
+
 ═══ ACTIONABLE PIPELINE OPERATIONS ═══
 You are not just an advisor — you can DIRECTLY MODIFY the user's pipeline data, metadata,
 configuration, and notes. When the user asks you to do something actionable (create features,
@@ -269,6 +299,47 @@ def _call_llm(messages: list, model_key: str, tools: list = None) -> dict:
         raise ValueError(f'Unknown provider: {provider}')
 
 
+def _enrich_dd_with_descriptions(file_id: int, dd_list: list) -> list:
+    """Backfill missing ``Feature_Description`` entries from the DataDictionary DB.
+
+    The Redis cache for the data dictionary can be written by multiple paths
+    (the declaration endpoint enriches descriptions, but the frontend bulk-push
+    in some components may overwrite the cache with description-less rows).
+    The DB (DataDictionary table) is the source of truth; use it as a fallback
+    so every consumer — slim system context AND the get_data_dictionary tool —
+    sees descriptions whenever they exist.
+
+    Cheap (single DB query for the file_id), idempotent, and safe to call
+    on every chat turn.
+    """
+    if not dd_list:
+        return dd_list
+    needs = [
+        (f.get('Feature_Name') or f.get('feature'))
+        for f in dd_list
+        if not (f.get('Feature_Description') or f.get('description'))
+    ]
+    if not needs:
+        return dd_list
+    try:
+        from declaration.models import DataDictionary
+        rows = DataDictionary.objects.filter(
+            data_file_id=file_id, column_name__in=[n for n in needs if n]
+        ).values_list('column_name', 'description')
+        desc_map = {col: desc for col, desc in rows if desc}
+    except Exception:
+        return dd_list
+    if not desc_map:
+        return dd_list
+    for f in dd_list:
+        name = f.get('Feature_Name') or f.get('feature')
+        if name and not (f.get('Feature_Description') or f.get('description')):
+            d = desc_map.get(name)
+            if d:
+                f['Feature_Description'] = d
+    return dd_list
+
+
 def _build_slim_context(file_id: int, section: str) -> str:
     """Build a compact context manifest from cached artifacts (~500 tokens).
 
@@ -288,13 +359,29 @@ def _build_slim_context(file_id: int, section: str) -> str:
                       f"(removed: {config.get('rows_removed', 0)})")
         parts.append(f"Split: {config.get('split_strategy', '?')}")
 
-    # Data dictionary (feature names so LLM knows what's available)
+    # Data dictionary — embed feature descriptions inline so every model
+    # (native tool-callers AND text-mode models that may skip tool calls)
+    # sees the business context without needing a follow-up call.
     dd = cache_get(file_id, ARTIFACT_DATA_DICTIONARY)
     if dd:
         dd_list = dd if isinstance(dd, list) else dd.get('features', [])
-        dd_names = [f.get('Feature_Name', f.get('feature', '?')) for f in dd_list]
-        parts.append(f"Data dictionary ({len(dd_list)} features): {', '.join(dd_names[:50])}")
-        parts.append("Use get_data_dictionary tool for feature descriptions and details.")
+        dd_list = _enrich_dd_with_descriptions(file_id, dd_list)
+        described = [(f.get('Feature_Name') or f.get('feature') or '?',
+                      (f.get('Feature_Description') or f.get('description') or '').strip())
+                     for f in dd_list]
+        any_desc = any(d for _, d in described)
+        if any_desc:
+            parts.append(f"Data dictionary ({len(dd_list)} features) — business descriptions:")
+            for name, desc in described[:60]:
+                parts.append(f"  • {name}: {desc}" if desc else f"  • {name}: (no description)")
+            if len(dd_list) > 60:
+                parts.append(f"  … and {len(dd_list) - 60} more (use get_data_dictionary for the rest).")
+        else:
+            names = [n for n, _ in described]
+            parts.append(f"Data dictionary ({len(dd_list)} features): {', '.join(names[:50])}")
+            parts.append("No business descriptions found for these features. "
+                         "Tell the user that uploading a dictionary file (or editing descriptions in the UI) "
+                         "would unlock domain-aware feature engineering.")
 
     # Feature list (names + VIF flags only)
     sel_feats = cache_get(file_id, ARTIFACT_SELECTED_FEATURES)
@@ -319,6 +406,36 @@ def _build_slim_context(file_id: int, section: str) -> str:
 
 # Maximum number of tool-call rounds before forcing a final response
 _MAX_TOOL_ROUNDS = 5
+
+# ---------------------------------------------------------------------------
+# Skill auto-routing — map user intent to a bundled skill
+# ---------------------------------------------------------------------------
+# Conservative keyword/phrase matching.  Designed to fire on clear intent
+# (\"derive new features\", \"feature engineering\", \"create features\", etc.)
+# while NOT firing on pure analytical questions (\"why is feature X important?\").
+
+_FEATURE_ENGINEERING_PATTERNS = [
+    r'\bfeature[\s\-]?engineer\w*\b',
+    r'\b(derive|derived|deriving|generate|generating|create|creating|engineer|engineering|construct|build)\b'
+        r'.{0,40}\b(new\s+)?features?\b',
+    r'\bnew\s+features?\b.{0,40}\b(from|out\s+of|based\s+on)\b',
+    r'\b(ratio|interaction|aggregation|aggregate|woe|iv|rfm|velocity|rolling\s+window|lag\s+features?)\b',
+]
+_FEATURE_ENGINEERING_RE = _re.compile('|'.join(_FEATURE_ENGINEERING_PATTERNS), _re.IGNORECASE)
+
+
+def _auto_route_skill(user_message: str) -> Optional[str]:
+    """Return the name of a skill to auto-load for this user message, or None.
+
+    Currently only the ``feature-engineering`` skill is auto-routed.  The
+    function is the single source of truth for intent detection so tests
+    can pin behaviour without mocking the LLM.
+    """
+    if not user_message:
+        return None
+    if get_skill('feature-engineering') and _FEATURE_ENGINEERING_RE.search(user_message):
+        return 'feature-engineering'
+    return None
 
 
 @workflow(name="declarai-chat")
@@ -370,6 +487,25 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
         content = msg.get('content', '')
         if role in ('user', 'assistant') and content:
             messages.append({'role': role, 'content': content})
+
+    # ── Skill auto-routing (model-agnostic) ──
+    # Native function-callers can hit invoke_skill themselves, but text-mode
+    # models (e.g., Gemma in text tool-calling mode) often skip tool calls.
+    # Detect feature-engineering intent in the user message and pre-load the
+    # skill body so EVERY model sees the playbook before answering.
+    # The skill loader is a @prometa_tool span itself, so the auto-route is
+    # still visible in the trace chain.
+    auto_skill = _auto_route_skill(user_message)
+    if auto_skill:
+        skill_body = _load_skill_traced(auto_skill)
+        messages.append({
+            'role': 'system',
+            'content': (f"The user's question matched the '{auto_skill}' skill — "
+                        f"its playbook has been pre-loaded below.  Ground your "
+                        f"answer in these patterns and cite the relevant section.\n\n"
+                        f"{skill_body}"),
+        })
+        set_span_attr('declarai.skill.auto_routed', auto_skill)
 
     # Add current user message
     messages.append({'role': 'user', 'content': user_message})

--- a/backend/declaration/views.py
+++ b/backend/declaration/views.py
@@ -478,6 +478,14 @@ class DeclarationViewSet(viewsets.ModelViewSet):
                     pass
 
             data_dict = self.replace_nan_with_none(data_dict)
+
+            # Push to AI assistant Redis cache so tool calls see descriptions immediately
+            try:
+                from ai_assistant.cache import cache_put, ARTIFACT_DATA_DICTIONARY
+                cache_put(data_file.id, ARTIFACT_DATA_DICTIONARY, data_dict)
+            except Exception:
+                pass  # Non-fatal: AI cache is best-effort
+
             return Response(data_dict)
 
         except Exception as e:

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -1680,6 +1680,7 @@ def _stub_engine_models(monkeypatch):
             'thinking': False,
             'thinking_level': None,
             'ram_gb': 3,
+            'tool_calling_mode': 'text',
         },
         'engine-llama3.2-1b': {
             'provider': 'engine',
@@ -1693,6 +1694,7 @@ def _stub_engine_models(monkeypatch):
             'thinking': False,
             'thinking_level': None,
             'ram_gb': 2,
+            'tool_calling_mode': 'text',
         },
     }
     monkeypatch.setattr(mr, '_fetch_engine_models', lambda: fake)
@@ -1825,3 +1827,442 @@ class TestModelRegistry:
         assert len(engine_models) > 0
         for m in engine_models:
             assert 'ram_gb' in m, f"Model '{m['key']}' missing ram_gb in list output"
+
+    def test_openai_models_have_native_tool_calling_mode(self):
+        """OpenAI models should declare tool_calling_mode='native'."""
+        from ai_assistant.model_registry import MODEL_REGISTRY
+        for key, cfg in MODEL_REGISTRY.items():
+            if cfg['provider'] == 'openai':
+                assert cfg.get('tool_calling_mode') == 'native', f"{key}: expected native tool calling"
+
+    def test_engine_models_have_tool_calling_mode(self, _stub_engine_models):
+        """Engine models should declare tool_calling_mode (default 'text')."""
+        from ai_assistant.model_registry import list_models
+        models = list_models()
+        engine_models = [m for m in models if m['provider'] == 'engine']
+        for m in engine_models:
+            assert 'tool_calling_mode' in m, f"Model '{m['key']}' missing tool_calling_mode"
+            assert m['tool_calling_mode'] in ('native', 'text'), f"{m['key']}: invalid tool_calling_mode"
+
+    def test_list_models_surfaces_tool_calling_mode(self):
+        """list_models() should include tool_calling_mode for all models."""
+        from ai_assistant.model_registry import list_models
+        models = list_models()
+        for m in models:
+            assert 'tool_calling_mode' in m, f"Model '{m['key']}' missing tool_calling_mode in list output"
+
+
+# ---------------------------------------------------------------------------
+# Data dictionary enrichment — DB-backed fallback for stale Redis cache
+# (regression for the "Gemma says no descriptions exist" bug)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestDataDictionaryEnrichment:
+    """Test _enrich_dd_with_descriptions falls back to the DB when the cache
+    has missing/null descriptions, and that downstream consumers
+    (system context + get_data_dictionary tool) surface those descriptions."""
+
+    @pytest.fixture
+    def _decl_with_descriptions(self):
+        from declaration.models import Declaration, DataDictionary
+        decl = Declaration.objects.create(
+            file='data_files/dd_enrich.csv',
+            name='dd_enrich.csv',
+            original_name='dd_enrich.csv',
+        )
+        DataDictionary.objects.create(data_file=decl, column_name='Var_1',
+                                      description='CC Num of application_L1M')
+        DataDictionary.objects.create(data_file=decl, column_name='Var_2',
+                                      description='Worst Account Status All Credits')
+        return decl
+
+    def test_enrich_backfills_missing_descriptions(self, _decl_with_descriptions):
+        from ai_assistant.views import _enrich_dd_with_descriptions
+        cached = [
+            {'Feature_Name': 'Var_1', 'Feature_Description': None},
+            {'Feature_Name': 'Var_2'},  # description key absent
+            {'Feature_Name': 'Var_3', 'Feature_Description': 'Already has one'},
+        ]
+        out = _enrich_dd_with_descriptions(_decl_with_descriptions.pk, cached)
+        by_name = {f['Feature_Name']: f.get('Feature_Description') for f in out}
+        assert by_name['Var_1'] == 'CC Num of application_L1M'
+        assert by_name['Var_2'] == 'Worst Account Status All Credits'
+        assert by_name['Var_3'] == 'Already has one'  # unchanged
+
+    def test_enrich_no_op_when_db_empty(self):
+        from ai_assistant.views import _enrich_dd_with_descriptions
+        cached = [{'Feature_Name': 'Var_1', 'Feature_Description': None}]
+        out = _enrich_dd_with_descriptions(file_id=987654, dd_list=cached)
+        assert out[0].get('Feature_Description') in (None, '')
+
+    def test_enrich_handles_empty_list(self):
+        from ai_assistant.views import _enrich_dd_with_descriptions
+        assert _enrich_dd_with_descriptions(1, []) == []
+
+    def test_slim_context_embeds_descriptions(self, _decl_with_descriptions):
+        """Regression: every model (incl. text-mode tool callers) must see
+        feature descriptions inline, not be told to call a tool."""
+        from ai_assistant.cache import cache_put, _get_redis, ARTIFACT_DATA_DICTIONARY
+        from ai_assistant.views import _build_slim_context
+        r = _get_redis()
+        if r is None:
+            pytest.skip("Redis not available")
+        # Cache holds NULL descriptions — same situation we observed in prod
+        fid = _decl_with_descriptions.pk
+        cache_put(fid, ARTIFACT_DATA_DICTIONARY, [
+            {'Feature_Name': 'Var_1', 'Feature_Description': None},
+            {'Feature_Name': 'Var_2', 'Feature_Description': None},
+        ])
+        try:
+            ctx = _build_slim_context(fid, 'dictionary_declaration')
+            assert 'business descriptions' in ctx.lower()
+            assert 'CC Num of application_L1M' in ctx
+            assert 'Worst Account Status All Credits' in ctx
+            # And it must NOT instruct the model that descriptions are missing
+            assert 'No business descriptions found' not in ctx
+        finally:
+            r.delete(f'ai:pipeline:{fid}:data_dictionary')
+
+    def test_slim_context_warns_when_truly_no_descriptions(self):
+        """When neither cache nor DB has descriptions, the system context
+        should explicitly tell the LLM so users can be guided to upload one."""
+        from ai_assistant.cache import cache_put, _get_redis, ARTIFACT_DATA_DICTIONARY
+        from ai_assistant.views import _build_slim_context
+        r = _get_redis()
+        if r is None:
+            pytest.skip("Redis not available")
+        cache_put(987655, ARTIFACT_DATA_DICTIONARY, [
+            {'Feature_Name': 'Var_1', 'Feature_Description': None},
+        ])
+        try:
+            ctx = _build_slim_context(987655, 'dictionary_declaration')
+            assert 'No business descriptions found' in ctx
+        finally:
+            r.delete('ai:pipeline:987655:data_dictionary')
+
+    def test_get_data_dictionary_tool_uses_db_fallback(self, _decl_with_descriptions):
+        """The get_data_dictionary tool output (used by native function-callers)
+        must also benefit from the DB fallback."""
+        from ai_assistant.cache import cache_put, _get_redis, ARTIFACT_DATA_DICTIONARY
+        from ai_assistant.tool_executor import execute_tool_call
+        r = _get_redis()
+        if r is None:
+            pytest.skip("Redis not available")
+        fid = _decl_with_descriptions.pk
+        cache_put(fid, ARTIFACT_DATA_DICTIONARY, [
+            {'Feature_Name': 'Var_1', 'Feature_Description': None,
+             'Data_Type': 'integer', 'Unique_Values': 10},
+            {'Feature_Name': 'Var_2', 'Feature_Description': None,
+             'Data_Type': 'str', 'Unique_Values': 9},
+        ])
+        try:
+            result = execute_tool_call(fid, 'get_data_dictionary', {})
+            assert 'CC Num of application_L1M' in result
+            assert 'Worst Account Status All Credits' in result
+        finally:
+            r.delete(f'ai:pipeline:{fid}:data_dictionary')
+
+
+# ---------------------------------------------------------------------------
+# Skill registry + invoke_skill tool + skill auto-routing
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSkillRegistry:
+    """Parses SKILL.md frontmatter, exposes registered skills."""
+
+    def test_feature_engineering_skill_is_discovered(self):
+        from ai_assistant.skill_registry import list_skills
+        skills = list_skills(refresh=True)
+        assert 'feature-engineering' in skills
+        sk = skills['feature-engineering']
+        assert sk.description  # non-empty
+        # Description from the bundled SKILL.md frontmatter
+        assert 'feature' in sk.description.lower()
+
+    def test_skill_body_is_loaded_lazily(self):
+        from ai_assistant.skill_registry import get_skill
+        sk = get_skill('feature-engineering')
+        assert sk is not None
+        body = sk.body()
+        # Body must contain real FE content, not the frontmatter
+        assert 'Feature Engineering Guide' in body
+        assert '---' not in body.splitlines()[0]  # frontmatter stripped
+
+    def test_unknown_skill_returns_none(self):
+        from ai_assistant.skill_registry import get_skill
+        assert get_skill('nonexistent-skill-xyz') is None
+
+    def test_frontmatter_parser_handles_quoted_values(self):
+        from ai_assistant.skill_registry import _split_frontmatter
+        text = '---\nname: foo\ndescription: "hello: world"\n---\nbody here\n'
+        meta, body = _split_frontmatter(text)
+        assert meta['name'] == 'foo'
+        assert meta['description'] == 'hello: world'
+        assert body.strip() == 'body here'
+
+    def test_frontmatter_parser_handles_no_frontmatter(self):
+        from ai_assistant.skill_registry import _split_frontmatter
+        meta, body = _split_frontmatter('plain markdown\n')
+        assert meta == {}
+        assert body == 'plain markdown\n'
+
+
+@pytest.mark.unit
+class TestInvokeSkillTool:
+    """The invoke_skill tool returns the skill body and is wired into the
+    OpenAI tool definition list with the bundled skill name."""
+
+    def test_tool_definition_includes_invoke_skill(self):
+        from ai_assistant.tool_definitions import PIPELINE_TOOLS
+        names = [t['function']['name'] for t in PIPELINE_TOOLS]
+        assert 'invoke_skill' in names
+
+    def test_tool_definition_enumerates_bundled_skills(self):
+        from ai_assistant.tool_definitions import PIPELINE_TOOLS
+        invoke = next(t for t in PIPELINE_TOOLS if t['function']['name'] == 'invoke_skill')
+        params = invoke['function']['parameters']['properties']
+        assert 'skill_name' in params
+        # The enum should list at least feature-engineering
+        assert 'feature-engineering' in params['skill_name'].get('enum', [])
+        assert 'feature-engineering' in invoke['function']['description'].lower()
+
+    def test_invoke_skill_handler_returns_body(self):
+        from ai_assistant.tool_executor import execute_tool_call
+        result = execute_tool_call(1, 'invoke_skill', {'skill_name': 'feature-engineering'})
+        assert 'BEGIN SKILL CONTENT' in result
+        assert 'END SKILL CONTENT' in result
+        assert 'Feature Engineering Guide' in result
+
+    def test_invoke_skill_handler_unknown_skill(self):
+        from ai_assistant.tool_executor import execute_tool_call
+        result = execute_tool_call(1, 'invoke_skill', {'skill_name': 'no-such-skill'})
+        assert "not bundled" in result
+        assert 'feature-engineering' in result  # lists available
+
+    def test_invoke_skill_handler_missing_arg(self):
+        from ai_assistant.tool_executor import execute_tool_call
+        result = execute_tool_call(1, 'invoke_skill', {})
+        assert "requires 'skill_name'" in result
+
+    def test_load_skill_traced_sets_span_attributes(self, monkeypatch):
+        """The dedicated traced loader stamps declarai.skill.* attributes so
+        each skill invocation appears as a distinct child span."""
+        from ai_assistant import tool_executor as te
+        captured = {}
+
+        def fake_set(key, value):
+            captured[key] = value
+
+        monkeypatch.setattr(te, 'set_span_attr', fake_set)
+        result = te._load_skill_traced('feature-engineering')
+        assert 'BEGIN SKILL CONTENT' in result
+        assert captured.get('declarai.skill.name') == 'feature-engineering'
+        assert captured.get('declarai.skill.found') is True
+        assert isinstance(captured.get('declarai.skill.body_chars'), int)
+        assert captured['declarai.skill.body_chars'] > 100
+
+
+@pytest.mark.unit
+class TestSkillAutoRouting:
+    """Auto-router fires on feature-engineering intent in the user message
+    so text-mode models (which often skip tool calls) still see the skill."""
+
+    @pytest.mark.parametrize('msg', [
+        "according to the project goal and the feature descriptions we have, "
+        "which new features can be derived from others",
+        "Please implement feature engineering on this dataset.",
+        "Create a few WOE bins for the categorical variables.",
+        "I want to derive ratio features from the income columns.",
+        "Can you generate new features based on the existing ones?",
+    ])
+    def test_auto_route_fires_on_fe_intent(self, msg):
+        from ai_assistant.views import _auto_route_skill
+        assert _auto_route_skill(msg) == 'feature-engineering'
+
+    @pytest.mark.parametrize('msg', [
+        "Why is Var_19 important in the SHAP plot?",
+        "Explain the SFS results to me.",
+        "What is the bad rate in the test split?",
+        "",
+    ])
+    def test_auto_route_does_not_fire_on_unrelated_questions(self, msg):
+        from ai_assistant.views import _auto_route_skill
+        assert _auto_route_skill(msg) is None
+
+
+# ---------------------------------------------------------------------------
+# Skill supplementary file access (get_skill_file tool + Skill.read_file)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSkillFileAccess:
+    """list_files() exposes references/scripts/templates and read_file()
+    enforces path-traversal protection plus suffix allow-listing."""
+
+    def test_list_files_excludes_skill_md(self):
+        from ai_assistant.skill_registry import get_skill
+        sk = get_skill('feature-engineering')
+        files = sk.list_files()
+        assert 'SKILL.md' not in files
+        # v2 ships these supplementary files
+        assert any(p.startswith('references/') for p in files)
+        assert any(p.startswith('scripts/') for p in files)
+        # All paths use forward slashes
+        assert all('\\' not in p for p in files)
+
+    def test_read_file_returns_content(self):
+        from ai_assistant.skill_registry import get_skill
+        sk = get_skill('feature-engineering')
+        text, err = sk.read_file('references/feature_engineering_best_practices.md')
+        assert err is None
+        assert text  # non-empty
+        assert len(text) > 100
+
+    def test_read_file_accepts_python_file(self):
+        from ai_assistant.skill_registry import get_skill
+        sk = get_skill('feature-engineering')
+        text, err = sk.read_file('scripts/example.py')
+        assert err is None
+        assert 'def main' in text or 'example' in text.lower()
+
+    def test_read_file_rejects_absolute_path(self):
+        from ai_assistant.skill_registry import get_skill
+        sk = get_skill('feature-engineering')
+        text, err = sk.read_file('/etc/passwd')
+        assert text == ''
+        assert err is not None
+        assert 'traversal' in err.lower() or 'outside' in err.lower()
+
+    def test_read_file_rejects_dot_dot_traversal(self):
+        from ai_assistant.skill_registry import get_skill
+        sk = get_skill('feature-engineering')
+        text, err = sk.read_file('../../etc/passwd')
+        assert text == ''
+        assert err is not None
+        assert 'traversal' in err.lower()
+
+    def test_read_file_rejects_disallowed_suffix(self):
+        from ai_assistant.skill_registry import get_skill
+        sk = get_skill('feature-engineering')
+        text, err = sk.read_file('scripts/example.exe')
+        assert text == ''
+        assert err is not None
+        assert 'only files ending' in err.lower()
+
+    def test_read_file_missing_file(self):
+        from ai_assistant.skill_registry import get_skill
+        sk = get_skill('feature-engineering')
+        text, err = sk.read_file('references/does_not_exist.md')
+        assert text == ''
+        assert err is not None
+        assert 'not found' in err.lower()
+
+    def test_read_file_empty_path(self):
+        from ai_assistant.skill_registry import get_skill
+        sk = get_skill('feature-engineering')
+        text, err = sk.read_file('')
+        assert text == ''
+        assert err is not None
+
+    def test_read_file_truncates_oversized(self, tmp_path, monkeypatch):
+        """Files larger than MAX_SKILL_FILE_BYTES are truncated with a marker."""
+        from ai_assistant import skill_registry as reg
+        # Create a fake skill on disk with one big file
+        sk_dir = tmp_path / 'big-skill'
+        sk_dir.mkdir()
+        (sk_dir / 'SKILL.md').write_text(
+            '---\nname: big-skill\ndescription: "big"\n---\n# Body\nhello\n',
+            encoding='utf-8',
+        )
+        big = 'A' * (reg.MAX_SKILL_FILE_BYTES + 50)
+        (sk_dir / 'huge.md').write_text(big, encoding='utf-8')
+
+        monkeypatch.setattr(reg, 'SKILLS_DIR', str(tmp_path))
+        reg.invalidate_cache()
+        try:
+            sk = reg.get_skill('big-skill')
+            assert sk is not None
+            text, err = sk.read_file('huge.md')
+            assert err is None
+            assert text.endswith('[truncated to 100000 bytes]')
+            assert text.count('A') == reg.MAX_SKILL_FILE_BYTES
+        finally:
+            # Restore default skills dir
+            reg.invalidate_cache()
+
+
+@pytest.mark.unit
+class TestGetSkillFileTool:
+    """get_skill_file is wired as a tool, returns content, and creates its
+    own prometa span via _load_skill_file_traced."""
+
+    def test_tool_definition_includes_get_skill_file(self):
+        from ai_assistant.tool_definitions import PIPELINE_TOOLS
+        names = [t['function']['name'] for t in PIPELINE_TOOLS]
+        assert 'get_skill_file' in names
+
+    def test_tool_definition_lists_files_in_description(self):
+        from ai_assistant.tool_definitions import PIPELINE_TOOLS
+        spec = next(t for t in PIPELINE_TOOLS if t['function']['name'] == 'get_skill_file')
+        desc = spec['function']['description']
+        # Description should advertise concrete file paths so the LLM can pick
+        assert 'references/' in desc or 'scripts/' in desc
+        # Required params are skill_name + path
+        assert set(spec['function']['parameters']['required']) == {'skill_name', 'path'}
+
+    def test_invoke_skill_response_lists_supplementary_files(self):
+        from ai_assistant.tool_executor import execute_tool_call
+        result = execute_tool_call(1, 'invoke_skill', {'skill_name': 'feature-engineering'})
+        assert 'Supplementary files' in result
+        assert 'references/' in result
+
+    def test_get_skill_file_handler_returns_body(self):
+        from ai_assistant.tool_executor import execute_tool_call
+        result = execute_tool_call(1, 'get_skill_file', {
+            'skill_name': 'feature-engineering',
+            'path': 'references/feature_engineering_best_practices.md',
+        })
+        assert 'BEGIN FILE CONTENT' in result
+        assert 'END FILE CONTENT' in result
+
+    def test_get_skill_file_handler_blocks_traversal(self):
+        from ai_assistant.tool_executor import execute_tool_call
+        result = execute_tool_call(1, 'get_skill_file', {
+            'skill_name': 'feature-engineering',
+            'path': '../../../../etc/passwd',
+        })
+        assert 'BEGIN FILE CONTENT' not in result
+        assert 'traversal' in result.lower() or 'outside' in result.lower()
+
+    def test_get_skill_file_handler_unknown_skill(self):
+        from ai_assistant.tool_executor import execute_tool_call
+        result = execute_tool_call(1, 'get_skill_file', {
+            'skill_name': 'nope',
+            'path': 'foo.md',
+        })
+        assert 'not bundled' in result
+
+    def test_get_skill_file_handler_missing_args(self):
+        from ai_assistant.tool_executor import execute_tool_call
+        result = execute_tool_call(1, 'get_skill_file', {'skill_name': 'feature-engineering'})
+        assert "requires both" in result.lower() or 'requires' in result.lower()
+
+    def test_load_skill_file_traced_sets_span_attributes(self, monkeypatch):
+        from ai_assistant import tool_executor as te
+        captured = {}
+
+        def fake_set(key, value):
+            captured[key] = value
+
+        monkeypatch.setattr(te, 'set_span_attr', fake_set)
+        result = te._load_skill_file_traced(
+            'feature-engineering',
+            'references/feature_engineering_best_practices.md',
+        )
+        assert 'BEGIN FILE CONTENT' in result
+        assert captured.get('declarai.skill.name') == 'feature-engineering'
+        assert captured.get('declarai.skill.file_path') == \
+            'references/feature_engineering_best_practices.md'
+        assert captured.get('declarai.skill.file_found') is True
+        assert isinstance(captured.get('declarai.skill.file_chars'), int)
+        assert captured['declarai.skill.file_chars'] > 100

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.css
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.css
@@ -138,6 +138,15 @@
   white-space: nowrap;
 }
 
+.model-option-tcm {
+  font-size: 9px;
+  background: rgba(100, 200, 255, 0.15);
+  padding: 1px 5px;
+  border-radius: 3px;
+  opacity: 0.8;
+  white-space: nowrap;
+}
+
 .model-option-provider {
   font-size: 10px;
   opacity: 0.5;

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.html
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.html
@@ -21,6 +21,7 @@
           >
             <span class="model-option-name">{{ m.display_name }}</span>
             <span class="model-option-ram" *ngIf="m.ram_gb">{{ m.ram_gb }} GB</span>
+            <span class="model-option-tcm" *ngIf="m.tool_calling_mode">{{ m.tool_calling_mode === 'native' ? '⚡ native' : '📝 text' }}</span>
             <span class="model-option-provider">{{ m.provider }}</span>
             <span class="model-option-check" *ngIf="m.key === selectedModel">&#10003;</span>
           </button>

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
@@ -21,7 +21,7 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
   private shouldScrollToBottom = false;
 
   // Model selector
-  availableModels: Array<{key: string; display_name: string; provider: string; ram_gb?: number}> = [];
+  availableModels: Array<{key: string; display_name: string; provider: string; ram_gb?: number; tool_calling_mode?: string}> = [];
   selectedModel: string = 'gpt-5.5';
   showModelSelector: boolean = false;
 

--- a/frontend/src/app/declaration/declaration.component.ts
+++ b/frontend/src/app/declaration/declaration.component.ts
@@ -4,6 +4,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { FeatureCardComponent } from '../feature-card/feature-card.component';
 import * as XLSX from 'xlsx';
 import { SharedService } from '../services/shared.service';
+import { DataService } from '../services/data.service';
 import { combineLatest, Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Router } from '@angular/router';
@@ -58,7 +59,8 @@ export class DeclarationComponent implements OnInit, OnDestroy {
     private http: HttpClient,
     private dialog: MatDialog,
     private sharedService: SharedService,
-    private router: Router
+    private router: Router,
+    private dataService: DataService
   ) {}
 
   ngOnInit() {
@@ -95,6 +97,10 @@ export class DeclarationComponent implements OnInit, OnDestroy {
                   this.dataDictionary = data;
                   this.initializeModelUsageFromBackend(data);
                   this.pushDeclarationAiContext();
+                  // Push to Redis cache for AI assistant
+                  this.dataService.pushAiCache(id, { data_dictionary: data }).subscribe({
+                    error: (err: any) => console.warn('[AI Cache] data dictionary push failed:', err),
+                  });
                 }
               },
               () => { /* dictionary may not exist yet — that's fine */ }
@@ -116,6 +122,12 @@ export class DeclarationComponent implements OnInit, OnDestroy {
                   this.dataDictionary = data;
                   this.initializeModelUsageFromBackend(data);
                   this.pushDeclarationAiContext();
+                  // Push to Redis cache for AI assistant
+                  if (this.currentFileId !== null) {
+                    this.dataService.pushAiCache(this.currentFileId, { data_dictionary: data }).subscribe({
+                      error: (err: any) => console.warn('[AI Cache] data dictionary push failed:', err),
+                    });
+                  }
                 }
               },
               () => { /* dictionary may not exist yet */ }
@@ -490,6 +502,12 @@ export class DeclarationComponent implements OnInit, OnDestroy {
           this.initializeModelUsageFromBackend(data);
           // Push dictionary to cumulative AI context
           this.pushDeclarationAiContext();
+          // Push data dictionary to Redis cache for AI assistant tool calls
+          if (this.currentFileId !== null && Array.isArray(data) && data.length > 0) {
+            this.dataService.pushAiCache(this.currentFileId, { data_dictionary: data }).subscribe({
+              error: (err: any) => console.warn('[AI Cache] data dictionary push failed:', err),
+            });
+          }
           // Checkpoint: dictionary generated
           this.sharedService.triggerCheckpoint('decl_dictionary_generated');
         },


### PR DESCRIPTION
Backend — AI assistant skills (NEW)
- skill_registry.py: discovers .skill bundles in backend/ai_assistant/skills/, parses YAML-ish frontmatter manually (no PyYAML dep), lazy body loader. New methods Skill.list_files() and Skill.read_file(rel_path) with strict path-traversal protection (no abs paths, no .., realpath containment), suffix allow-list (.md/.txt/.py/.json/.yml/.yaml), and 100KB truncation.
- tools: invoke_skill(skill_name) returns SKILL.md body + supplementary file listing; get_skill_file(skill_name, path) returns one supplementary file. Both wrapped in @prometa_tool decorators so each invocation appears as a distinct child span (skill-invoke / skill-file-read) in the trace chain with declarai.skill.{name,found,path,body_chars,file_count,file_path, file_chars} attributes.
- Auto-routing: _auto_route_skill() detects feature-engineering intent in the user message and pre-loads the skill body before the LLM call so text-mode models (Gemma) also see the playbook. Same traced loader, so auto-route also produces a span.
- Bundled skill: feature-engineering v2 (~57KB) — domain-specific feature patterns (banking, fraud, telecom, insurance, healthcare, trading) + leakage-prevention checklist + best practices, error handling, and pipeline reference scripts.
- SYSTEM_PROMPT documents both tools and when to call them.

Backend — data dictionary fix
- declaration/views.py: get_data_dictionary tool path now hydrates Feature_Description from the DB when the cached payload has nulls (frontend sometimes pushes the dict before descriptions are persisted).

Backend — multi-model tool calling
- model_registry.py: added tool_calling_mode metadata ('native' for GPT-x, 'text' for engine-served open models). Surfaced via _MODEL_META_KEYS so the frontend can render it.

Frontend — model selector UX
- ai-chat-panel: shows '⚡ native' / '📝 text' badge per model in the selector dropdown so users see whether tool calls work natively or via text action blocks.

Frontend — AI cache pushes
- declaration.component.ts: pushes the data dictionary to the AI Redis cache after each load/regenerate so the assistant always has the current Feature_Description set.

Tests
- 37 new unit tests across TestSkillRegistry, TestInvokeSkillTool, TestSkillAutoRouting, TestSkillFileAccess, TestGetSkillFileTool.
- Total: 392 passing, 0 regressions.

Trace shape per chat turn:
  declarai-chat (workflow)
    skill-invoke (tool, NEW)             skill body load
    skill-file-read (tool, NEW)          per supplementary file read
    llm-advisor (agent)
    rag-tool-dispatch (tool)             pipeline artifact lookups