### PR TITLE
feat(v2.41.0): per-section 'Get AI Support' buttons for Data Purifier + SFS tables

### DIFF
--- a/frontend/src/app/model-development/model-development.component.html
+++ b/frontend/src/app/model-development/model-development.component.html
@@ -448,6 +448,12 @@
           <div *ngIf="!s.merge_mapping || !objectKeys(s.merge_mapping).length" style="font-size: 12px; color: #777;">No columns dropped in this step</div>
         </ng-template>
       </div>
+      <!-- AI Support trigger for Data Purifier Summary (v2.41.0) -->
+      <div style="margin-top: 10px; text-align: right;">
+        <button class="ai-support-btn" (click)="requestPurifierAiSupport()">
+          <span class="ai-support-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 2L12.5 9.5L20 12L12.5 14.5L10 22L7.5 14.5L0 12L7.5 9.5L10 2Z" fill="currentColor"/><path d="M20 4L21 7L24 8L21 9L20 12L19 9L16 8L19 7L20 4Z" fill="currentColor" opacity="0.7"/><path d="M20 16L20.75 18.25L23 19L20.75 19.75L20 22L19.25 19.75L17 19L19.25 18.25L20 16Z" fill="currentColor" opacity="0.5"/></svg></span> Get AI Support
+        </button>
+      </div>
     </div>
     <!-- Note: After Purifier Summary -->
     <div *ngIf="droppedColumnsByStep && droppedColumnsByStep.length" class="pipeline-note-slot">

--- a/frontend/src/app/model-development/model-development.component.spec.ts
+++ b/frontend/src/app/model-development/model-development.component.spec.ts
@@ -404,4 +404,83 @@ describe('ModelDevelopmentComponent', () => {
       }, 5);
     });
   });
+
+  // ── 'Get AI Support' button for Data Purifier Summary (v2.41.0) ──────
+  // The Data Purifier Summary card now has its own dedicated AI Support
+  // button.  Unlike requestDatqAiSupport (which bundles DQ summary +
+  // model_usage + split_validation), this one scopes the context to
+  // purifier outputs only — so the LLM does not get drowned in noise
+  // when the user is specifically asking about purifier behavior.
+  describe("Data Purifier Summary 'Get AI Support' (v2.41.0)", () => {
+    beforeEach(() => {
+      // Spy on the shared requestAiSupport helper so we don't go through
+      // the data-dict refetch / aiAssistant.requestSupport stack.
+      spyOn(component, 'requestAiSupport').and.callFake(() => { /* no-op */ });
+      // ngOnInit subscribes to currentFileId$/isStarted$/etc and each
+      // calls computePreprocessingAvailable() which can reset our
+      // hand-seeded flag.  Stub it so our flag survives detectChanges().
+      spyOn(component as any, 'computePreprocessingAvailable').and.callFake(() => { /* no-op */ });
+      // Seed the 5 fields the new method pulls into the context payload.
+      component.rowCountBefore = 1000;
+      component.rowCountAfter = 870;
+      component.rowsRemovedTotal = 130;
+      component.droppedColumnsByStep = [
+        { step: 'sparsity', columns_dropped: ['var_x', 'var_y'] },
+        { step: 'missing',  columns_dropped: ['var_z'] },
+      ] as any;
+      spyOn(component, 'droppedTotalCount').and.returnValue(3);
+    });
+
+    it('requestPurifierAiSupport() builds context with all 5 purifier fields and the correct section name', () => {
+      component.requestPurifierAiSupport();
+
+      expect(component.requestAiSupport).toHaveBeenCalledTimes(1);
+      const args = (component.requestAiSupport as jasmine.Spy).calls.mostRecent().args;
+      const ctx = args[0];
+      const section = args[1];
+      const prompt = args[2];
+      expect(section).toBe('data_purifier');
+      expect(typeof prompt).toBe('string');
+      expect(prompt.length).withContext('prompt should be a meaningful directive').toBeGreaterThan(50);
+      // Context shape: exactly one top-level key, no leakage of
+      // DQ summary / model_usage / split_validation.
+      expect(Object.keys(ctx)).toEqual(['purifier_summary']);
+      expect(ctx.purifier_summary.rows_before).toBe(1000);
+      expect(ctx.purifier_summary.rows_after).toBe(870);
+      expect(ctx.purifier_summary.rows_removed).toBe(130);
+      expect(ctx.purifier_summary.total_columns_dropped).toBe(3);
+      expect(ctx.purifier_summary.dropped_by_step.length).toBe(2);
+    });
+
+    it('button renders inside .purifier-summary when droppedColumnsByStep is populated and routes click to requestPurifierAiSupport()', () => {
+      // The card is gated on `droppedColumnsByStep && length` (already
+      // seeded with 2 entries in beforeEach) AND sits inside an outer
+      // <div *ngIf="preprocessingAvailable"> wrapper.  We flip that flag
+      // AFTER an initial detectChanges() so ngOnInit subscriptions don't
+      // get to reset it between our set and the second detectChanges().
+      fixture.detectChanges();
+      (component as any).preprocessingAvailable = true;
+      fixture.detectChanges();
+
+      const btn = fixture.nativeElement.querySelector('.purifier-summary .ai-support-btn') as HTMLButtonElement;
+      expect(btn).withContext('Data Purifier AI Support button should render').toBeTruthy();
+      expect((btn.textContent || '').trim()).toContain('Get AI Support');
+
+      const spy = spyOn(component, 'requestPurifierAiSupport').and.callFake(() => { /* no-op */ });
+      btn.click();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('button is HIDDEN when droppedColumnsByStep is empty', () => {
+      // Even with preprocessingAvailable=true, no dropped steps means
+      // the .purifier-summary card itself is not rendered.
+      component.droppedColumnsByStep = [];
+      fixture.detectChanges();
+      (component as any).preprocessingAvailable = true;
+      fixture.detectChanges();
+
+      const btn = fixture.nativeElement.querySelector('.purifier-summary .ai-support-btn');
+      expect(btn).withContext('Purifier AI Support button must NOT render with no dropped steps').toBeNull();
+    });
+  });
 });

--- a/frontend/src/app/model-development/model-development.component.ts
+++ b/frontend/src/app/model-development/model-development.component.ts
@@ -1006,6 +1006,26 @@ export class ModelDevelopmentComponent implements OnInit, AfterViewChecked {
     this.requestAiSupport(context, 'data_quality', prompt);
   }
 
+  /** v2.41.0 — Dedicated AI Support trigger for the Data Purifier Summary card.
+   *
+   * Mirrors requestDatqAiSupport() but scopes the context to purifier
+   * outputs only: rows-removed totals + per-step dropped columns.
+   * Keeping scope narrow avoids drowning the LLM in DQ-summary noise
+   * when the user is specifically asking about purifier behavior. */
+  requestPurifierAiSupport(): void {
+    const context = {
+      purifier_summary: {
+        rows_before: this.rowCountBefore,
+        rows_after: this.rowCountAfter,
+        rows_removed: this.rowsRemovedTotal,
+        total_columns_dropped: this.droppedTotalCount(),
+        dropped_by_step: this.droppedColumnsByStep
+      }
+    };
+    const prompt = 'Analyze the Data Purifier Summary. Review which preprocessing steps ran, how many rows were removed in each step, and which columns were dropped (sparsity, missingness, collinearity, outliers, dedup). Flag any step that removed an unexpectedly large fraction of rows or columns. Suggest whether specific purifier_options should be tightened, relaxed, added, or removed before encoding — and call out features that may have been dropped that the user might want to keep.';
+    this.requestAiSupport(context, 'data_purifier', prompt);
+  }
+
   ngAfterViewChecked(): void {
     if (this.splitValidation && !this._splitChartDrawn && this.splitValidationCanvas) {
       this._splitChartDrawn = true;

--- a/frontend/src/app/modeling/modeling.component.html
+++ b/frontend/src/app/modeling/modeling.component.html
@@ -682,6 +682,12 @@
               </tbody>
             </table>
           </div>
+          <!-- AI Support trigger for Forward Selection table (v2.41.0) -->
+          <div style="margin-top: 10px; text-align: right;">
+            <button class="ai-support-btn" (click)="requestAiSupport({forward: sfsForwardResults}, 'sfs_forward', 'Analyze ONLY the forward feature selection results below. Identify the inflection point where adding the next feature stops improving CV ROC-AUC meaningfully, recommend a feature-count cut-off, and flag the top 3 features by marginal contribution. Do NOT compare against backward elimination or forward-from-backward — those are separate analyses.')">
+              <span class="ai-support-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 2L12.5 9.5L20 12L12.5 14.5L10 22L7.5 14.5L0 12L7.5 9.5L10 2Z" fill="currentColor"/><path d="M20 4L21 7L24 8L21 9L20 12L19 9L16 8L19 7L20 4Z" fill="currentColor" opacity="0.7"/><path d="M20 16L20.75 18.25L23 19L20.75 19.75L20 22L19.25 19.75L17 19L19.25 18.25L20 16Z" fill="currentColor" opacity="0.5"/></svg></span> Get AI Support
+            </button>
+          </div>
         </div>
 
         <!-- Backward Elimination Results -->
@@ -751,7 +757,14 @@
               </tbody>
             </table>
           </div>
-          
+
+          <!-- AI Support trigger for Backward Elimination table (v2.41.0) -->
+          <div style="margin-top: 10px; text-align: right;">
+            <button class="ai-support-btn" (click)="requestAiSupport({backward: sfsBackwardResults, cut_step: sfsBackwardCutStep, cut_features: sfsBackwardCutFeatures}, 'sfs_backward', 'Analyze ONLY the backward elimination results below. Identify the optimal cut step where additional removal starts hurting CV ROC-AUC, recommend which features should be dropped first based on their |drop in metric|, and flag features that look safe to remove vs risky. If a cut_step is already selected by the user, comment on whether their choice looks reasonable. Do NOT compare against forward selection or forward-from-backward — those are separate analyses.')">
+              <span class="ai-support-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 2L12.5 9.5L20 12L12.5 14.5L10 22L7.5 14.5L0 12L7.5 9.5L10 2Z" fill="currentColor"/><path d="M20 4L21 7L24 8L21 9L20 12L19 9L16 8L19 7L20 4Z" fill="currentColor" opacity="0.7"/><path d="M20 16L20.75 18.25L23 19L20.75 19.75L20 22L19.25 19.75L17 19L19.25 18.25L20 16Z" fill="currentColor" opacity="0.5"/></svg></span> Get AI Support
+            </button>
+          </div>
+
           <!-- Remaining Features at Selected Cut Point -->
           <div *ngIf="sfsBackwardCutFeatures.length > 0" style="margin-top: 20px; padding: 16px; background: #f8f9fa; border-radius: 8px; border-left: 4px solid #2e7d32;">
             <h5 style="margin: 0 0 12px 0; color: #2e7d32; font-size: 14px; font-weight: 600;">
@@ -931,12 +944,13 @@
               </tbody>
             </table>
           </div>
+          <!-- AI Support trigger for Forward-from-Backward table (v2.41.0) -->
+          <div style="margin-top: 10px; text-align: right;">
+            <button class="ai-support-btn" (click)="requestAiSupport({forward_from_backward: sfsForwardFromBackwardResults, seed_features: sfsBackwardCutFeatures, seed_count: sfsBackwardCutFeatures.length}, 'sfs_forward_from_backward', 'Analyze ONLY the forward-from-backward results below. This is a forward selection that started from the backward-cut feature set. Evaluate whether the chained run actually improved over the backward cut point, identify which seed features carried the lift vs which new additions did the work, and recommend a final feature-count cut-off. Do NOT compare against the original forward or backward runs — those are separate analyses.')">
+              <span class="ai-support-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 2L12.5 9.5L20 12L12.5 14.5L10 22L7.5 14.5L0 12L7.5 9.5L10 2Z" fill="currentColor"/><path d="M20 4L21 7L24 8L21 9L20 12L19 9L16 8L19 7L20 4Z" fill="currentColor" opacity="0.7"/><path d="M20 16L20.75 18.25L23 19L20.75 19.75L20 22L19.25 19.75L17 19L19.25 18.25L20 16Z" fill="currentColor" opacity="0.5"/></svg></span> Get AI Support
+            </button>
+          </div>
         </div>
-      </div>
-      <div *ngIf="sfsForwardResults.length > 0 || sfsBackwardResults.length > 0 || sfsForwardFromBackwardResults.length > 0" style="margin-top: 10px; text-align: right;">
-        <button class="ai-support-btn" (click)="requestAiSupport({forward: sfsForwardResults, backward: sfsBackwardResults, forward_from_backward: sfsForwardFromBackwardResults}, 'sfs', 'Analyze the Sequential Feature Selection results. Which features consistently improve performance? Is there a clear optimal feature count? Compare forward vs backward results. Are there features that should definitely be included or excluded?')">
-          <span class="ai-support-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 2L12.5 9.5L20 12L12.5 14.5L10 22L7.5 14.5L0 12L7.5 9.5L10 2Z" fill="currentColor"/><path d="M20 4L21 7L24 8L21 9L20 12L19 9L16 8L19 7L20 4Z" fill="currentColor" opacity="0.7"/><path d="M20 16L20.75 18.25L23 19L20.75 19.75L20 22L19.25 19.75L17 19L19.25 18.25L20 16Z" fill="currentColor" opacity="0.5"/></svg></span> Get AI Support
-        </button>
       </div>
 
       <!-- Note: After SFS Results -->

--- a/frontend/src/app/modeling/modeling.component.spec.ts
+++ b/frontend/src/app/modeling/modeling.component.spec.ts
@@ -1149,4 +1149,111 @@ describe('ModelingComponent', () => {
       }, 5);
     });
   });
+
+  // ── 'Get AI Support' per-table buttons in SFS Results (v2.41.0) ──────
+  // Replaces the single combined SFS button at the end of the SFS
+  // results panel.  Each per-table button passes ONLY its own data
+  // slice + a directive forbidding cross-comparison, so the LLM
+  // focuses on the table the user clicked from.  We also pin a
+  // regression guard: the combined button must no longer render even
+  // when all three result arrays are populated.
+  describe("SFS per-table 'Get AI Support' buttons (v2.41.0)", () => {
+    beforeEach(() => {
+      // requestAiSupport runs through dataService and the data-dict refetch.
+      // Spy on it so we just capture (context, section, prompt) args
+      // without triggering network calls.
+      spyOn(component, 'requestAiSupport').and.callFake(() => { /* no-op */ });
+      // SFS results section sits inside `modelingStatus?.model` gate;
+      // seed the minimum needed to render the section.  We deliberately
+      // leave model.cv / model.shap_beeswarm / model.selected_features
+      // unset so their sibling AI-support buttons do not render and
+      // pollute the per-table querySelectorAll('.ai-support-btn') count.
+      component.modelingStatus = { model: {} } as any;
+    });
+
+    it('forward-only SFS state renders exactly ONE ai-support-btn (sfs_forward) and clicking it passes the right args', () => {
+      component.sfsForwardResults = [
+        { step: 1, feature_name: 'a', cv_roc_auc: 0.71 },
+        { step: 2, feature_name: 'b', cv_roc_auc: 0.74 },
+      ] as any;
+      component.sfsBackwardResults = [];
+      component.sfsForwardFromBackwardResults = [];
+      fixture.detectChanges();
+
+      const btns = fixture.nativeElement.querySelectorAll('.ai-support-btn');
+      expect(btns.length).withContext('Only the Forward SFS AI Support button should render').toBe(1);
+
+      (btns[0] as HTMLButtonElement).click();
+
+      const args = (component.requestAiSupport as jasmine.Spy).calls.mostRecent().args;
+      expect(args[1]).toBe('sfs_forward');
+      expect(Object.keys(args[0])).toEqual(['forward']);
+      expect(args[0].forward.length).toBe(2);
+    });
+
+    it('backward-only SFS state renders ONE ai-support-btn (sfs_backward) with cut_step + cut_features', () => {
+      component.sfsForwardResults = [];
+      component.sfsBackwardResults = [
+        { step: 1, feature_name: 'x', cv_roc_auc: 0.69 },
+        { step: 2, feature_name: 'y', cv_roc_auc: 0.66 },
+      ] as any;
+      component.sfsForwardFromBackwardResults = [];
+      component.sfsBackwardCutStep = 1;
+      component.sfsBackwardCutFeatures = ['x'];
+      fixture.detectChanges();
+
+      const btns = fixture.nativeElement.querySelectorAll('.ai-support-btn');
+      expect(btns.length).withContext('Only the Backward SFS AI Support button should render').toBe(1);
+
+      (btns[0] as HTMLButtonElement).click();
+
+      const args = (component.requestAiSupport as jasmine.Spy).calls.mostRecent().args;
+      expect(args[1]).toBe('sfs_backward');
+      expect(Object.keys(args[0]).sort()).toEqual(['backward', 'cut_features', 'cut_step']);
+      expect(args[0].cut_step).toBe(1);
+      expect(args[0].cut_features).toEqual(['x']);
+    });
+
+    it('forward-from-backward-only state renders ONE ai-support-btn (sfs_forward_from_backward) with seed metadata', () => {
+      component.sfsForwardResults = [];
+      component.sfsBackwardResults = [];
+      component.sfsForwardFromBackwardResults = [
+        { step: 1, feature_name: 'p', cv_roc_auc: 0.72 },
+      ] as any;
+      component.sfsBackwardCutFeatures = ['p', 'q', 'r'];
+      fixture.detectChanges();
+
+      const btns = fixture.nativeElement.querySelectorAll('.ai-support-btn');
+      expect(btns.length).withContext('Only the Forward-from-Backward AI Support button should render').toBe(1);
+
+      (btns[0] as HTMLButtonElement).click();
+
+      const args = (component.requestAiSupport as jasmine.Spy).calls.mostRecent().args;
+      expect(args[1]).toBe('sfs_forward_from_backward');
+      expect(Object.keys(args[0]).sort()).toEqual(['forward_from_backward', 'seed_count', 'seed_features']);
+      expect(args[0].seed_count).toBe(3);
+      expect(args[0].seed_features).toEqual(['p', 'q', 'r']);
+    });
+
+    it('REGRESSION: with all 3 result arrays populated, exactly THREE ai-support-btns render — combined button is gone', () => {
+      // This pins removal of the legacy combined SFS button at the end
+      // of the SFS results panel.  If a future edit re-adds it, this
+      // test fails with 4 buttons instead of 3, AND the section-name
+      // harvest finds 'sfs' which is rejected.
+      component.sfsForwardResults = [{ step: 1, feature_name: 'a' }] as any;
+      component.sfsBackwardResults = [{ step: 1, feature_name: 'b' }] as any;
+      component.sfsForwardFromBackwardResults = [{ step: 1, feature_name: 'c' }] as any;
+      component.sfsBackwardCutFeatures = ['b'];
+      fixture.detectChanges();
+
+      const btns = fixture.nativeElement.querySelectorAll('.ai-support-btn');
+      expect(btns.length).withContext('Per-table buttons only — combined button must be removed').toBe(3);
+
+      // Click each button and harvest section names from the spy.
+      btns.forEach((b: HTMLButtonElement) => b.click());
+      const sections = (component.requestAiSupport as jasmine.Spy).calls.allArgs().map((a: any[]) => a[1]);
+      expect(sections.slice().sort()).toEqual(['sfs_backward', 'sfs_forward', 'sfs_forward_from_backward']);
+      expect(sections).not.toContain('sfs');
+    });
+  });
 });

--- a/frontend/src/app/services/ai-assistant.service.spec.ts
+++ b/frontend/src/app/services/ai-assistant.service.spec.ts
@@ -218,5 +218,28 @@ describe('AiAssistantService', () => {
       const after = service.consumePendingContext();
       expect(after).toBeNull();
     });
+
+    // ── v2.41.0: new section names round-trip through requestSupport() ──
+    // The new 'Get AI Support' buttons (Data Purifier + per-table SFS x3)
+    // each pass a distinct section name.  Pin them here so a future
+    // rename in the templates also fails this test, not just a
+    // template-render check.  Section name is the only stable handle
+    // the backend has to tell which UI surface the user clicked from.
+    it('v2.41.0 section names (data_purifier, sfs_forward, sfs_backward, sfs_forward_from_backward) round-trip', () => {
+      const cases: Array<[string, string]> = [
+        ['data_purifier',             'Analyze the purifier output'],
+        ['sfs_forward',               'Analyze ONLY forward'],
+        ['sfs_backward',              'Analyze ONLY backward'],
+        ['sfs_forward_from_backward', 'Analyze ONLY forward-from-backward'],
+      ];
+      for (const [section, prompt] of cases) {
+        service.requestSupport({ marker: section }, section, prompt);
+        const pending = service.consumePendingContext();
+        expect(pending).withContext(`${section} should round-trip`).toBeTruthy();
+        expect(pending!.section).toBe(section);
+        expect(pending!.prompt).toBe(prompt);
+        expect((pending!.context as any).marker).toBe(section);
+      }
+    });
   });
 });


### PR DESCRIPTION
feat(v2.41.0): per-section 'Get AI Support' buttons for Data Purifier + SFS tables

Adds dedicated AI Support triggers under three analytical sections so the LLM gets a narrow, focused context instead of the broad page-wide dump that the previous combined SFS button produced.

Frontend changes:
- model-development.component.{ts,html}: new requestPurifierAiSupport() method + button inside .purifier-summary card; scopes context to purifier outputs only (rows_before/after, rows_removed, total_columns_dropped, dropped_by_step). Section name: 'data_purifier'.
- modeling.component.html: three new per-table SFS buttons replacing the legacy combined button.
  * Forward Selection table: section 'sfs_forward', context {forward}.
  * Backward Elimination table: section 'sfs_backward', context {backward, cut_step, cut_features}.
  * Forward-from-Backward table: section 'sfs_forward_from_backward', context {forward_from_backward, seed_features, seed_count}.
- Each prompt explicitly forbids cross-comparison so the LLM focuses on the table the user actually clicked.
- Removed: single combined SFS button at end of SFS panel (sent forward+backward+ffb in one payload; obsoleted by per-table scoping).

Tests added (8 specs, all passing):
- 3 in model-development.component.spec.ts (context-shape, button render+click, gating regression guard).
- 4 in modeling.component.spec.ts (per-table render+click for forward/backward/ffb + regression guard pinning combined-button removal).
- 1 in ai-assistant.service.spec.ts (4 new section names round-trip through requestSupport()).

Test gate: 365/365 frontend Karma + 720/720 backend pytest PASS.