### PR TITLE
fix(ai-assistant): session_id on redis-* spans + disable tracing under tests

### DIFF
--- a/ToDoS.txt
+++ b/ToDoS.txt
@@ -7,6 +7,7 @@ z: bug-fix or hot-fix
 
 
 !CFH!
+- let assistant modify any configuration parameter in the pipeline that user can do via frontend (e.g. LoM change and ordinal raking)
 - start hyperparameter
 - add 'view details' button right under the progress-bar of SFS-running, when clicek user should see the selected feature, its description, cv based performance metric of model including the new feature, percentage change of performance metrıc as ın table format:
 - stopping criteria selections via %-change of metrics and min-max feature count.
@@ -24,4 +25,5 @@ After the implementation is complete and functional, here are potential future i
 
 good/bag flag of credit applications within the 12 months period of its usage
 according to the project goal and the feature descriptions we have, which new features can be derived from others in the aim of increasing the predictive performance of boosting algorithms. create these suggested features in our dataset.
+according to the feature-description, which of them can be ordinal categorical rather than being nominal as labeled as default?
 please explain what is happening in SHAP Beeswarm plot with feature-wise examples.

--- a/backend/ai_assistant/cache.py
+++ b/backend/ai_assistant/cache.py
@@ -17,6 +17,8 @@ import logging
 import os
 from typing import Any, Optional
 
+from .prometa_config import tool as prometa_tool, set_span_attr
+
 logger = logging.getLogger(__name__)
 
 _redis_client = None
@@ -55,73 +57,164 @@ def _key(file_id: int, artifact: str) -> str:
 # Public API
 # ---------------------------------------------------------------------------
 
+@prometa_tool(name="redis-set")
 def cache_put(file_id: int, artifact: str, data: Any, ttl: int = DEFAULT_TTL) -> bool:
-    """Store a pipeline artifact in the cache. Returns True on success."""
+    """Store a pipeline artifact in the cache. Returns True on success.
+
+    Emits a ``redis-set`` span with attributes:
+      - declarai.cache.file_id   pipeline file id
+      - declarai.cache.artifact  artifact key (e.g. 'data_dictionary')
+      - declarai.cache.bytes     serialized payload size
+      - declarai.cache.ttl       ttl seconds
+      - declarai.cache.ok        whether the write succeeded
+    """
+    set_span_attr('declarai.cache.file_id', file_id)
+    set_span_attr('declarai.cache.artifact', artifact)
+    set_span_attr('declarai.cache.ttl', ttl)
     r = _get_redis()
     if not r:
+        set_span_attr('declarai.cache.ok', False)
+        set_span_attr('declarai.cache.reason', 'redis-unavailable')
         return False
     try:
-        r.setex(_key(file_id, artifact), ttl, json.dumps(data, default=str))
+        payload = json.dumps(data, default=str)
+        set_span_attr('declarai.cache.bytes', len(payload))
+        r.setex(_key(file_id, artifact), ttl, payload)
+        set_span_attr('declarai.cache.ok', True)
         return True
     except Exception as exc:
+        set_span_attr('declarai.cache.ok', False)
+        set_span_attr('declarai.cache.reason', str(exc)[:200])
         logger.warning("cache_put failed (%s/%s): %s", file_id, artifact, exc)
         return False
 
 
+@prometa_tool(name="redis-get")
 def cache_get(file_id: int, artifact: str) -> Optional[Any]:
-    """Retrieve a pipeline artifact from the cache. Returns None if missing."""
+    """Retrieve a pipeline artifact from the cache. Returns None if missing.
+
+    Emits a ``redis-get`` span with attributes:
+      - declarai.cache.file_id   pipeline file id
+      - declarai.cache.artifact  artifact key (e.g. 'pipeline_config')
+      - declarai.cache.hit       True when a value was returned
+      - declarai.cache.bytes     raw payload size on hit
+      - declarai.cache.reason    error / miss reason (when applicable)
+    """
+    set_span_attr('declarai.cache.file_id', file_id)
+    set_span_attr('declarai.cache.artifact', artifact)
     r = _get_redis()
     if not r:
+        set_span_attr('declarai.cache.hit', False)
+        set_span_attr('declarai.cache.reason', 'redis-unavailable')
         return None
     try:
         raw = r.get(_key(file_id, artifact))
         if raw is None:
+            set_span_attr('declarai.cache.hit', False)
             return None
+        set_span_attr('declarai.cache.hit', True)
+        set_span_attr('declarai.cache.bytes', len(raw))
         return json.loads(raw)
     except Exception as exc:
+        set_span_attr('declarai.cache.hit', False)
+        set_span_attr('declarai.cache.reason', str(exc)[:200])
         logger.warning("cache_get failed (%s/%s): %s", file_id, artifact, exc)
         return None
 
 
+@prometa_tool(name="redis-set-bulk")
 def cache_put_bulk(file_id: int, artifacts: dict[str, Any], ttl: int = DEFAULT_TTL) -> bool:
-    """Store multiple artifacts at once using a Redis pipeline."""
+    """Store multiple artifacts at once using a Redis pipeline.
+
+    Emits a ``redis-set-bulk`` span with attributes:
+      - declarai.cache.file_id      pipeline file id
+      - declarai.cache.keys         artifact keys written (comma separated)
+      - declarai.cache.key_count    number of keys written
+      - declarai.cache.bytes        total serialized payload size
+      - declarai.cache.ttl          ttl seconds
+      - declarai.cache.ok           whether the pipelined write succeeded
+    """
+    set_span_attr('declarai.cache.file_id', file_id)
+    set_span_attr('declarai.cache.keys', ','.join(artifacts.keys()))
+    set_span_attr('declarai.cache.key_count', len(artifacts))
+    set_span_attr('declarai.cache.ttl', ttl)
     r = _get_redis()
     if not r:
+        set_span_attr('declarai.cache.ok', False)
+        set_span_attr('declarai.cache.reason', 'redis-unavailable')
         return False
     try:
         pipe = r.pipeline()
+        total_bytes = 0
         for artifact, data in artifacts.items():
-            pipe.setex(_key(file_id, artifact), ttl, json.dumps(data, default=str))
+            payload = json.dumps(data, default=str)
+            total_bytes += len(payload)
+            pipe.setex(_key(file_id, artifact), ttl, payload)
         pipe.execute()
+        set_span_attr('declarai.cache.bytes', total_bytes)
+        set_span_attr('declarai.cache.ok', True)
         return True
     except Exception as exc:
+        set_span_attr('declarai.cache.ok', False)
+        set_span_attr('declarai.cache.reason', str(exc)[:200])
         logger.warning("cache_put_bulk failed (file_id=%s): %s", file_id, exc)
         return False
 
 
+@prometa_tool(name="redis-delete")
 def cache_delete(file_id: int, artifact: str) -> bool:
-    """Remove a specific artifact from the cache."""
+    """Remove a specific artifact from the cache.
+
+    Emits a ``redis-delete`` span with attributes:
+      - declarai.cache.file_id   pipeline file id
+      - declarai.cache.artifact  artifact key being evicted
+      - declarai.cache.ok        whether the delete succeeded
+    """
+    set_span_attr('declarai.cache.file_id', file_id)
+    set_span_attr('declarai.cache.artifact', artifact)
     r = _get_redis()
     if not r:
+        set_span_attr('declarai.cache.ok', False)
+        set_span_attr('declarai.cache.reason', 'redis-unavailable')
         return False
     try:
         r.delete(_key(file_id, artifact))
+        set_span_attr('declarai.cache.ok', True)
         return True
     except Exception as exc:
+        set_span_attr('declarai.cache.ok', False)
+        set_span_attr('declarai.cache.reason', str(exc)[:200])
         logger.warning("cache_delete failed (%s/%s): %s", file_id, artifact, exc)
         return False
 
 
+@prometa_tool(name="redis-list")
 def cache_list_artifacts(file_id: int) -> list[str]:
-    """List all cached artifact types for a given file_id."""
+    """List all cached artifact types for a given file_id.
+
+    Emits a ``redis-list`` span with attributes:
+      - declarai.cache.file_id     pipeline file id
+      - declarai.cache.prefix      key prefix scanned
+      - declarai.cache.key_count   number of matching keys
+      - declarai.cache.keys        matching artifact names (comma separated)
+    """
+    set_span_attr('declarai.cache.file_id', file_id)
+    prefix = f"ai:pipeline:{file_id}:"
+    set_span_attr('declarai.cache.prefix', prefix)
     r = _get_redis()
     if not r:
+        set_span_attr('declarai.cache.key_count', 0)
+        set_span_attr('declarai.cache.reason', 'redis-unavailable')
         return []
     try:
-        prefix = f"ai:pipeline:{file_id}:"
         keys = r.keys(f"{prefix}*")
-        return [k.replace(prefix, '') for k in keys]
+        artifacts = [k.replace(prefix, '') for k in keys]
+        set_span_attr('declarai.cache.key_count', len(artifacts))
+        set_span_attr('declarai.cache.keys', ','.join(artifacts))
+        return artifacts
     except Exception as exc:
+        set_span_attr('declarai.cache.key_count', 0)
+        set_span_attr('declarai.cache.reason', str(exc)[:200])
         logger.warning("cache_list_artifacts failed (file_id=%s): %s", file_id, exc)
         return []
 

--- a/backend/ai_assistant/cache.py
+++ b/backend/ai_assistant/cache.py
@@ -17,7 +17,24 @@ import logging
 import os
 from typing import Any, Optional
 
-from .prometa_config import tool as prometa_tool, set_span_attr
+from .prometa_config import tool as prometa_tool, set_span_attr, set_session_id
+
+
+def _stamp_session(file_id: int) -> None:
+    """Tag the current cache span with the file's session id.
+
+    Cache helpers are called from two contexts: inside the chat workflow
+    (child span — session already set, this is an idempotent re-set) and
+    from the standalone /api/ai/cache_push/ endpoint (root span — without
+    this call the span lands in Trace Explorer with no session and
+    pollutes the view next to real user traces).
+    """
+    if file_id is None:
+        return
+    try:
+        set_session_id(f'declarai-file-{int(file_id)}')
+    except (TypeError, ValueError):
+        pass
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +85,7 @@ def cache_put(file_id: int, artifact: str, data: Any, ttl: int = DEFAULT_TTL) ->
       - declarai.cache.ttl       ttl seconds
       - declarai.cache.ok        whether the write succeeded
     """
+    _stamp_session(file_id)
     set_span_attr('declarai.cache.file_id', file_id)
     set_span_attr('declarai.cache.artifact', artifact)
     set_span_attr('declarai.cache.ttl', ttl)
@@ -100,6 +118,7 @@ def cache_get(file_id: int, artifact: str) -> Optional[Any]:
       - declarai.cache.bytes     raw payload size on hit
       - declarai.cache.reason    error / miss reason (when applicable)
     """
+    _stamp_session(file_id)
     set_span_attr('declarai.cache.file_id', file_id)
     set_span_attr('declarai.cache.artifact', artifact)
     r = _get_redis()
@@ -134,6 +153,7 @@ def cache_put_bulk(file_id: int, artifacts: dict[str, Any], ttl: int = DEFAULT_T
       - declarai.cache.ttl          ttl seconds
       - declarai.cache.ok           whether the pipelined write succeeded
     """
+    _stamp_session(file_id)
     set_span_attr('declarai.cache.file_id', file_id)
     set_span_attr('declarai.cache.keys', ','.join(artifacts.keys()))
     set_span_attr('declarai.cache.key_count', len(artifacts))
@@ -170,6 +190,7 @@ def cache_delete(file_id: int, artifact: str) -> bool:
       - declarai.cache.artifact  artifact key being evicted
       - declarai.cache.ok        whether the delete succeeded
     """
+    _stamp_session(file_id)
     set_span_attr('declarai.cache.file_id', file_id)
     set_span_attr('declarai.cache.artifact', artifact)
     r = _get_redis()
@@ -198,6 +219,7 @@ def cache_list_artifacts(file_id: int) -> list[str]:
       - declarai.cache.key_count   number of matching keys
       - declarai.cache.keys        matching artifact names (comma separated)
     """
+    _stamp_session(file_id)
     set_span_attr('declarai.cache.file_id', file_id)
     prefix = f"ai:pipeline:{file_id}:"
     set_span_attr('declarai.cache.prefix', prefix)

--- a/backend/ai_assistant/prometa_config.py
+++ b/backend/ai_assistant/prometa_config.py
@@ -33,6 +33,14 @@ def get_prometa():
         return _prometa
     _initialized = True
 
+    # Disable tracing under pytest so test runs (especially the file_id=99999
+    # "missing resource" cases) don't pollute the Session Explorer with
+    # sessions like `declarai-file-99999`. `PROMETA_DISABLE=1` is the explicit
+    # kill-switch; `PYTEST_CURRENT_TEST` is set by pytest while a test runs.
+    if os.environ.get('PROMETA_DISABLE') == '1' or os.environ.get('PYTEST_CURRENT_TEST'):
+        logger.info("Prometa tracing disabled (test/PROMETA_DISABLE).")
+        return None
+
     stage = os.environ.get('PROMETA_STAGE', 'staging').lower()
     stage_upper = stage.upper()
 

--- a/backend/ai_assistant/tool_executor.py
+++ b/backend/ai_assistant/tool_executor.py
@@ -45,12 +45,142 @@ def _not_available(name: str) -> str:
     return f"No {name} data is available in the cache. The user may not have completed this pipeline step yet."
 
 
+def _stamp_read_attrs(artifact: str, data: Any) -> None:
+    """Stamp common attributes on a ``cache-read:<artifact>`` span."""
+    set_span_attr('declarai.cache.artifact', artifact)
+    if data is None:
+        set_span_attr('declarai.cache.hit', False)
+        return
+    set_span_attr('declarai.cache.hit', True)
+    if isinstance(data, list):
+        set_span_attr('declarai.cache.shape', 'list')
+        set_span_attr('declarai.cache.length', len(data))
+    elif isinstance(data, dict):
+        set_span_attr('declarai.cache.shape', 'dict')
+        set_span_attr('declarai.cache.keys', ','.join(list(data.keys())[:20]))
+
+
+# ---------------------------------------------------------------------------
+# Raw readers (server-side + LLM-initiated callers share these)
+# ---------------------------------------------------------------------------
+# Each raw reader wraps a ``cache_get`` with its own ``cache-read:<artifact>``
+# span.  This gives the trace waterfall a visible, named row per artifact
+# regardless of whether the read was triggered by the LLM (via
+# ``rag-tool-dispatch`` -> handler -> reader) or by the server prefetch path
+# (``_build_slim_context`` -> reader).  The underlying ``cache_get`` call
+# produces a nested ``redis-get`` child span.
+
+@prometa_tool(name="cache-read:split_validation")
+def read_split_validation(file_id: int) -> Optional[dict]:
+    data = cache_get(file_id, ARTIFACT_SPLIT_VALIDATION)
+    _stamp_read_attrs(ARTIFACT_SPLIT_VALIDATION, data)
+    return data
+
+
+@prometa_tool(name="cache-read:dq_summary")
+def read_dq_summary(file_id: int) -> Optional[Any]:
+    data = cache_get(file_id, ARTIFACT_DQ_SUMMARY)
+    _stamp_read_attrs(ARTIFACT_DQ_SUMMARY, data)
+    return data
+
+
+@prometa_tool(name="cache-read:feature_stats")
+def read_feature_stats(file_id: int) -> Optional[dict]:
+    data = cache_get(file_id, ARTIFACT_FEATURE_STATS)
+    _stamp_read_attrs(ARTIFACT_FEATURE_STATS, data)
+    return data
+
+
+@prometa_tool(name="cache-read:vif_decomposition")
+def read_vif_decomposition(file_id: int) -> Optional[dict]:
+    data = cache_get(file_id, ARTIFACT_VIF_DECOMPOSITION)
+    _stamp_read_attrs(ARTIFACT_VIF_DECOMPOSITION, data)
+    return data
+
+
+@prometa_tool(name="cache-read:encoding_plan")
+def read_encoding_plan(file_id: int) -> Optional[Any]:
+    data = cache_get(file_id, ARTIFACT_ENCODING_PLAN)
+    _stamp_read_attrs(ARTIFACT_ENCODING_PLAN, data)
+    return data
+
+
+@prometa_tool(name="cache-read:selected_features")
+def read_selected_features(file_id: int) -> Optional[Any]:
+    data = cache_get(file_id, ARTIFACT_SELECTED_FEATURES)
+    _stamp_read_attrs(ARTIFACT_SELECTED_FEATURES, data)
+    return data
+
+
+@prometa_tool(name="cache-read:shap_details")
+def read_shap_details(file_id: int) -> Optional[Any]:
+    data = cache_get(file_id, ARTIFACT_SHAP_DETAILS)
+    _stamp_read_attrs(ARTIFACT_SHAP_DETAILS, data)
+    return data
+
+
+@prometa_tool(name="cache-read:sfs_results")
+def read_sfs_results(file_id: int) -> Optional[dict]:
+    data = cache_get(file_id, ARTIFACT_SFS_RESULTS)
+    _stamp_read_attrs(ARTIFACT_SFS_RESULTS, data)
+    return data
+
+
+@prometa_tool(name="cache-read:cv_results")
+def read_cv_results(file_id: int) -> Optional[dict]:
+    data = cache_get(file_id, ARTIFACT_CV_RESULTS)
+    _stamp_read_attrs(ARTIFACT_CV_RESULTS, data)
+    return data
+
+
+@prometa_tool(name="cache-read:pipeline_notes")
+def read_pipeline_notes(file_id: int) -> Optional[dict]:
+    data = cache_get(file_id, ARTIFACT_PIPELINE_NOTES)
+    _stamp_read_attrs(ARTIFACT_PIPELINE_NOTES, data)
+    return data
+
+
+@prometa_tool(name="cache-read:pipeline_config")
+def read_pipeline_config(file_id: int) -> Optional[dict]:
+    data = cache_get(file_id, ARTIFACT_PIPELINE_CONFIG)
+    _stamp_read_attrs(ARTIFACT_PIPELINE_CONFIG, data)
+    return data
+
+
+@prometa_tool(name="cache-read:data_dictionary")
+def read_data_dictionary(file_id: int) -> Optional[list]:
+    """Read the data dictionary and backfill missing Feature_Description
+    entries from the ``DataDictionary`` DB (the single source of truth).
+
+    The DB backfill is performed here (inside the ``cache-read:data_dictionary``
+    span) rather than in every caller so that the returned value is always
+    the enriched list regardless of whether the LLM dispatched the read or
+    the slim-context prefetch did.  The span covers both the cache hit and
+    the optional DB enrichment for easy latency attribution.
+    """
+    raw = cache_get(file_id, ARTIFACT_DATA_DICTIONARY)
+    if raw is None:
+        _stamp_read_attrs(ARTIFACT_DATA_DICTIONARY, None)
+        return None
+    features = raw if isinstance(raw, list) else raw.get('features', [])
+    try:
+        from ai_assistant.views import _enrich_dd_with_descriptions
+        enriched = _enrich_dd_with_descriptions(file_id, features)
+        set_span_attr('declarai.cache.enriched', True)
+    except Exception as exc:
+        set_span_attr('declarai.cache.enriched', False)
+        set_span_attr('declarai.cache.enrich_error', str(exc)[:200])
+        enriched = features
+    _stamp_read_attrs(ARTIFACT_DATA_DICTIONARY, enriched)
+    return enriched
+
+
 # ---------------------------------------------------------------------------
 # Individual tool handlers
 # ---------------------------------------------------------------------------
 
 def _handle_get_split_validation(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_SPLIT_VALIDATION)
+    data = read_split_validation(file_id)
     if not data:
         return _not_available("split validation")
     splits = data.get('splits', [])
@@ -66,7 +196,7 @@ def _handle_get_split_validation(file_id: int, args: dict) -> str:
 
 
 def _handle_get_dq_summary(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_DQ_SUMMARY)
+    data = read_dq_summary(file_id)
     if not data:
         return _not_available("data quality summary")
     features = data if isinstance(data, list) else data.get('summary', [])
@@ -89,7 +219,7 @@ def _handle_get_dq_summary(file_id: int, args: dict) -> str:
 
 
 def _handle_get_feature_stats(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_FEATURE_STATS)
+    data = read_feature_stats(file_id)
     if not data:
         return _not_available("feature statistics")
     feature = args.get('feature', '')
@@ -112,7 +242,7 @@ def _handle_get_feature_stats(file_id: int, args: dict) -> str:
 
 
 def _handle_get_vif_decomposition(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_VIF_DECOMPOSITION)
+    data = read_vif_decomposition(file_id)
     if not data:
         return _not_available("VIF decomposition")
     feature = args.get('feature', '')
@@ -135,7 +265,7 @@ def _handle_get_vif_decomposition(file_id: int, args: dict) -> str:
 
 
 def _handle_get_encoding_plan(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_ENCODING_PLAN)
+    data = read_encoding_plan(file_id)
     if not data:
         return _not_available("encoding plan")
     features = data if isinstance(data, list) else data.get('plan', [])
@@ -150,7 +280,7 @@ def _handle_get_encoding_plan(file_id: int, args: dict) -> str:
 
 
 def _handle_get_selected_features(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_SELECTED_FEATURES)
+    data = read_selected_features(file_id)
     if not data:
         return _not_available("selected features")
     features = data if isinstance(data, list) else data.get('features', [])
@@ -170,7 +300,7 @@ def _handle_get_selected_features(file_id: int, args: dict) -> str:
 
 
 def _handle_get_shap_details(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_SHAP_DETAILS)
+    data = read_shap_details(file_id)
     if not data:
         return _not_available("SHAP details")
     features = data if isinstance(data, list) else data.get('features', [])
@@ -187,7 +317,7 @@ def _handle_get_shap_details(file_id: int, args: dict) -> str:
 
 
 def _handle_get_sfs_results(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_SFS_RESULTS)
+    data = read_sfs_results(file_id)
     if not data:
         return _not_available("SFS results")
     direction_filter = args.get('direction')
@@ -222,7 +352,7 @@ def _handle_get_sfs_results(file_id: int, args: dict) -> str:
 
 
 def _handle_get_cv_results(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_CV_RESULTS)
+    data = read_cv_results(file_id)
     if not data:
         return _not_available("cross-validation results")
     lines = [
@@ -239,7 +369,7 @@ def _handle_get_cv_results(file_id: int, args: dict) -> str:
 
 
 def _handle_get_pipeline_notes(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_PIPELINE_NOTES)
+    data = read_pipeline_notes(file_id)
     if not data:
         return "No pipeline notes have been saved."
     lines = ["Pipeline Notes:"]
@@ -250,7 +380,7 @@ def _handle_get_pipeline_notes(file_id: int, args: dict) -> str:
 
 
 def _handle_get_pipeline_config(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_PIPELINE_CONFIG)
+    data = read_pipeline_config(file_id)
     if not data:
         return _not_available("pipeline configuration")
     lines = [
@@ -268,18 +398,11 @@ def _handle_get_pipeline_config(file_id: int, args: dict) -> str:
 
 
 def _handle_get_data_dictionary(file_id: int, args: dict) -> str:
-    data = cache_get(file_id, ARTIFACT_DATA_DICTIONARY)
-    if not data:
+    # ``read_data_dictionary`` already does cache read + DB backfill inside
+    # its own ``cache-read:data_dictionary`` span.
+    features = read_data_dictionary(file_id)
+    if features is None:
         return _not_available("data dictionary")
-    features = data if isinstance(data, list) else data.get('features', [])
-    # Backfill missing Feature_Description from the DataDictionary DB
-    # (single source of truth) so stale cache entries don't hide
-    # business descriptions from the assistant.
-    try:
-        from ai_assistant.views import _enrich_dd_with_descriptions
-        features = _enrich_dd_with_descriptions(file_id, features)
-    except Exception:
-        pass  # Non-fatal: continue with whatever cache had
     feature_filter = args.get('feature')
     if feature_filter:
         features = [f for f in features if f.get('Feature_Name', f.get('feature', '')) == feature_filter]

--- a/backend/ai_assistant/views.py
+++ b/backend/ai_assistant/views.py
@@ -18,7 +18,7 @@ from .prometa_config import workflow, agent, tool, flush as prometa_flush, set_s
 from .tool_definitions import PIPELINE_TOOLS
 from .tool_executor import execute_tool_call, _load_skill_traced
 from .skill_registry import get_skill
-from .cache import cache_get, cache_list_artifacts, ARTIFACT_PIPELINE_CONFIG, ARTIFACT_SELECTED_FEATURES, ARTIFACT_DATA_DICTIONARY
+from .cache import cache_list_artifacts
 from .model_registry import (
     get_model_config, list_models, DEFAULT_MODEL,
     call_openai, call_engine,
@@ -345,11 +345,24 @@ def _build_slim_context(file_id: int, section: str) -> str:
 
     This replaces the old approach of dumping the entire pipeline context.
     The LLM can request detailed data via tool calls when needed.
+
+    Every underlying Redis read is performed through an instrumented raw
+    reader (``read_pipeline_config``/``read_data_dictionary``/...) so each
+    fetch appears as its own ``cache-read:<artifact>`` span in the trace
+    waterfall — symmetric with the spans emitted when the LLM itself
+    invokes a tool via ``rag-tool-dispatch``.
     """
+    # Local import to avoid circular dependency at module load time.
+    from .tool_executor import (
+        read_pipeline_config,
+        read_data_dictionary,
+        read_selected_features,
+    )
+
     parts = []
 
     # Pipeline config (always include)
-    config = cache_get(file_id, ARTIFACT_PIPELINE_CONFIG)
+    config = read_pipeline_config(file_id)
     if config:
         parts.append(f"Pipeline: {config.get('pipeline_type', '?')}")
         td = config.get('target_definition', '')
@@ -362,10 +375,9 @@ def _build_slim_context(file_id: int, section: str) -> str:
     # Data dictionary — embed feature descriptions inline so every model
     # (native tool-callers AND text-mode models that may skip tool calls)
     # sees the business context without needing a follow-up call.
-    dd = cache_get(file_id, ARTIFACT_DATA_DICTIONARY)
-    if dd:
-        dd_list = dd if isinstance(dd, list) else dd.get('features', [])
-        dd_list = _enrich_dd_with_descriptions(file_id, dd_list)
+    # The raw reader already performs the DB backfill for missing descriptions.
+    dd_list = read_data_dictionary(file_id)
+    if dd_list:
         described = [(f.get('Feature_Name') or f.get('feature') or '?',
                       (f.get('Feature_Description') or f.get('description') or '').strip())
                      for f in dd_list]
@@ -384,7 +396,7 @@ def _build_slim_context(file_id: int, section: str) -> str:
                          "would unlock domain-aware feature engineering.")
 
     # Feature list (names + VIF flags only)
-    sel_feats = cache_get(file_id, ARTIFACT_SELECTED_FEATURES)
+    sel_feats = read_selected_features(file_id)
     if sel_feats:
         feat_list = sel_feats if isinstance(sel_feats, list) else sel_feats.get('features', [])
         names = [f.get('feature', '?') for f in feat_list[:40]]
@@ -393,7 +405,8 @@ def _build_slim_context(file_id: int, section: str) -> str:
         if high_vif:
             parts.append(f"High-VIF features (>5): {', '.join(high_vif)}")
 
-    # Available data (so the LLM knows which tools will return data)
+    # Available data (so the LLM knows which tools will return data).
+    # ``cache_list_artifacts`` is already instrumented with ``redis-list``.
     available = cache_list_artifacts(file_id)
     if available:
         parts.append(f"Cached artifacts available: {', '.join(available)}")

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -4,6 +4,14 @@ Provides shared fixtures used across all test categories.
 """
 import io
 import os
+
+# Disable Prometa OTLP export for the entire test session so test runs don't
+# emit sessions like `declarai-file-99999` into the platform's Session Explorer.
+# Set before any test module imports the AI assistant (decorators init lazily,
+# but the env check runs at first decorated-call, which can be during a test
+# fixture rather than the test body — so PYTEST_CURRENT_TEST alone isn't enough).
+os.environ.setdefault('PROMETA_DISABLE', '1')
+
 import pytest
 import pandas as pd
 import numpy as np

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -2266,3 +2266,374 @@ class TestGetSkillFileTool:
         assert captured.get('declarai.skill.file_found') is True
         assert isinstance(captured.get('declarai.skill.file_chars'), int)
         assert captured['declarai.skill.file_chars'] > 100
+
+
+# ---------------------------------------------------------------------------
+# Redis-level spans (Option D): cache_get/cache_put/cache_list_artifacts
+# now each emit their own trace span via @prometa_tool.
+# ---------------------------------------------------------------------------
+
+class _SpanCapture:
+    """Tiny helper that replays the sequence of set_span_attr(key, value)
+    calls across span boundaries by snapshotting on each new span start.
+
+    Tests that only need the aggregate final attribute map can use
+    ``captured`` directly; tests that care about per-span grouping can
+    walk ``by_span``.
+    """
+
+    def __init__(self):
+        self.captured: dict = {}
+        self.by_span: list[dict] = []
+        self._current: dict = {}
+
+    def set_attr(self, key, value):
+        self.captured[key] = value
+        self._current[key] = value
+
+    def snapshot(self):
+        if self._current:
+            self.by_span.append(self._current)
+            self._current = {}
+
+
+def _patch_span_attr(monkeypatch, *modules, capture: _SpanCapture):
+    """Replace ``set_span_attr`` in each target module with the capture hook."""
+    import importlib
+    for mod_name in modules:
+        mod = importlib.import_module(mod_name)
+        monkeypatch.setattr(mod, 'set_span_attr', capture.set_attr)
+
+
+@pytest.mark.unit
+class TestRedisSpanInstrumentation:
+    """cache_get/cache_put/cache_list_artifacts now emit their own Prometa
+    tool spans with named attributes (redis-get, redis-set, redis-list)."""
+
+    def test_cache_get_hit_stamps_attrs(self, monkeypatch):
+        from ai_assistant import cache as cache_mod
+        from ai_assistant.cache import cache_put, cache_get, _get_redis
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.cache', capture=cap)
+
+        # Seed and read back
+        cache_put(42424, 'test_span_artifact', {'k': 'v'})
+        cap.captured.clear()
+        result = cache_get(42424, 'test_span_artifact')
+
+        try:
+            assert result == {'k': 'v'}
+            assert cap.captured.get('declarai.cache.file_id') == 42424
+            assert cap.captured.get('declarai.cache.artifact') == 'test_span_artifact'
+            assert cap.captured.get('declarai.cache.hit') is True
+            assert isinstance(cap.captured.get('declarai.cache.bytes'), int)
+            assert cap.captured['declarai.cache.bytes'] > 0
+        finally:
+            _get_redis().delete('ai:pipeline:42424:test_span_artifact')
+
+    def test_cache_get_miss_stamps_hit_false(self, monkeypatch):
+        from ai_assistant.cache import cache_get, _get_redis
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.cache', capture=cap)
+
+        result = cache_get(42425, 'does_not_exist_xyz')
+        assert result is None
+        assert cap.captured.get('declarai.cache.artifact') == 'does_not_exist_xyz'
+        assert cap.captured.get('declarai.cache.hit') is False
+        # A miss must not stamp a byte count
+        assert 'declarai.cache.bytes' not in cap.captured
+
+    def test_cache_put_stamps_ok_and_ttl(self, monkeypatch):
+        from ai_assistant.cache import cache_put, _get_redis
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.cache', capture=cap)
+
+        try:
+            assert cache_put(42426, 'span_put_test', {'x': 1}, ttl=123) is True
+            assert cap.captured.get('declarai.cache.artifact') == 'span_put_test'
+            assert cap.captured.get('declarai.cache.ttl') == 123
+            assert cap.captured.get('declarai.cache.ok') is True
+            assert cap.captured.get('declarai.cache.bytes') > 0
+        finally:
+            _get_redis().delete('ai:pipeline:42426:span_put_test')
+
+    def test_cache_list_artifacts_stamps_prefix_and_count(self, monkeypatch):
+        from ai_assistant.cache import cache_put, cache_list_artifacts, _get_redis
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.cache', capture=cap)
+
+        try:
+            cache_put(42427, 'alpha', [1])
+            cache_put(42427, 'beta', [2])
+            cap.captured.clear()
+            keys = cache_list_artifacts(42427)
+            assert set(keys) >= {'alpha', 'beta'}
+            assert cap.captured.get('declarai.cache.prefix') == 'ai:pipeline:42427:'
+            assert cap.captured.get('declarai.cache.key_count') >= 2
+            assert 'alpha' in cap.captured.get('declarai.cache.keys', '')
+        finally:
+            r = _get_redis()
+            r.delete('ai:pipeline:42427:alpha')
+            r.delete('ai:pipeline:42427:beta')
+
+    def test_cache_put_bulk_stamps_key_count(self, monkeypatch):
+        from ai_assistant.cache import cache_put_bulk, _get_redis
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.cache', capture=cap)
+
+        try:
+            assert cache_put_bulk(42428, {'a': 1, 'b': 2, 'c': 3}) is True
+            assert cap.captured.get('declarai.cache.key_count') == 3
+            assert set(cap.captured.get('declarai.cache.keys', '').split(',')) == {'a', 'b', 'c'}
+            assert cap.captured.get('declarai.cache.ok') is True
+        finally:
+            r = _get_redis()
+            for k in ('a', 'b', 'c'):
+                r.delete(f'ai:pipeline:42428:{k}')
+
+    def test_cache_delete_stamps_ok(self, monkeypatch):
+        from ai_assistant.cache import cache_put, cache_delete, _get_redis
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.cache', capture=cap)
+
+        cache_put(42429, 'to_delete', {'foo': 1})
+        cap.captured.clear()
+        assert cache_delete(42429, 'to_delete') is True
+        assert cap.captured.get('declarai.cache.artifact') == 'to_delete'
+        assert cap.captured.get('declarai.cache.ok') is True
+
+
+# ---------------------------------------------------------------------------
+# Option B-rich: every cached artifact exposes a ``read_*`` raw reader
+# decorated with ``@prometa_tool(name="cache-read:<artifact>")``.  Handlers
+# and ``_build_slim_context`` both route through these readers so the
+# cache-read span is emitted regardless of who triggered the read.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestCacheReadSpans:
+    """Each cached artifact has a @prometa_tool-decorated raw reader."""
+
+    @pytest.mark.parametrize('reader_name,artifact', [
+        ('read_split_validation',   'split_validation'),
+        ('read_dq_summary',         'dq_summary'),
+        ('read_feature_stats',      'feature_stats'),
+        ('read_vif_decomposition',  'vif_decomposition'),
+        ('read_encoding_plan',      'encoding_plan'),
+        ('read_selected_features',  'selected_features'),
+        ('read_shap_details',       'shap_details'),
+        ('read_sfs_results',        'sfs_results'),
+        ('read_cv_results',         'cv_results'),
+        ('read_pipeline_notes',     'pipeline_notes'),
+        ('read_pipeline_config',    'pipeline_config'),
+        ('read_data_dictionary',    'data_dictionary'),
+    ])
+    def test_raw_reader_exists_and_is_exported(self, reader_name, artifact):
+        """Every artifact has a public raw reader used by the slim context
+        build + the tool handler so the span hierarchy is consistent."""
+        from ai_assistant import tool_executor
+        assert hasattr(tool_executor, reader_name), (
+            f"tool_executor must expose {reader_name} for artifact '{artifact}'")
+        reader = getattr(tool_executor, reader_name)
+        assert callable(reader)
+
+    def test_read_pipeline_config_stamps_cache_read_attrs(self, monkeypatch):
+        from ai_assistant.cache import cache_put, _get_redis
+        from ai_assistant.tool_executor import read_pipeline_config
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.tool_executor', capture=cap)
+
+        try:
+            cache_put(53000, 'pipeline_config', {'pipeline_type': 'classification'})
+            cap.captured.clear()
+            data = read_pipeline_config(53000)
+            assert data == {'pipeline_type': 'classification'}
+            assert cap.captured.get('declarai.cache.artifact') == 'pipeline_config'
+            assert cap.captured.get('declarai.cache.hit') is True
+            assert cap.captured.get('declarai.cache.shape') == 'dict'
+        finally:
+            _get_redis().delete('ai:pipeline:53000:pipeline_config')
+
+    def test_read_selected_features_stamps_list_shape(self, monkeypatch):
+        from ai_assistant.cache import cache_put, _get_redis
+        from ai_assistant.tool_executor import read_selected_features
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.tool_executor', capture=cap)
+
+        try:
+            cache_put(53001, 'selected_features',
+                      [{'feature': 'f1'}, {'feature': 'f2'}, {'feature': 'f3'}])
+            cap.captured.clear()
+            data = read_selected_features(53001)
+            assert len(data) == 3
+            assert cap.captured.get('declarai.cache.shape') == 'list'
+            assert cap.captured.get('declarai.cache.length') == 3
+        finally:
+            _get_redis().delete('ai:pipeline:53001:selected_features')
+
+    def test_read_miss_stamps_hit_false(self, monkeypatch):
+        from ai_assistant.cache import _get_redis
+        from ai_assistant.tool_executor import read_shap_details
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.tool_executor', capture=cap)
+
+        data = read_shap_details(53002)
+        assert data is None
+        assert cap.captured.get('declarai.cache.hit') is False
+
+    def test_read_data_dictionary_stamps_enriched_flag(self, monkeypatch):
+        from ai_assistant.cache import cache_put, _get_redis
+        from ai_assistant.tool_executor import read_data_dictionary
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.tool_executor', capture=cap)
+
+        try:
+            cache_put(53003, 'data_dictionary',
+                      [{'Feature_Name': 'Var_1', 'Feature_Description': None}])
+            cap.captured.clear()
+            data = read_data_dictionary(53003)
+            assert data is not None
+            # Whether or not the DB had a description, the enrichment path
+            # must have been attempted and stamped a boolean outcome.
+            assert 'declarai.cache.enriched' in cap.captured
+        finally:
+            _get_redis().delete('ai:pipeline:53003:data_dictionary')
+
+    def test_handlers_route_through_raw_readers(self, monkeypatch):
+        """When the LLM invokes a tool via ``execute_tool_call``, the handler
+        must delegate to the raw reader so the ``cache-read:<artifact>`` span
+        is always emitted.  We verify by observing that attributes stamped
+        only by the raw reader appear in the captured set."""
+        from ai_assistant.cache import cache_put, _get_redis
+        from ai_assistant.tool_executor import execute_tool_call
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.tool_executor', capture=cap)
+
+        try:
+            cache_put(53004, 'encoding_plan',
+                      [{'feature': 'f1', 'user_lom': 'Nominal', 'nunique': 5}])
+            cap.captured.clear()
+            out = execute_tool_call(53004, 'get_encoding_plan', {})
+            assert 'Encoding Plan' in out
+            # ``_stamp_read_attrs`` (called only from the raw reader) would
+            # have set shape=list.
+            assert cap.captured.get('declarai.cache.shape') == 'list'
+            assert cap.captured.get('declarai.cache.length') == 1
+        finally:
+            _get_redis().delete('ai:pipeline:53004:encoding_plan')
+
+
+@pytest.mark.unit
+class TestSlimContextEmitsCacheReadSpans:
+    """``_build_slim_context`` now calls raw readers for every fetch so
+    the trace waterfall shows a ``cache-read:<artifact>`` span per
+    included artifact, symmetric with LLM-driven tool dispatch."""
+
+    def test_slim_context_uses_readers_not_cache_get(self, monkeypatch):
+        """Strongest guarantee: ``cache_get`` is NOT called directly from
+        ``_build_slim_context`` — every read goes through an instrumented
+        raw reader (each of which internally calls ``cache_get``, but via
+        its own span layer)."""
+        from ai_assistant.cache import cache_put, _get_redis
+        from ai_assistant import tool_executor, views
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        reader_calls: list[str] = []
+
+        def track(artifact_label):
+            original = getattr(tool_executor, f'read_{artifact_label}')
+
+            def _wrapped(file_id):
+                reader_calls.append(artifact_label)
+                return original(file_id)
+            return _wrapped
+
+        monkeypatch.setattr(tool_executor, 'read_pipeline_config',
+                            track('pipeline_config'))
+        monkeypatch.setattr(tool_executor, 'read_data_dictionary',
+                            track('data_dictionary'))
+        monkeypatch.setattr(tool_executor, 'read_selected_features',
+                            track('selected_features'))
+
+        try:
+            cache_put(53100, 'pipeline_config', {'pipeline_type': 'classification'})
+            cache_put(53100, 'data_dictionary',
+                      [{'Feature_Name': 'Var_A', 'Feature_Description': 'alpha'}])
+            cache_put(53100, 'selected_features',
+                      [{'feature': 'Var_A', 'vif': 1.2}])
+
+            text = views._build_slim_context(53100, 'general')
+            assert 'Pipeline: classification' in text
+            assert 'Var_A' in text
+            assert set(reader_calls) == {
+                'pipeline_config', 'data_dictionary', 'selected_features'}
+        finally:
+            r = _get_redis()
+            for k in ('pipeline_config', 'data_dictionary', 'selected_features'):
+                r.delete(f'ai:pipeline:53100:{k}')
+
+    def test_slim_context_stamps_cache_read_attrs_per_artifact(self, monkeypatch):
+        """Exercising the real readers: the capture must contain at least
+        one ``declarai.cache.artifact=<each>`` stamp for every included
+        artifact."""
+        from ai_assistant.cache import cache_put, _get_redis
+        from ai_assistant import tool_executor, views
+        if _get_redis() is None:
+            pytest.skip("Redis not available")
+
+        # Capture only attributes emitted inside tool_executor (the raw
+        # reader layer) — ignore the deeper cache.py stamps.
+        seen_artifacts: list[str] = []
+        original = tool_executor.set_span_attr
+
+        def capture(key, value):
+            if key == 'declarai.cache.artifact':
+                seen_artifacts.append(value)
+            if callable(original):
+                original(key, value)
+        monkeypatch.setattr(tool_executor, 'set_span_attr', capture)
+
+        try:
+            cache_put(53101, 'pipeline_config', {'pipeline_type': 'classification'})
+            cache_put(53101, 'selected_features', [{'feature': 'f1'}])
+            views._build_slim_context(53101, 'general')
+            assert 'pipeline_config' in seen_artifacts
+            assert 'selected_features' in seen_artifacts
+        finally:
+            r = _get_redis()
+            for k in ('pipeline_config', 'selected_features'):
+                r.delete(f'ai:pipeline:53101:{k}')


### PR DESCRIPTION
## Summary

Two related cleanups so the Prometa Session Explorer / Trace Explorer stays focused on real user activity. Triggered by orphan traces appearing between real chat traces in Trace Explorer, and a permanent `declarai-file-99999` session full of 100%-error traces in Session Explorer.

- **Stamp `session_id` on every cache span.** `cache_put`, `cache_get`, `cache_put_bulk`, `cache_delete`, and `cache_list_artifacts` each call a small `_stamp_session(file_id)` helper at entry that emits `session_id = declarai-file-<file_id>`. Cache helpers are called from two contexts:
  - **Inside the chat workflow** (`_chat_workflow` / `dispatch_action` set the session) — child span, this is now an idempotent re-set.
  - **From `/api/ai/cache_push/` and the data-dictionary upload path** — these are standalone HTTP requests outside any workflow, so the resulting `redis-set` / `redis-set-bulk` spans were emitted as **root traces with no session id** and landed between real chat traces in Trace Explorer. They now correctly group under the user's `declarai-file-<id>` session.
- **Disable tracing under pytest.** `get_prometa()` short-circuits to `None` when `PROMETA_DISABLE=1` or `PYTEST_CURRENT_TEST` is set, and `backend/conftest.py` sets `PROMETA_DISABLE=1` at module import so the gate trips before any decorated function runs (the env check otherwise fires at first decorated-call, which can be in a fixture before `PYTEST_CURRENT_TEST` is set). Stops `file_id=99999` "missing resource" tests from emitting a permanent `declarai-file-99999` session of 100%-error traces.

## Why

The AI assistant's tool/cache spans are useful telemetry but were undermining the UX of the platform they report into — orphan traces with no session id sat between real chat traces in Trace Explorer, and the test suite's sentinel `file_id=99999` produced a permanent noise session. Fixing it at the lowest layer (inside the cache helpers, which already receive `file_id` as their first arg) attributes spans correctly regardless of caller, with no changes needed at any callsite.

## What reviewers should know

- `set_session_id` is already designed as a no-op when the SDK is unavailable, so `_stamp_session` is safe under any tracing state.
- The conftest sets the env var via `os.environ.setdefault`, so a developer who explicitly wants tracing during a test run can override with `PROMETA_DISABLE=0` (or unset before invocation).
- Historical cleanup (the `declarai-file-99999` session and existing orphan redis-* root traces in ClickHouse) is **out of scope** for this PR — it's a one-shot `ALTER TABLE prometa.traces DELETE` to be run against the deployed ClickHouse separately.
- Pre-commit gate green: 417 backend tests across unit / regression / functional / integration / UAT.

## Test plan

- [x] Pre-commit gate passed (417 backend tests, 5 categories).
- [ ] Locally trigger the `/api/ai/cache_push/` endpoint with `file_id=479`, confirm the resulting `redis-set-bulk` trace in Trace Explorer shows `session_id = declarai-file-479` (not `—`).
- [ ] Run `pytest backend/tests/test_functional.py -k 99999` and confirm no new `declarai-file-99999` traces land in the Session Explorer.
- [ ] Confirm the existing chat flow on a real file still produces a session-grouped trace tree (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)