### PR TITLE
fix(v2.41.1): chat renderer turns LaTeX ($\rightarrow$) into Unicode

### DIFF
--- a/backend/ai_assistant/views.py
+++ b/backend/ai_assistant/views.py
@@ -56,6 +56,12 @@ The user is a data scientist or risk analyst building a supervised binary classi
 • Use well-known rule-of-thumbs when applicable (e.g., PSI > 0.25 = population shift,
   VIF > 5 = multicollinearity concern, missing > 30% = consider dropping, etc.).
 • Prefer bullet points, short paragraphs, and tables. Highlight key takeaways first.
+• Use Unicode characters DIRECTLY for math, arrows, and Greek letters: → ⇒ ← ↔ ≤ ≥
+  ≠ ≈ ± × ÷ · ∈ ∉ ∑ ∏ ∫ √ ∞ α β γ δ θ λ μ π ρ σ τ φ χ ψ ω Δ Σ Ω, etc.
+  Do NOT emit LaTeX syntax like $\\rightarrow$, \\alpha, \\le, or $$...$$ — our chat
+  renderer is markdown-only (no MathJax / KaTeX) and will display LaTeX source
+  as raw text the user has to mentally translate.  Example: write "PSI ≥ 0.25 →
+  significant shift", not "PSI $\\ge$ 0.25 $\\rightarrow$ significant shift".
 • Do NOT deep-dive into math, formulas, or theoretical proofs UNLESS the user explicitly asks.
   If the user asks "why?" or "explain this metric", then go deeper.
 • When flagging an issue, always pair it with a practical suggestion on what to do about it.
@@ -653,7 +659,9 @@ Discipline:
 _LITE_SYSTEM_PROMPT = """You are DeclarAI Assistant — a hands-on AI advisor inside a credit-risk / ML
 binary-classification pipeline.  Be concrete, ground every claim in the
 context provided, quote real feature names and numbers, and prefer bullet
-points and short paragraphs over essays.
+points and short paragraphs over essays.  Use Unicode for math (→ ⇒ ≤ ≥
+≠ ≈ ± × ÷ · α β σ π Δ Σ Ω); do NOT emit LaTeX like $\\rightarrow$ or
+\\alpha — the chat renderer has no MathJax and will show the source.
 
 ═══ PIPELINE STAGES ═══
 1. Data Declaration  2. Data Purifier (preprocessing)  3. Data Quality Summary

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -7972,3 +7972,97 @@ class TestSystemPromptSelection:
         assert captured.get('declarai.system_prompt.chars', 0) >= 32_000, (
             "Full branch should report the full prompt size."
         )
+
+
+# ---------------------------------------------------------------------------
+# v2.41.1: Unicode-only formatting rule (no LaTeX in chat output)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSystemPromptLatexFormattingRule:
+    """v2.41.1 — pin the rule that forbids LaTeX syntax in chat output.
+
+    The chat renderer is a hand-rolled markdown subset (no MathJax/KaTeX)
+    so any LaTeX the model emits — `$\\rightarrow$`, `\\alpha`, `$$...$$` —
+    is shown to the user as raw source.  Both system prompts now instruct
+    the model to use Unicode characters directly.
+
+    The frontend has a defensive `_delatexify` pass too (covered by Karma
+    specs in `ai-chat-panel.component.spec.ts`), but the prompt-side rule
+    is the primary fix: it prevents the LLM from emitting LaTeX in the
+    first place, which keeps the message history clean for downstream
+    consumers (audit logs, retraining corpus, traces) — places the
+    frontend rendering pass cannot reach.
+
+    These tests fail-fast if a future prompt edit drops the rule.
+    """
+
+    def test_full_prompt_forbids_latex_syntax(self):
+        from ai_assistant.views import SYSTEM_PROMPT
+        # Must explicitly forbid LaTeX commands.
+        assert 'LaTeX' in SYSTEM_PROMPT, (
+            "Full system prompt must mention 'LaTeX' so the LLM knows "
+            "the keyword being banned."
+        )
+        # Must show at least one concrete LaTeX-syntax example so the
+        # model can pattern-match what's forbidden.  Use $\rightarrow$
+        # since that's the literal user-reported case from v2.41.1.
+        assert '\\rightarrow' in SYSTEM_PROMPT, (
+            "Full system prompt must show the user-reported $\\rightarrow$ "
+            "example so the LLM recognises the forbidden pattern."
+        )
+
+    def test_full_prompt_recommends_unicode_directly(self):
+        from ai_assistant.views import SYSTEM_PROMPT
+        # The flip side of the rule: the model must know what to use
+        # INSTEAD of LaTeX.  Verify a representative Unicode arrow and
+        # comparison op appear in the prompt so the model can copy from
+        # the catalogue.
+        for char in ('→', '⇒', '≤', '≥', '≠', 'α', 'β', 'σ', 'π', 'Δ', 'Σ'):
+            assert char in SYSTEM_PROMPT, (
+                f"Full system prompt should list the Unicode character "
+                f"{char!r} as a concrete substitute for the LaTeX form."
+            )
+
+    def test_lite_prompt_forbids_latex_syntax(self):
+        from ai_assistant.views import _LITE_SYSTEM_PROMPT
+        # The lite prompt has a tighter token budget so the rule is
+        # condensed but it MUST still appear — engine models (gemma,
+        # llama, qwen) that get the lite prompt are precisely the ones
+        # most likely to spam LaTeX from training-data bias.
+        assert 'LaTeX' in _LITE_SYSTEM_PROMPT, (
+            "Lite system prompt must mention 'LaTeX' so engine models "
+            "know the keyword being banned."
+        )
+        assert '\\rightarrow' in _LITE_SYSTEM_PROMPT, (
+            "Lite system prompt must show the $\\rightarrow$ example "
+            "so engine models recognise the forbidden pattern."
+        )
+
+    def test_lite_prompt_recommends_unicode_directly(self):
+        from ai_assistant.views import _LITE_SYSTEM_PROMPT
+        # Lite catalogue is smaller than the full prompt's, but it MUST
+        # at minimum cover the arrow + comparison families since those
+        # are the highest-volume offenders.
+        for char in ('→', '⇒', '≤', '≥', '≠'):
+            assert char in _LITE_SYSTEM_PROMPT, (
+                f"Lite system prompt should list the Unicode character "
+                f"{char!r} as a concrete substitute for LaTeX."
+            )
+
+    def test_full_prompt_warning_co_locates_with_unicode_recommendation(self):
+        """The forbid-LaTeX rule and the use-Unicode recommendation MUST
+        appear together (not in separate disconnected sections).  If a
+        future prompt edit splits them, the model sees the negative rule
+        without the positive substitute and is more likely to fall back
+        to LaTeX habits.  We pin co-location by checking both 'LaTeX' and
+        a Unicode arrow appear within the same ~500-char window."""
+        from ai_assistant.views import SYSTEM_PROMPT
+        idx = SYSTEM_PROMPT.find('LaTeX')
+        assert idx >= 0, "Expected 'LaTeX' marker missing from full prompt."
+        # 500-char window centred on the LaTeX marker.
+        window = SYSTEM_PROMPT[max(0, idx - 250):idx + 250]
+        assert '→' in window, (
+            "The forbid-LaTeX rule must be co-located with at least the "
+            "Unicode arrow `→` so the model sees the substitute next to "
+            "the prohibition."
+        )

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.spec.ts
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.spec.ts
@@ -1082,4 +1082,139 @@ describe('AiChatPanelComponent', () => {
       );
     });
   });
+
+  // ── v2.41.1: LaTeX → Unicode rendering pass ─────────────────────────
+  // The chat renderer is a hand-rolled markdown subset with no MathJax /
+  // KaTeX layer.  When the LLM emits LaTeX-style symbols (e.g.
+  // `$\rightarrow$`, `\alpha`, `\le`) the user previously saw the raw
+  // source in the chat bubble.  v2.41.1 adds a defensive `_delatexify`
+  // pass inside `_formatInline` that converts the most common
+  // ML/credit-risk symbols to Unicode before markdown processing.
+  //
+  // These specs pin the round-trip for the user-reported case AND a
+  // representative sample of every category (arrows, comparison ops,
+  // arithmetic, set/logic, calculus, Greek lowercase + uppercase).
+  // The system prompts ALSO instruct the LLM to use Unicode directly
+  // (see TestSystemPromptLatexFormattingRule on the backend); this
+  // client-side pass is defense-in-depth so a rogue model output can
+  // never put raw LaTeX on screen.
+  describe('v2.41.1 LaTeX → Unicode rendering', () => {
+    it('REGRESSION: the user-reported `$\\rightarrow$` renders as `→`', () => {
+      // The exact string from the v2.41.1 bug report: assistant emitted
+      // `$\rightarrow$` and the user saw it raw in the chat bubble.
+      const out = component.formatMessage('PSI ≥ 0.25 $\\rightarrow$ significant shift');
+      expect(out).toContain('→');
+      expect(out).not.toContain('rightarrow');
+      expect(out).not.toContain('\\');
+    });
+
+    it('handles bare `\\rightarrow` without $ delimiters', () => {
+      const out = component.formatMessage('See \\rightarrow next step');
+      expect(out).toContain('→');
+      expect(out).not.toContain('rightarrow');
+    });
+
+    it('converts the full arrow family', () => {
+      const out = component.formatMessage(
+        'Arrows: $\\Rightarrow$ $\\leftarrow$ $\\Leftarrow$ $\\leftrightarrow$ $\\uparrow$ $\\downarrow$ $\\mapsto$'
+      );
+      expect(out).toContain('⇒');
+      expect(out).toContain('←');
+      expect(out).toContain('⇐');
+      expect(out).toContain('↔');
+      expect(out).toContain('↑');
+      expect(out).toContain('↓');
+      expect(out).toContain('↦');
+      expect(out).not.toMatch(/Rightarrow|leftarrow|Leftarrow|leftrightarrow|uparrow|downarrow|mapsto/);
+    });
+
+    it('converts comparison + arithmetic ops', () => {
+      const out = component.formatMessage(
+        'Ops: $\\leq$ $\\le$ $\\geq$ $\\ge$ $\\neq$ $\\approx$ $\\pm$ $\\times$ $\\div$ $\\cdot$'
+      );
+      // Each conversion target appears at least once.  We don't pin the
+      // count because $\le$ and $\leq$ both map to ≤ (so two ≤ from those).
+      expect(out).toContain('≤');
+      expect(out).toContain('≥');
+      expect(out).toContain('≠');
+      expect(out).toContain('≈');
+      expect(out).toContain('±');
+      expect(out).toContain('×');
+      expect(out).toContain('÷');
+      expect(out).toContain('·');
+      // None of the LaTeX command names should leak through.
+      expect(out).not.toMatch(/\\(leq|le|geq|ge|neq|approx|pm|times|div|cdot)\b/);
+    });
+
+    it('converts Greek letters (lowercase + uppercase)', () => {
+      const out = component.formatMessage(
+        'Greek: $\\alpha$ $\\beta$ $\\sigma$ $\\mu$ $\\pi$ $\\theta$ $\\Delta$ $\\Sigma$ $\\Omega$'
+      );
+      expect(out).toContain('α');
+      expect(out).toContain('β');
+      expect(out).toContain('σ');
+      expect(out).toContain('μ');
+      expect(out).toContain('π');
+      expect(out).toContain('θ');
+      expect(out).toContain('Δ');
+      expect(out).toContain('Σ');
+      expect(out).toContain('Ω');
+      expect(out).not.toMatch(/\\(alpha|beta|sigma|mu|pi|theta|Delta|Sigma|Omega)\b/);
+    });
+
+    it('converts calculus + set/logic operators', () => {
+      const out = component.formatMessage(
+        'Math: $\\sum$ $\\prod$ $\\int$ $\\infty$ $\\sqrt$ $\\partial$ $\\in$ $\\notin$ $\\forall$'
+      );
+      expect(out).toContain('∑');
+      expect(out).toContain('∏');
+      expect(out).toContain('∫');
+      expect(out).toContain('∞');
+      expect(out).toContain('√');
+      expect(out).toContain('∂');
+      expect(out).toContain('∈');
+      expect(out).toContain('∉');
+      expect(out).toContain('∀');
+    });
+
+    it('REGRESSION: money strings like `$50` and `$1,200` are NOT corrupted', () => {
+      // The whole point of NOT writing a generic `$...$` stripper is to
+      // keep money/price strings intact.  This pin guards against a
+      // future "smarter" stripper regressing the ML/finance use case.
+      const out = component.formatMessage(
+        'Loan amount $50,000 with $1,200 monthly payment for $24 months'
+      );
+      expect(out).toContain('$50,000');
+      expect(out).toContain('$1,200');
+      expect(out).toContain('$24');
+    });
+
+    it('REGRESSION: code blocks and inline code with backslashes are not LaTeX-mangled', () => {
+      // Markdown inline code like `\n` (Python newline literal) should
+      // pass through unchanged — the LaTeX pass must not eat the
+      // backslash inside non-LaTeX contexts.  We test this via the
+      // `\,` spacing command rule: a code mention of `\,` is rare, so
+      // the broader contract here is "unknown commands stay as-is".
+      const out = component.formatMessage('Unknown: \\foobar should stay');
+      expect(out).toContain('\\foobar');
+    });
+
+    it('shortcuts when the input has no backslash at all (perf path)', () => {
+      // The early return optimisation: strings without `\` should
+      // pass through unchanged byte-for-byte (modulo HTML escaping +
+      // markdown formatting).
+      const out = component.formatMessage('Plain text with → and ≤ already in unicode');
+      expect(out).toContain('→');
+      expect(out).toContain('≤');
+      expect(out).not.toContain('\\');
+    });
+
+    it('integrates cleanly with markdown bold + LaTeX in the same line', () => {
+      // Ensures the LaTeX pass runs BEFORE markdown so `**bold**` still
+      // renders as `<strong>` even when the line also has LaTeX.
+      const out = component.formatMessage('**Result:** PSI $\\ge$ 0.25');
+      expect(out).toContain('<strong>Result:</strong>');
+      expect(out).toContain('≥');
+    });
+  });
 });

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
@@ -877,6 +877,12 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
     if (!text) return '';
     let s = text
       .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    // v2.41.1 — strip LaTeX BEFORE markdown so `$\rightarrow$` becomes
+    // `→` instead of being passed through as raw text the user sees.
+    // The system prompts also instruct the LLM to use Unicode directly,
+    // but this pass is defense-in-depth: a rogue model output can never
+    // put raw LaTeX on screen.
+    s = this._delatexify(s);
     // Headers
     s = s.replace(/^#### (.+)/, '<strong style="font-size:13px;">$1</strong>');
     s = s.replace(/^### (.+)/, '<strong style="font-size:14px;">$1</strong>');
@@ -891,6 +897,142 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
     // Bullet/numbered list items
     s = s.replace(/^- (.+)/, '• $1');
     s = s.replace(/^\d+\.\s/, (m) => m);
+    return s;
+  }
+
+  /**
+   * v2.41.1 — Convert the most common LaTeX commands to Unicode.
+   *
+   * Our chat renderer is a hand-rolled markdown subset (see
+   * `_formatInline` and `_renderTable` above) — it has no MathJax /
+   * KaTeX layer.  Without this pass, content like `$\rightarrow$` or
+   * `\alpha` shows up as raw LaTeX in the chat bubble, which is what
+   * the user reported in the v2.41.1 bug.
+   *
+   * We accept BOTH `\command` and `$\command$` forms by allowing an
+   * optional `$` on each side of every pattern.  A strict `$...$`
+   * stripper for unrecognised content is deliberately omitted: a naive
+   * regex would corrupt money strings like "$50 and $60" and the win
+   * for unknown LaTeX is small (the user still sees broken-but-
+   * recognisable source).
+   *
+   * Symbol catalog covers what's plausible in a credit-risk / ML
+   * conversation: arrows, comparison & arithmetic ops, set & logic
+   * operators, calculus, full Greek alphabet (lowercase + the
+   * uppercase letters that differ from Latin).
+   */
+  private _delatexify(s: string): string {
+    if (!s || s.indexOf('\\') === -1) return s;
+    // Pattern shape: `<optional $><LaTeX command><non-letter lookahead><optional $>`.
+    // The negative lookahead `(?![a-zA-Z])` is critical: without it, `\\in`
+    // would prefix-match inside `\\int` and `\\infty`, producing garbage
+    // like `∈t$` and `∈fty$`.  Same hazard applies to `\\le` (prefix of
+    // `\\leq`/`\\leftarrow`/`\\leftrightarrow`), `\\ge` (`\\geq`), `\\ne`
+    // (`\\neq`).  We use the lookahead uniformly so rule order doesn't
+    // have to encode that knowledge — but we ALSO order longer commands
+    // first as defense-in-depth (`\\int` before `\\in`, etc.).
+    //
+    // A single rule per command handles BOTH `\command` and `$\command$`
+    // forms because the leading `\$?` and trailing `\$?` each match zero
+    // or one `$` independently.
+    const map: Array<[RegExp, string]> = [
+      // Arrows
+      [/\$?\\rightarrow(?![a-zA-Z])\$?/g, '→'],
+      [/\$?\\to(?![a-zA-Z])\$?/g, '→'],
+      [/\$?\\Rightarrow(?![a-zA-Z])\$?/g, '⇒'],
+      [/\$?\\Leftrightarrow(?![a-zA-Z])\$?/g, '⇔'],
+      [/\$?\\leftrightarrow(?![a-zA-Z])\$?/g, '↔'],
+      [/\$?\\Leftarrow(?![a-zA-Z])\$?/g, '⇐'],
+      [/\$?\\leftarrow(?![a-zA-Z])\$?/g, '←'],
+      [/\$?\\uparrow(?![a-zA-Z])\$?/g, '↑'],
+      [/\$?\\downarrow(?![a-zA-Z])\$?/g, '↓'],
+      [/\$?\\mapsto(?![a-zA-Z])\$?/g, '↦'],
+      // Comparison + arithmetic — longer commands first (`\leq` before `\le`).
+      [/\$?\\leq(?![a-zA-Z])\$?/g, '≤'],
+      [/\$?\\le(?![a-zA-Z])\$?/g, '≤'],
+      [/\$?\\geq(?![a-zA-Z])\$?/g, '≥'],
+      [/\$?\\ge(?![a-zA-Z])\$?/g, '≥'],
+      [/\$?\\neq(?![a-zA-Z])\$?/g, '≠'],
+      [/\$?\\ne(?![a-zA-Z])\$?/g, '≠'],
+      [/\$?\\approx(?![a-zA-Z])\$?/g, '≈'],
+      [/\$?\\equiv(?![a-zA-Z])\$?/g, '≡'],
+      [/\$?\\sim(?![a-zA-Z])\$?/g, '∼'],
+      [/\$?\\propto(?![a-zA-Z])\$?/g, '∝'],
+      [/\$?\\pm(?![a-zA-Z])\$?/g, '±'],
+      [/\$?\\mp(?![a-zA-Z])\$?/g, '∓'],
+      [/\$?\\times(?![a-zA-Z])\$?/g, '×'],
+      [/\$?\\div(?![a-zA-Z])\$?/g, '÷'],
+      [/\$?\\cdot(?![a-zA-Z])\$?/g, '·'],
+      [/\$?\\ast(?![a-zA-Z])\$?/g, '∗'],
+      // Set / logic — `\notin` before `\in`, longer subset before shorter.
+      [/\$?\\notin(?![a-zA-Z])\$?/g, '∉'],
+      [/\$?\\in(?![a-zA-Z])\$?/g, '∈'],
+      [/\$?\\subseteq(?![a-zA-Z])\$?/g, '⊆'],
+      [/\$?\\subset(?![a-zA-Z])\$?/g, '⊂'],
+      [/\$?\\supseteq(?![a-zA-Z])\$?/g, '⊇'],
+      [/\$?\\supset(?![a-zA-Z])\$?/g, '⊃'],
+      [/\$?\\cup(?![a-zA-Z])\$?/g, '∪'],
+      [/\$?\\cap(?![a-zA-Z])\$?/g, '∩'],
+      [/\$?\\forall(?![a-zA-Z])\$?/g, '∀'],
+      [/\$?\\exists(?![a-zA-Z])\$?/g, '∃'],
+      [/\$?\\emptyset(?![a-zA-Z])\$?/g, '∅'],
+      // Calculus / operators — `\infty` and `\int` come before `\in`
+      // (defense-in-depth ordering even though the lookahead would catch it).
+      [/\$?\\infty(?![a-zA-Z])\$?/g, '∞'],
+      [/\$?\\int(?![a-zA-Z])\$?/g, '∫'],
+      [/\$?\\sum(?![a-zA-Z])\$?/g, '∑'],
+      [/\$?\\prod(?![a-zA-Z])\$?/g, '∏'],
+      [/\$?\\partial(?![a-zA-Z])\$?/g, '∂'],
+      [/\$?\\nabla(?![a-zA-Z])\$?/g, '∇'],
+      [/\$?\\sqrt(?![a-zA-Z])\$?/g, '√'],
+      // Greek lowercase
+      [/\$?\\alpha(?![a-zA-Z])\$?/g, 'α'],
+      [/\$?\\beta(?![a-zA-Z])\$?/g, 'β'],
+      [/\$?\\gamma(?![a-zA-Z])\$?/g, 'γ'],
+      [/\$?\\delta(?![a-zA-Z])\$?/g, 'δ'],
+      [/\$?\\varepsilon(?![a-zA-Z])\$?/g, 'ε'],
+      [/\$?\\epsilon(?![a-zA-Z])\$?/g, 'ε'],
+      [/\$?\\zeta(?![a-zA-Z])\$?/g, 'ζ'],
+      [/\$?\\eta(?![a-zA-Z])\$?/g, 'η'],
+      [/\$?\\theta(?![a-zA-Z])\$?/g, 'θ'],
+      [/\$?\\iota(?![a-zA-Z])\$?/g, 'ι'],
+      [/\$?\\kappa(?![a-zA-Z])\$?/g, 'κ'],
+      [/\$?\\lambda(?![a-zA-Z])\$?/g, 'λ'],
+      [/\$?\\mu(?![a-zA-Z])\$?/g, 'μ'],
+      [/\$?\\nu(?![a-zA-Z])\$?/g, 'ν'],
+      [/\$?\\xi(?![a-zA-Z])\$?/g, 'ξ'],
+      [/\$?\\pi(?![a-zA-Z])\$?/g, 'π'],
+      [/\$?\\rho(?![a-zA-Z])\$?/g, 'ρ'],
+      [/\$?\\sigma(?![a-zA-Z])\$?/g, 'σ'],
+      [/\$?\\tau(?![a-zA-Z])\$?/g, 'τ'],
+      [/\$?\\upsilon(?![a-zA-Z])\$?/g, 'υ'],
+      [/\$?\\varphi(?![a-zA-Z])\$?/g, 'φ'],
+      [/\$?\\phi(?![a-zA-Z])\$?/g, 'φ'],
+      [/\$?\\chi(?![a-zA-Z])\$?/g, 'χ'],
+      [/\$?\\psi(?![a-zA-Z])\$?/g, 'ψ'],
+      [/\$?\\omega(?![a-zA-Z])\$?/g, 'ω'],
+      // Greek uppercase (only the ones that differ visually from Latin).
+      [/\$?\\Gamma(?![a-zA-Z])\$?/g, 'Γ'],
+      [/\$?\\Delta(?![a-zA-Z])\$?/g, 'Δ'],
+      [/\$?\\Theta(?![a-zA-Z])\$?/g, 'Θ'],
+      [/\$?\\Lambda(?![a-zA-Z])\$?/g, 'Λ'],
+      [/\$?\\Xi(?![a-zA-Z])\$?/g, 'Ξ'],
+      [/\$?\\Pi(?![a-zA-Z])\$?/g, 'Π'],
+      [/\$?\\Sigma(?![a-zA-Z])\$?/g, 'Σ'],
+      [/\$?\\Phi(?![a-zA-Z])\$?/g, 'Φ'],
+      [/\$?\\Psi(?![a-zA-Z])\$?/g, 'Ψ'],
+      [/\$?\\Omega(?![a-zA-Z])\$?/g, 'Ω'],
+      // Spacing commands the LLM may emit but which mean nothing here.
+      [/\\,/g, ' '],
+      [/\\;/g, ' '],
+      [/\\:/g, ' '],
+      [/\\!/g, ''],
+      [/\\qquad(?![a-zA-Z])/g, '    '],
+      [/\\quad(?![a-zA-Z])/g, '  '],
+    ];
+    for (const [re, repl] of map) {
+      s = s.replace(re, repl);
+    }
     return s;
   }
 


### PR DESCRIPTION
## Problem

Assistant emitted markdown like `PSI $\ge$ 0.25 $\rightarrow$ significant shift` and the chat bubble showed the **raw LaTeX source** to the user. Our chat panel is a hand-rolled markdown subset (`_formatInline` / `_renderTable` in `ai-chat-panel.component.ts`) — it has no MathJax / KaTeX layer, so any LaTeX the LLM emits is shown verbatim.

## Two-layer fix

### 1. Frontend (defense in depth)
New `_delatexify()` pass in `ai-chat-panel.component.ts` runs inside `_formatInline` between HTML escape and markdown formatting. Maps the most common credit-risk / ML symbols to Unicode:

| Category | Coverage |
|---|---|
| Arrows | → ⇒ ← ⇐ ↔ ⇔ ↑ ↓ ↦ |
| Comparison + arithmetic | ≤ ≥ ≠ ≈ ≡ ∼ ∝ ± ∓ × ÷ · ∗ |
| Set / logic | ∈ ∉ ⊂ ⊆ ⊃ ⊇ ∪ ∩ ∀ ∃ ∅ |
| Calculus | ∑ ∏ ∫ ∂ ∇ ∞ √ |
| Greek lowercase | α β γ δ ε ζ η θ ι κ λ μ ν ξ π ρ σ τ υ φ χ ψ ω |
| Greek uppercase | Γ Δ Θ Λ Ξ Π Σ Φ Ψ Ω |

Each rule shape: `\$?\\command(?![a-zA-Z])\$?` so it handles both `\command` and `\$\command\$` forms in a single pattern. The negative lookahead is **critical** — without it, `\in` would prefix-match inside `\int` and `\infty`, producing garbage like `∈t\$` and `∈fty\$` (caught during initial test run, hence the lookahead + ordering belt + suspenders).

Money strings like `\$50` and `\$1,200` are deliberately preserved (no `\$...\$` stripper).

### 2. Backend (preventive)
Both system prompts now instruct the LLM to use Unicode directly:

- `SYSTEM_PROMPT` (full, ~9000 tokens, OpenAI cloud models) — new bullet under COMMUNICATION STYLE listing 30+ Unicode targets and the exact \$\\rightarrow\$ forbid-example.
- `_LITE_SYSTEM_PROMPT` (lite, ~2500 tokens, gemma/llama/qwen engine models) — condensed one-liner near the top with the same forbid-example.

This keeps the message **history** clean (audit logs, retraining corpus, traces) — places the frontend rendering pass cannot reach.

## Tests added (15 new specs, all green)

**9 Karma specs** in `ai-chat-panel.component.spec.ts`:
- REGRESSION pin for the user-reported `\$\\rightarrow\$`.
- Bare `\\rightarrow` (without \$).
- Full arrow / comparison / Greek / calculus families.
- **REGRESSION pin: money strings like `\$50` are NOT corrupted.**
- Unknown command (`\\foobar`) passes through unchanged.
- Perf path: no-backslash strings short-circuit early.
- Markdown bold + LaTeX in same line render together correctly.

**5 pytest specs** in `TestSystemPromptLatexFormattingRule` (`backend/tests/test_unit.py`):
- Both prompts contain the 'LaTeX' keyword + the \$\\rightarrow\$ forbid-example.
- Both prompts list Unicode substitutes (→ ⇒ ≤ ≥ ≠ + Greek for full).
- Forbid-rule and Unicode recommendation are co-located in the full prompt within a 500-char window.

## Test gate (DeclarAI Pre-Commit Test Gate)

```
🔬 Unit:        557 ✅
🛡️ Regression:   34 ✅
⚙️ Functional:  111 ✅
🔗 Integration:  14 ✅
👤 UAT:           9 ✅
🏗️ Frontend Build:    ✅
🧪 Frontend Karma:  375 specs ✅
Backend: 725 / Frontend: 375 — ALL GREEN
```

## Files changed

- `backend/ai_assistant/views.py` — both system prompts
- `backend/tests/test_unit.py` — `TestSystemPromptLatexFormattingRule`
- `frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts` — `_delatexify()` + wire into `_formatInline()`
- `frontend/src/app/ai-chat-panel/ai-chat-panel.component.spec.ts` — 9 new specs

## Risk + rollback

- **Surface:** chat panel rendering only. No DB schema, no API contract, no data flow change.
- **Rollback:** revert this PR. The frontend pass is isolated; the prompt rule is additive (deleting it just removes the LLM-side hint, frontend pass still works).
- **Behavior on existing convos:** stored message history is unchanged on the backend; the frontend rendering pass applies on display, so old messages with raw LaTeX will start rendering as Unicode after this lands.

Closes the chat-bubble-shows-LaTeX bug.