### PR TITLE
feat(v2.42.0): adopt prometa-sdk prompt_render contract — closes AML A4 misverdict

### DIFF
--- a/backend/ai_assistant/prometa_config.py
+++ b/backend/ai_assistant/prometa_config.py
@@ -139,6 +139,34 @@ def get_prometa():
         except Exception as exc_ai:
             logger.warning("Prometa OpenAI auto-instrumentation failed: %s", exc_ai)
 
+        # v2.42.0 (AML A4): enable dual-channel raw capture.  The
+        # auto-instrumentation above stamps ``gen_ai.prompt`` with a
+        # ``safe_json(messages)`` blob TRUNCATED to 32 000 bytes
+        # (``prometa/integrations/_llm_common.py:MAX_TEXT_ATTR_BYTES``).
+        # In production our messages array routinely exceeds 32 KB
+        # (system prompt + slim context + auto-routed skill body +
+        # history + tool defs), so the truncation knife lands AFTER the
+        # leading system prompt but BEFORE any ``"role":"user"`` marker.
+        # The platform's A4 detector then sees "no user role" and flags
+        # the span as `absent`.
+        #
+        # Turning raw_channel on lets us stamp the FULL role-tagged
+        # messages JSON as ``prometa.raw.rendered_prompt`` (no
+        # truncation; the platform routes it to the short-TTL
+        # ``spans_raw`` table) AND stamp the user query alone as
+        # ``prometa.raw.input`` — both via the helpers in
+        # ``ai_assistant/views.py`` and the canonical
+        # ``prompt_render`` context manager.  See plan:
+        # /Users/caglarsubasi/.windsurf/plans/plan-c19801.md.
+        try:
+            from prometa import _raw_channel as prometa_raw_channel
+            prometa_raw_channel.enable()
+            logger.info("Prometa raw-channel enabled (A4 prompt isolation contract).")
+        except (ImportError, AttributeError):
+            logger.info("Prometa raw-channel helper not available (SDK <0.7).")
+        except Exception as exc_rc:
+            logger.warning("Prometa raw-channel enable failed: %s", exc_rc)
+
     except ImportError:
         logger.warning("prometa-sdk not installed — tracing disabled. "
                        "Install with: pip install prometa-sdk")
@@ -191,6 +219,84 @@ def _make_lazy_decorator(kind: str):
 workflow = _make_lazy_decorator('workflow')
 agent = _make_lazy_decorator('agent')
 tool = _make_lazy_decorator('tool')
+
+
+# ---------------------------------------------------------------------------
+# v2.42.0 — prompt.render contract (AML A4 / B7 / C4 / C5 / C6)
+# ---------------------------------------------------------------------------
+# Lazy import + safe-no-op fallback for ``prometa.prompt_render``.
+#
+# Why a wrapper?  Direct ``from prometa import prompt_render`` would
+# break import on older SDKs (the symbol landed in v0.4.x and crystallized
+# in v0.7.x) and would also raise inside pytest where ``PROMETA_DISABLE=1``
+# turns the whole SDK into a no-op.  The wrapper below is a context
+# manager with the same interface — when the real helper is unavailable,
+# it yields a stand-in handle whose ``.assembled(...)`` method is a no-op.
+#
+# Call site (``ai_assistant/views.py::_chat_workflow``) is unconditional:
+# ``with prompt_render(template_version=..., raw_rendered_prompt=...) as p:
+#       p.assembled(role_boundaries=..., system_token_count=..., ...)``
+# so the contract attributes (``prompt.role_boundaries``,
+# ``prompt.template_version``, optional ``prometa.raw.rendered_prompt``)
+# land on a dedicated ``prompt.render`` span when the SDK is live and
+# silently drop on the floor in test/dev environments.
+# ---------------------------------------------------------------------------
+
+class _NoOpPromptRenderHandle:
+    """Stand-in returned when the SDK's prompt_render helper is unavailable.
+
+    Mirrors ``prometa.prompt._PromptRenderHandle.assembled`` signature so
+    call sites don't need to special-case the no-op path.  Every kwarg
+    accepted by the real helper is also accepted here — kwargs are
+    ignored.
+    """
+
+    def assembled(self, **_kwargs) -> None:  # noqa: D401 - thin wrapper
+        return None
+
+
+@contextmanager
+def prompt_render(*, template_version: str = None,
+                  raw_rendered_prompt: str = None):
+    """Emit a ``prompt.render`` span for the AML A4 detector.
+
+    Thin wrapper over ``prometa.prompt_render`` that degrades cleanly:
+      * Real SDK available + Prometa initialized → yields the SDK's
+        ``_PromptRenderHandle`` which stamps ``prompt.template_version`` +
+        ``prometa.raw.rendered_prompt`` (when raw_channel is enabled) on
+        the span, and whose ``.assembled(...)`` writes
+        ``prompt.role_boundaries`` + token counts.
+      * SDK missing OR Prometa not initialized OR helper raises →
+        yields ``_NoOpPromptRenderHandle()`` which absorbs ``.assembled``
+        calls silently.
+
+    The raw_channel toggle (enabled in ``get_prometa()``) gates whether
+    ``raw_rendered_prompt`` actually lands on the span — the platform's
+    short-TTL ``spans_raw`` table is opt-in.
+    """
+    # Fast path: ensure Prometa is initialized; if not, yield no-op.
+    p = get_prometa()
+    if p is None:
+        yield _NoOpPromptRenderHandle()
+        return
+    try:
+        from prometa import prompt_render as _real_prompt_render
+    except (ImportError, AttributeError):
+        # v0.6.x and earlier — symbol absent.  In production we hard-pin
+        # prometa-sdk==0.7.1 (see requirements.txt) so this branch only
+        # fires in legacy/test environments.
+        yield _NoOpPromptRenderHandle()
+        return
+    try:
+        with _real_prompt_render(
+            template_version=template_version,
+            raw_rendered_prompt=raw_rendered_prompt,
+        ) as handle:
+            yield handle
+    except Exception as exc:  # pragma: no cover - defensive
+        # Never let an observability bug take down the chat workflow.
+        logger.warning("prompt_render span failed: %s", exc)
+        yield _NoOpPromptRenderHandle()
 
 
 def has_active_span() -> bool:

--- a/backend/ai_assistant/views.py
+++ b/backend/ai_assistant/views.py
@@ -18,6 +18,7 @@ from .prometa_config import (
     workflow, agent, tool, flush as prometa_flush,
     set_span_attr, set_session_id, set_customer_id, set_request_model,
     model_route, plan_generate, current_span_id, set_input_ref,
+    prompt_render,
 )
 from .tool_definitions import PIPELINE_TOOLS
 from .tool_executor import execute_tool_call, _load_skill_traced
@@ -1065,6 +1066,120 @@ def _auto_route_skill(user_message: str) -> Optional[str]:
     return None
 
 
+# ---------------------------------------------------------------------------
+# v2.42.0 — AML A4 prompt-render contract helpers
+# ---------------------------------------------------------------------------
+# These helpers compute the structured attributes that the Prometa AML A4
+# detector reads (``prompt.role_boundaries``,
+# ``prompt.context_components``, token counts).  They are kept tiny and
+# pure-Python so unit tests can pin them directly without touching the
+# OpenAI client.
+#
+# Why the rename from ``role`` → ``aml_role`` in the boundaries?  The AML
+# contract groups assistant + tool messages under semantically distinct
+# channels — but the OpenAI SDK uses the literal strings "assistant" and
+# "tool" for both wire roles.  The mapping is 1:1 today so we just pass
+# the OpenAI role straight through; the helper would be the place to
+# rename if a future detector wanted (e.g.) ``policy`` separated from
+# ``system``.
+# ---------------------------------------------------------------------------
+
+def _approx_tokens(text: Optional[str]) -> int:
+    """Quick token estimate per the prometa-sdk convention (chars / 4).
+
+    Used to populate ``prompt.system_token_count`` / ``user_token_count``
+    / ``tool_token_count`` on the ``prompt.render`` span.  An exact count
+    would require pulling in tiktoken or the model's tokenizer — overkill
+    for an attribute the detector treats as a coarse signal.
+    """
+    return (len(text) // 4) if text else 0
+
+
+def _compute_role_boundaries(messages: list,
+                             rendered_json: str) -> list[dict]:
+    """Walk ``messages`` and return ``[{role, start, end}, ...]`` byte ranges.
+
+    Re-serializes each individual message and locates its slice inside
+    ``rendered_json`` (the result of ``json.dumps(messages,
+    ensure_ascii=False)`` at the call site).  Because the call site uses
+    the SAME ``json.dumps`` call to produce both ``rendered_json`` AND
+    the per-message slice, byte equality is guaranteed and the search
+    is O(n) on a moving start cursor.
+
+    Returns an empty list if any message can't be located — the contract
+    favours "no boundaries" over "wrong boundaries" so the detector
+    falls back to substring matching gracefully.
+
+    The role attribute uses the OpenAI wire string verbatim ("system",
+    "user", "assistant", "tool").  Multi-modal content (list-of-dicts
+    rather than string) is serialized identically by both passes, so
+    the boundary search still works.
+    """
+    if not messages or not rendered_json:
+        return []
+    boundaries = []
+    cursor = 0
+    for msg in messages:
+        try:
+            slice_json = json.dumps(msg, ensure_ascii=False)
+        except (TypeError, ValueError):
+            # Non-serializable message (shouldn't happen for OpenAI
+            # messages, but be defensive).  Bail rather than emit half
+            # the boundaries.
+            return []
+        idx = rendered_json.find(slice_json, cursor)
+        if idx < 0:
+            # The slice couldn't be located — this would mean json.dumps
+            # serialized the full list and the individual message
+            # differently (e.g., dict-ordering difference).  Bail.
+            return []
+        boundaries.append({
+            'role': msg.get('role', 'unknown'),
+            'start': idx,
+            'end': idx + len(slice_json),
+        })
+        cursor = idx + len(slice_json)
+    return boundaries
+
+
+def _describe_context_components(use_tools: bool,
+                                 has_context: bool,
+                                 auto_skill: Optional[str],
+                                 has_history: bool) -> list[str]:
+    """Enumerate the knowledge sources blended into this prompt.
+
+    Consumed by the AML C6 (dynamic context assembly) detector via
+    ``prompt.context_components``.  Order mirrors the order in which
+    each component is appended to the messages array in
+    ``_chat_workflow`` so the audit trail matches the wire shape.
+    """
+    parts = ['system_prompt']
+    if use_tools:
+        parts.append('slim_context')
+    elif has_context:
+        parts.append('legacy_full_context')
+    if has_history:
+        parts.append('conversation_history')
+    if auto_skill:
+        parts.append(f'skill:{auto_skill}')
+    parts.append('user_query')
+    return parts
+
+
+def _sum_tool_message_tokens(messages: list) -> int:
+    """Sum token estimates across every ``role: "tool"`` and ``role:
+    "assistant"`` message (assistant tool_calls payload counts toward the
+    tool channel for A4's accounting)."""
+    total = 0
+    for m in messages:
+        role = m.get('role')
+        if role in ('tool', 'assistant'):
+            content = m.get('content') or ''
+            if isinstance(content, str):
+                total += _approx_tokens(content)
+    return total
+
+
 @workflow(name="declarai-chat")
 def _chat_workflow(user_message: str, context: dict, section: str, history: list,
                    file_id: int = None, model: str = None) -> dict:
@@ -1152,6 +1267,49 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
 
     # Add current user message
     messages.append({'role': 'user', 'content': user_message})
+
+    # ── v2.42.0: AML A4 prompt-render contract ─────────────────────────
+    # Emit a ``prompt.render`` span carrying structured role boundaries
+    # and the FULL (untruncated) role-tagged messages JSON.  This closes
+    # the v2.21.0+ failure mode where the openai auto-instrumentation's
+    # ``gen_ai.prompt`` attribute exceeded its 32 KB cap and got
+    # truncated mid-array, causing A4 to see a leading "role":"system"
+    # marker only — no user, assistant, or tool boundaries — and flag
+    # the span as ``absent``.  The detector reads ``prompt.role_boundaries``
+    # (structured) FIRST and falls back to substring inspection of
+    # ``prometa.raw.rendered_prompt`` (full untruncated blob) — so this
+    # block makes A4 swing back to ``present`` regardless of payload
+    # size.  Also stamp ``prometa.raw.input`` = just the user query
+    # string, distinct from the rendered prompt, so the detector can
+    # cleanly verify ``userInput !== rendered``.
+    #
+    # All four attributes are gated by the raw-channel toggle enabled
+    # in ``prometa_config.get_prometa()``.  ``prompt_render`` is a
+    # safe-no-op context manager when Prometa is disabled (test env).
+    _rendered = json.dumps(messages, ensure_ascii=False)
+    _role_boundaries = _compute_role_boundaries(messages, _rendered)
+    with prompt_render(
+        template_version=f'declarai-chat@{system_prompt_variant}',
+        raw_rendered_prompt=_rendered,
+    ) as _p:
+        _p.assembled(
+            template_version=f'declarai-chat@{system_prompt_variant}',
+            system_token_count=_approx_tokens(system_prompt_text),
+            user_token_count=_approx_tokens(user_message),
+            tool_token_count=_sum_tool_message_tokens(messages),
+            role_boundaries=_role_boundaries,
+            context_components=_describe_context_components(
+                use_tools=use_tools,
+                has_context=bool(context),
+                auto_skill=auto_skill,
+                has_history=bool(history),
+            ),
+        )
+    # Stamp the user query alone on the declarai-chat workflow span (not
+    # the prompt.render child) so it sits next to gen_ai.prompt.user
+    # for cross-checking.  set_span_attr is a no-op when no span is
+    # active or the SDK isn't installed.
+    set_span_attr('prometa.raw.input', user_message)
 
     # Tool-calling loop (only for models that support function calling)
     tools = PIPELINE_TOOLS if (use_tools and model_cfg.get('supports_tools')) else None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,7 @@ statsmodels>=0.14
 
 # AI Assistant
 openai>=1.0
-prometa-sdk>=0.7.1,<0.8
+prometa-sdk==0.7.1
 redis>=5.0
 
 # Testing dependencies

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -8066,3 +8066,388 @@ class TestSystemPromptLatexFormattingRule:
             "Unicode arrow `→` so the model sees the substitute next to "
             "the prohibition."
         )
+
+
+# ---------------------------------------------------------------------------
+# v2.42.0: AML A4 prompt-render contract
+# ---------------------------------------------------------------------------
+# These tests pin the structured-attribute contract that the Prometa AML
+# A4 detector reads.  Pre-v2.42.0 the detector was forced to substring-
+# match `"role":"user"` inside the `gen_ai.prompt` attribute, which the
+# openai auto-instrumentation truncates to 32 000 bytes.  Once production
+# payloads (system prompt + slim context + auto-routed skill body +
+# history + tool defs) crossed the 32 KB threshold, the truncation knife
+# landed AFTER the leading system prompt but BEFORE any user-role marker
+# — so A4 saw "1 system, 0 user, 0 asst, 0 tool" even though our
+# _chat_workflow emits proper multi-role messages.  The fix is to emit
+# the structured `prompt.role_boundaries` attribute via the SDK v0.7.1
+# `prompt_render` context manager, plus stamp the raw user query as
+# `prometa.raw.input`.
+#
+# We pin: (1) the pure helpers `_compute_role_boundaries` /
+# `_approx_tokens` / `_describe_context_components` /
+# `_sum_tool_message_tokens` (fast, no fixtures needed), and (2) the
+# wiring into `_chat_workflow` itself via a captured-attribute fake.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPromptRenderRoleBoundaryHelpers:
+    """Pure-function tests for the v2.42.0 role-boundary helpers."""
+
+    def test_approx_tokens_chars_div_4(self):
+        from ai_assistant.views import _approx_tokens
+        assert _approx_tokens(None) == 0
+        assert _approx_tokens('') == 0
+        assert _approx_tokens('1234') == 1
+        # 11 chars // 4 = 2 — matches the prometa-sdk convention.
+        assert _approx_tokens('hello world') == 2
+
+    def test_compute_role_boundaries_minimal_two_role_array(self):
+        """The minimum-viable A4-passing payload: one system + one user."""
+        import json
+        from ai_assistant.views import _compute_role_boundaries
+        msgs = [
+            {'role': 'system', 'content': 'You are an assistant.'},
+            {'role': 'user', 'content': 'Hello!'},
+        ]
+        rendered = json.dumps(msgs, ensure_ascii=False)
+        b = _compute_role_boundaries(msgs, rendered)
+        assert len(b) == 2
+        assert [x['role'] for x in b] == ['system', 'user']
+        # Boundaries must be NON-OVERLAPPING and each slice must round-trip
+        # to the original message JSON.  This is what A4 reads to verify
+        # role isolation.
+        assert b[0]['end'] <= b[1]['start']
+        assert rendered[b[0]['start']:b[0]['end']] == json.dumps(msgs[0], ensure_ascii=False)
+        assert rendered[b[1]['start']:b[1]['end']] == json.dumps(msgs[1], ensure_ascii=False)
+
+    def test_compute_role_boundaries_multi_round_with_tools(self):
+        """Realistic tool-calling turn: system + slim_context + history
+        user + history assistant + current user + assistant_with_tool_calls
+        + tool result + assistant final.  Every role must produce a
+        distinct boundary."""
+        import json
+        from ai_assistant.views import _compute_role_boundaries
+        msgs = [
+            {'role': 'system', 'content': 'You are DeclarAI.'},
+            {'role': 'system', 'content': 'Pipeline context summary:\nfile_id=42'},
+            {'role': 'user', 'content': 'previous question'},
+            {'role': 'assistant', 'content': 'previous answer'},
+            {'role': 'user', 'content': 'current question'},
+            {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'c1',
+                'type': 'function',
+                'function': {'name': 'get_data_dictionary', 'arguments': '{}'}}]},
+            {'role': 'tool', 'tool_call_id': 'c1',
+             'content': '{"features": ["Var_1", "Var_2"]}'},
+            {'role': 'assistant', 'content': 'Two features available.'},
+        ]
+        rendered = json.dumps(msgs, ensure_ascii=False)
+        b = _compute_role_boundaries(msgs, rendered)
+        assert len(b) == 8
+        roles = [x['role'] for x in b]
+        # Pin that EVERY role-type appears at least once — A4's "missing
+        # user-role" failure mode would surface here as a missing 'user'
+        # entry in the list.
+        assert set(roles) == {'system', 'user', 'assistant', 'tool'}, roles
+        # Boundaries must be monotonically non-overlapping.
+        for prev, curr in zip(b, b[1:]):
+            assert prev['end'] <= curr['start'], (prev, curr)
+
+    def test_compute_role_boundaries_returns_empty_on_empty_input(self):
+        """Defensive: empty input never produces phantom boundaries."""
+        from ai_assistant.views import _compute_role_boundaries
+        assert _compute_role_boundaries([], 'anything') == []
+        assert _compute_role_boundaries(
+            [{'role': 'user', 'content': 'x'}], '') == []
+
+    def test_compute_role_boundaries_survives_unicode_payload(self):
+        """Real chat content carries unicode (Turkish question marks,
+        emojis, math symbols introduced in v2.41.1).  json.dumps with
+        ensure_ascii=False must produce identical bytes on both sides
+        of the boundary computation."""
+        import json
+        from ai_assistant.views import _compute_role_boundaries
+        msgs = [
+            {'role': 'system', 'content': 'You are an assistant.'},
+            {'role': 'user', 'content': 'PSI ≥ 0.25 → significant shift'},
+        ]
+        rendered = json.dumps(msgs, ensure_ascii=False)
+        b = _compute_role_boundaries(msgs, rendered)
+        assert len(b) == 2
+        # The unicode chars must be inside the user slice (not lost to
+        # encoding).
+        user_slice = rendered[b[1]['start']:b[1]['end']]
+        assert '≥' in user_slice
+        assert '→' in user_slice
+
+    def test_describe_context_components_orders_match_message_assembly(self):
+        """The component list must list components in the SAME ORDER
+        they were appended to the messages array in _chat_workflow, so
+        the audit trail matches the wire shape (the C6 detector groups
+        spans by this ordered fingerprint)."""
+        from ai_assistant.views import _describe_context_components
+        # Slim-context + skill + history + user (the most populated path).
+        parts = _describe_context_components(
+            use_tools=True, has_context=False,
+            auto_skill='feature-engineering', has_history=True,
+        )
+        assert parts == [
+            'system_prompt', 'slim_context', 'conversation_history',
+            'skill:feature-engineering', 'user_query',
+        ], parts
+
+    def test_describe_context_components_minimal_path(self):
+        """Stateless chat (no file, no history, no skill) still records
+        system + user."""
+        from ai_assistant.views import _describe_context_components
+        parts = _describe_context_components(
+            use_tools=False, has_context=False,
+            auto_skill=None, has_history=False,
+        )
+        assert parts == ['system_prompt', 'user_query']
+
+    def test_describe_context_components_legacy_full_context_path(self):
+        """When tools aren't available (no cached artifacts) but a
+        context blob was passed, the legacy_full_context channel fires
+        instead of slim_context — pin this so the two paths stay
+        distinguishable in the audit."""
+        from ai_assistant.views import _describe_context_components
+        parts = _describe_context_components(
+            use_tools=False, has_context=True,
+            auto_skill=None, has_history=False,
+        )
+        assert 'legacy_full_context' in parts
+        assert 'slim_context' not in parts
+
+    def test_sum_tool_message_tokens_only_counts_tool_and_assistant(self):
+        """Tool budget = assistant + tool content (system + user are
+        accounted separately).  Verifies the helper does NOT double-count
+        system / user channels into the tool budget."""
+        from ai_assistant.views import _sum_tool_message_tokens
+        msgs = [
+            {'role': 'system', 'content': 'x' * 100},  # should NOT count
+            {'role': 'user', 'content': 'y' * 100},    # should NOT count
+            {'role': 'assistant', 'content': 'z' * 40},
+            {'role': 'tool', 'tool_call_id': 'c1', 'content': 'w' * 40},
+        ]
+        # 40 // 4 = 10 each, total 20.  Anything > 20 means we're
+        # leaking system or user content into the tool budget.
+        assert _sum_tool_message_tokens(msgs) == 20
+
+
+@pytest.mark.unit
+class TestPromptRenderWorkflowWiring:
+    """End-to-end wiring tests: _chat_workflow must invoke prompt_render
+    with the right kwargs and stamp prometa.raw.input on the workflow span.
+
+    We monkeypatch `_call_llm`, `prompt_render`, `set_span_attr`, and the
+    Redis-touching helpers so the test is a pure-function span-attr
+    contract check — no OpenAI network, no engine call, no Redis."""
+
+    def _patch_workflow_environment(self, monkeypatch, captured_attrs, captured_prompt_render):
+        from ai_assistant import views
+
+        def fake_call_llm(messages, model_key, tools=None):
+            return {
+                'choices': [{
+                    'message': {'role': 'assistant', 'content': 'ok'},
+                    'finish_reason': 'stop',
+                }],
+                'usage': {'total_tokens': 10},
+            }
+
+        def fake_set_span_attr(key, value):
+            captured_attrs[key] = value
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_prompt_render(*, template_version=None, raw_rendered_prompt=None):
+            captured_prompt_render['template_version'] = template_version
+            captured_prompt_render['raw_rendered_prompt'] = raw_rendered_prompt
+
+            class _Handle:
+                def assembled(self, **kwargs):
+                    captured_prompt_render['assembled_kwargs'] = kwargs
+            yield _Handle()
+
+        def fake_get_model_config(key):
+            return {
+                'provider': 'openai',
+                'model_id': 'gpt-test',
+                'supports_tools': False,
+                'max_tokens': 1024,
+            }
+
+        monkeypatch.setattr(views, '_call_llm', fake_call_llm)
+        monkeypatch.setattr(views, 'set_span_attr', fake_set_span_attr)
+        monkeypatch.setattr(views, 'prompt_render', fake_prompt_render)
+        monkeypatch.setattr(views, 'get_model_config', fake_get_model_config)
+        monkeypatch.setattr(views, 'cache_list_artifacts', lambda fid: [])
+        monkeypatch.setattr(views, 'set_session_id', lambda *a, **k: None)
+        monkeypatch.setattr(views, 'set_customer_id', lambda *a, **k: None)
+
+    def test_chat_workflow_invokes_prompt_render_with_role_boundaries(self, monkeypatch):
+        from ai_assistant import views
+        attrs, captured_pr = {}, {}
+        self._patch_workflow_environment(monkeypatch, attrs, captured_pr)
+
+        views._chat_workflow(
+            user_message='Explain PSI.',
+            context=None, section='general', history=[],
+            file_id=None, model='gpt-test',
+        )
+
+        # 1. prompt_render must have been invoked with template_version
+        # carrying the system_prompt_variant ('full' for openai provider).
+        assert captured_pr.get('template_version') == 'declarai-chat@full'
+
+        # 2. raw_rendered_prompt must be a valid JSON array containing
+        # BOTH a system role and a user role (the A4 contract).
+        import json as _json
+        rendered = captured_pr.get('raw_rendered_prompt')
+        assert rendered is not None
+        parsed = _json.loads(rendered)
+        roles = [m.get('role') for m in parsed]
+        assert 'system' in roles
+        assert 'user' in roles
+
+        # 3. assembled() must have been called with role_boundaries
+        # listing every role in the rendered prompt.
+        kwargs = captured_pr.get('assembled_kwargs', {})
+        boundaries = kwargs.get('role_boundaries')
+        assert boundaries is not None and len(boundaries) >= 2
+        boundary_roles = [b['role'] for b in boundaries]
+        assert 'system' in boundary_roles
+        assert 'user' in boundary_roles
+
+    def test_chat_workflow_stamps_prometa_raw_input_with_just_user_query(self, monkeypatch):
+        """The contract says prometa.raw.input MUST be the user's
+        latest query alone (not the rendered prompt).  This is what
+        the A4 detector uses to verify userInput !== rendered."""
+        from ai_assistant import views
+        attrs, captured_pr = {}, {}
+        self._patch_workflow_environment(monkeypatch, attrs, captured_pr)
+
+        question = 'What features have high VIF?'
+        views._chat_workflow(
+            user_message=question,
+            context=None, section='general', history=[],
+            file_id=None, model='gpt-test',
+        )
+
+        # prometa.raw.input must equal the user message EXACTLY — not
+        # the rendered prompt, not a snippet, not a prefix.
+        assert attrs.get('prometa.raw.input') == question
+
+        # And it MUST NOT equal raw_rendered_prompt (that would
+        # reproduce the v2.41.x byte-identity bug Prometa flagged).
+        assert attrs.get('prometa.raw.input') != captured_pr.get('raw_rendered_prompt')
+
+    def test_chat_workflow_prompt_render_assembled_carries_context_components(self, monkeypatch):
+        """C6 detector reads prompt.context_components — verify the
+        workflow lists at least system_prompt + user_query for the
+        minimal turn (no file, no history, no skill)."""
+        from ai_assistant import views
+        attrs, captured_pr = {}, {}
+        self._patch_workflow_environment(monkeypatch, attrs, captured_pr)
+
+        views._chat_workflow(
+            user_message='hi',
+            context=None, section='general', history=[],
+            file_id=None, model='gpt-test',
+        )
+
+        kwargs = captured_pr.get('assembled_kwargs', {})
+        components = kwargs.get('context_components')
+        assert components is not None
+        assert 'system_prompt' in components
+        assert 'user_query' in components
+        # The minimal turn has NO slim_context / history / skill —
+        # those entries must be ABSENT, not just empty strings.
+        assert 'slim_context' not in components
+        assert 'conversation_history' not in components
+        assert not any(c.startswith('skill:') for c in components)
+
+
+# ---------------------------------------------------------------------------
+# v2.42.0: prometa-sdk version lock — CI guard
+# ---------------------------------------------------------------------------
+# Catches future Docker-cache / pip-cache drift like the v0.6.0-in-
+# container situation that hid the A4 truncation bug from us.  The pin
+# in requirements.txt (`prometa-sdk==X.Y.Z`) must match the version
+# actually installed in the environment running the tests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProMetaSdkVersionLock:
+    """Defense against installed-vs-pinned drift.
+
+    The bug that motivated v2.42.0 hid for ~24 hours because
+    requirements.txt was pinned to >=0.7.1 but the running container
+    was on v0.6.0 (Docker layer cache wasn't invalidated when the pin
+    was bumped).  This test reads the pin from requirements.txt and
+    asserts the installed prometa.__version__ matches EXACTLY.  Fails
+    fast in CI / pre-commit, including on any environment where pip
+    re-resolves into a newer minor release we haven't verified."""
+
+    def _read_pin(self) -> str:
+        """Return the version literal pinned in requirements.txt.
+
+        Supports the canonical hard-pin form 'prometa-sdk==X.Y.Z'.
+        Any other form (range, no pin) is a deliberate refusal — we
+        want this lock to be obvious to readers.
+        """
+        from pathlib import Path
+        import re
+        backend_dir = Path(__file__).resolve().parent.parent
+        req = (backend_dir / 'requirements.txt').read_text()
+        for line in req.splitlines():
+            line = line.strip()
+            if line.startswith('prometa-sdk'):
+                m = re.match(r'^prometa-sdk==([0-9]+\.[0-9]+\.[0-9]+)\s*$', line)
+                assert m, (
+                    f"prometa-sdk must be HARD-PINNED in requirements.txt "
+                    f"(form: prometa-sdk==X.Y.Z); found: {line!r}"
+                )
+                return m.group(1)
+        raise AssertionError(
+            "prometa-sdk entry not found in requirements.txt — "
+            "the version lock test cannot run without a pin."
+        )
+
+    def test_installed_prometa_sdk_matches_requirements_pin(self):
+        import prometa
+        installed = prometa.__version__
+        pinned = self._read_pin()
+        assert installed == pinned, (
+            f"prometa-sdk version drift detected: installed={installed!r} "
+            f"but requirements.txt pins =={pinned!r}.  Rebuild the "
+            f"backend Docker image with --no-cache or re-run "
+            f"`pip install -r requirements.txt` to align.  This drift "
+            f"is precisely what hid the v2.41.x AML A4 truncation bug "
+            f"from us for ~24h — keep it locked."
+        )
+
+    def test_prompt_render_helper_is_importable_on_pinned_version(self):
+        """The v2.42.0 fix depends on the prompt_render helper that
+        crystallized in prometa-sdk 0.7.x.  If we ever downgrade the
+        pin, this test forces explicit acknowledgement that we'd lose
+        the A4 contract.  Read-only check — does not invoke the helper."""
+        from prometa import prompt_render
+        assert callable(prompt_render), (
+            "prompt_render must be importable; the AML A4 contract "
+            "(prompt.role_boundaries + prometa.raw.rendered_prompt) "
+            "depends on this helper landing in the SDK."
+        )
+
+    def test_raw_channel_helper_is_importable_on_pinned_version(self):
+        """Same logic as above but for the _raw_channel toggle.
+        Without it, prompt_render(raw_rendered_prompt=...) drops the
+        raw kwarg at the SDK boundary and A4 falls back to the
+        truncated gen_ai.prompt — re-introducing the v2.41.x bug."""
+        from prometa import _raw_channel
+        assert callable(_raw_channel.enable)
+        assert callable(_raw_channel.is_enabled)


### PR DESCRIPTION
## TL;DR

Prometa AML's A4 (Prompt Isolation) detector flagged DeclarAI spans `absent` between **May 26 23:02 UTC** and **May 27 01:57 UTC**. Investigation showed our `_chat_workflow` IS emitting properly role-tagged messages — **the regression was in observability, not in the actual LLM call shape.** Fix: adopt prometa-sdk v0.7.1's structured `prompt_render` contract so A4 reads the canonical `prompt.role_boundaries` attribute instead of substring-matching the truncated `gen_ai.prompt`.

## Root cause

prometa-sdk's openai auto-instrumentation populates `gen_ai.prompt` via `safe_json(messages)` + `truncate(..., 32_000)` (see `prometa/integrations/_llm_common.py:MAX_TEXT_ATTR_BYTES`). With v2.21.0's feature-engineering skill body, v2.40.0's slim context, and longer histories with tool-call rounds, the serialized messages JSON routinely exceeds 32 KB.

Because OpenAI's `messages` always leads with the `system` role, the truncation knife lands **after** the leading system prompt but **before** any `role:user` substring — A4 then sees `1 system, 0 user, 0 asst, 0 tool` even on a healthy multi-turn call.

## Two-layer fix

### 1. Adopt prometa-sdk v0.7.1's structured contract (the canonical A4 path)

- **Enable `prometa._raw_channel` at boot** in `prometa_config.get_prometa()` — gates the `prometa.raw.*` attribute family to the short-TTL `spans_raw` channel.
- **Add a safe-no-op `prompt_render` wrapper** (mirrors the existing `workflow / agent / tool` lazy-decorator pattern) so call sites are unconditional even when Prometa is disabled in tests.
- **In `_chat_workflow`** (after the full messages array is assembled), wrap with:

  ```python
  with prompt_render(template_version=..., raw_rendered_prompt=...) as p:
      p.assembled(role_boundaries=..., system_token_count=..., ...)
  ```

  This stamps the structured `prompt.role_boundaries` attribute the A4 detector reads **first** (no string matching needed) plus `prometa.raw.rendered_prompt` (full untruncated blob) for substring fallback.
- **Separately stamp `prometa.raw.input`** = just the user query string so the detector can verify `userInput !== rendered` cleanly.

### 2. Lock the SDK version + add a CI drift guard

- **Hard-pin** `prometa-sdk==0.7.1` in `requirements.txt` (was `>=0.7.1,<0.8` which silently allowed v0.6.0 to persist in the running container — exactly the drift that hid this bug from us for ~24 h).
- **New `TestProMetaSdkVersionLock` class** reads the pin from `requirements.txt` and asserts `prometa.__version__` matches exactly, plus verifies `prompt_render` + `_raw_channel` helpers are importable.

## New pure helpers in `views.py`

| Helper | Purpose |
|---|---|
| `_approx_tokens(text)` | chars / 4 estimate per the SDK convention |
| `_compute_role_boundaries(messages, rendered_json)` | walks messages and returns `[{role, start, end}, ...]` byte ranges; returns `[]` defensively if any slice can't be located |
| `_describe_context_components(...)` | orders match the message assembly order (system_prompt, slim_context \| legacy_full_context, conversation_history, skill:NAME, user_query) |
| `_sum_tool_message_tokens(messages)` | accounting helper for tool + assistant content (NOT system/user) |

## Tests added (15 new specs, all green)

- **9 `TestPromptRenderRoleBoundaryHelpers`** — pure-function specs (boundaries round-trip, unicode payload, ordering, empty defenses)
- **3 `TestPromptRenderWorkflowWiring`** — captured-attribute specs that prove `_chat_workflow` invokes `prompt_render` with role_boundaries AND stamps `prometa.raw.input == user_query` (≠ `raw_rendered_prompt`)
- **3 `TestProMetaSdkVersionLock`** — CI guard against installed-vs-pinned drift; importability of `prompt_render` + `_raw_channel`

## Test gate (DeclarAI Pre-Commit Test Gate auto-ran)

```
🔬 Unit:        572 ✅  (+15 new)
🛡️ Regression:   34 ✅
⚙️ Functional:  111 ✅
🔗 Integration:  14 ✅
👤 UAT:           9 ✅
Frontend (sanity): 375 specs ✅ (no FE changes)
─────────────────────────────────────────────
Backend 740 / Frontend 375 — ALL GREEN
```

## Non-goals (deliberately not done)

- **No structural change to the messages array** — our code already emits proper multi-role messages; the AML team's 'restore role-tagged arrays' recommendation was based on the truncation symptom and doesn't apply once `role_boundaries` is surfaced. Touching the messages shape would risk degrading LLM quality (e.g., moving the skill body `system` → `user` could shift instruction-following behavior).
- **No reduction of messages array size** — brittle, loses information density, and the contract fix makes the cap irrelevant for A4.
- **No change to `gen_ai.prompt` truncation** — that's prometa-sdk internal; v0.7.1 still truncates at 32 KB and that's fine for the Conversation panel (which uses `gen_ai.prompt.user` for the latest user message).

## Risk + rollback

- **Surface:** observability only. No LLM call shape change. No DB schema, no API contract, no data flow change.
- **Frontend:** untouched.
- **Rollback:** revert this PR. The prometa-sdk pin reverts to the previous range; the `prompt_render` block becomes a no-op (the wrapper handles missing SDK). No downstream consumer breaks.

## Verification

After deploy lands, wait **one cron tick (~1 h)** then check the Prometa AML dashboard at the declarai agent URL. A4 should swing from `na` (post-platform-patch) → `present` with concrete evidence like `'10/10 rendered prompts show distinct system + user role boundaries (100%)'`.

Closes the AML A4 misverdict + the prometa-sdk version-drift hygiene gap.