### PR TITLE
chore(deps): bump prometa-sdk floor from 0.3.3 to 0.5.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,7 @@ statsmodels>=0.14
 
 # AI Assistant
 openai>=1.0
-prometa-sdk>=0.3.3
+prometa-sdk>=0.5.0
 redis>=5.0
 
 # Testing dependencies


### PR DESCRIPTION
## Summary

Bumps the \`prometa-sdk\` floor in \`backend/requirements.txt\` from \`>=0.3.3\` to \`>=0.5.0\`. PyPI now serves \`prometa-sdk\` 0.5.0 (released 2026-05-17) and two releases have landed since the previous floor:

* **0.4.0** — AML v0.4 instrumentation contract: 16 new helpers across the 41-feature catalog (guardrails, PII filters, memory ops, retries, prompt rendering, auth/consent, retrieval, reasoning, reviewer-invoke, event triggers, model routing, sentiment).
* **0.5.0** — correlation-chain identity-horizontal helpers: \`set_customer_id\`, \`set_user_id\`, \`set_conversation_id\`, \`set_request_model\`, \`set_tool_name\` + a \`customer_id\` constructor kwarg. These match the platform's correlation-id migration that landed in agent-hook-v2 (#186–#193) and let the platform's resolver materialise the full canonical chain (\`org:sol:agent:tool:cus:user::session:trace:span\`) on every span this app emits.

## Code changes

None. Existing prometa decorator + span-context usage in \`backend/ai_assistant/prometa_config.py\` is unchanged — both SDK releases are additive. The floor bump simply makes the new helpers discoverable to anyone wiring fresh instrumentation here.

A follow-up PR can wire \`set_customer_id\` / \`set_user_id\` / etc. into \`prometa_config\` if/when this app starts attaching customer identity to its agent traces.

## Test plan

- Pre-push hook ran the full quality gate locally:
  - **Backend**: 505 tests passed across 5 categories
  - **Frontend**: build verified + 166 Karma specs passed
- \`pip install -r backend/requirements.txt\` resolves \`prometa-sdk\` 0.5.0 cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)