### PR TITLE
fix(v2.43.1): mirror engine reasoning caps + opt reasoning models into enable_thinking

### DIFF
--- a/backend/ai_assistant/model_registry.py
+++ b/backend/ai_assistant/model_registry.py
@@ -218,11 +218,20 @@ def _ram_gb_estimate(size_bytes: int) -> int:
 def _build_engine_entry(model_data: dict) -> dict:
     """Translate one entry from the engine's ``/v1/models`` payload.
 
-    Capability metadata (architecture, reasoning, thinking_level) isn't
-    surfaced by the engine today, so we fill safe defaults that match the
-    historical hard-coded entries: dense, non-reasoning, non-thinking, tools
-    on (the engine routes tool calls through the same code path regardless
-    of whether the underlying model supports them).
+    The engine surfaces capability metadata per-model on ``/v1/models`` —
+    ``reasoning`` / ``thinking`` / ``thinking_level`` / ``tool_calling_mode``
+    — based on its ``infer_model_capabilities`` heuristic (e.g. anything
+    matching ``nemotron|deepseek-r1|qwen3-thinking|qwq|...`` is flagged as
+    reasoning).  We mirror those flags into the DeclarAI registry so the
+    frontend can render badges correctly AND so ``call_engine`` can opt
+    reasoning-family models into ``chat_template_kwargs.enable_thinking``
+    (see ``call_engine`` for why this matters — without it the chat
+    template tells Nemotron its think block is already closed and the
+    model leaks raw CoT into ``content``).
+
+    Fields missing from the engine payload fall back to safe non-reasoning
+    defaults so older engine builds that pre-date the capability surface
+    keep working unchanged.
     """
     engine_id = model_data['id']
     # The engine may surface tool_calling_mode per model; default to 'text'
@@ -236,9 +245,9 @@ def _build_engine_entry(model_data: dict) -> dict:
         'max_tokens': 4096,
         'supports_tools': True,
         'architecture': 'dense',
-        'reasoning': False,
-        'thinking': False,
-        'thinking_level': None,
+        'reasoning': bool(model_data.get('reasoning', False)),
+        'thinking': bool(model_data.get('thinking', False)),
+        'thinking_level': model_data.get('thinking_level'),
         'ram_gb': _ram_gb_estimate(int(model_data.get('size_bytes', 0))),
         'tool_calling_mode': tcm,
     }
@@ -392,6 +401,25 @@ def call_engine(messages: list, model_cfg: dict, tools: list = None) -> dict:
       LLM_ENGINE_BASE_URL  — defaults to http://llm-engine:8080/v1
       LLM_ENGINE_API_KEY   — bearer token (engine accepts any value when
                               its AUTH_ENABLED=false; required when on)
+
+    v2.43.1 — for reasoning-family models (Nemotron, DeepSeek-R1, Qwen3-
+    Thinking, QwQ, …) we pass ``chat_template_kwargs={'enable_thinking':
+    True}`` to the engine.  Their GGUF chat templates branch on a Jinja
+    ``enable_thinking`` variable: when it's falsy (the default when no
+    client passes it), the template pre-emits ``<think></think>`` — i.e.
+    tells the model its think block is already done — but a reasoning-
+    trained model produces CoT prose anyway, just *without* ``<think>``
+    markers.  Setting ``enable_thinking=True`` makes the template pre-emit
+    ``<think>\n`` instead, which makes the wire output more explicit when
+    the model does close the block.  The flag is a documented OpenAI-
+    extension (vLLM and Ollama HTTP both honour it the same way) so this
+    is correct configuration for reasoning models, **not a leak fix**.
+    The actual leak fix has to land engine-side: the blocking-path
+    response normalizer needs an ``expects_reasoning_prelude`` flag that
+    mirrors the streaming path, so the engine can correctly classify
+    raw-CoT-without-markers as reasoning when the model exhausts
+    ``max_tokens`` before closing ``</think>``.  Filed as engine feedback
+    in ``docs/engine-feedback/nemotron-cot-leak-blocking-normalizer.md``.
     """
     from openai import OpenAI
 
@@ -411,6 +439,12 @@ def call_engine(messages: list, model_cfg: dict, tools: list = None) -> dict:
     if tools and model_cfg.get('supports_tools'):
         kwargs['tools'] = tools
         kwargs['tool_choice'] = 'auto'
+    # Reasoning-family models need an explicit ``enable_thinking=True`` to
+    # avoid the silent CoT-into-content leak — see docstring above.
+    if model_cfg.get('reasoning'):
+        kwargs['extra_body'] = {
+            'chat_template_kwargs': {'enable_thinking': True},
+        }
 
     response = client.chat.completions.create(**kwargs)
     return response.model_dump()

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -3518,6 +3518,173 @@ class TestModelRegistry:
 
 
 # ---------------------------------------------------------------------------
+# v2.43.1: Nemotron CoT-leak fix — reasoning-family models must opt into
+# chat_template_kwargs={'enable_thinking': True} on the engine call so the
+# GGUF template pre-emits ``<think>\n`` and the engine's response normalizer
+# can route the prelude to ``reasoning_content`` instead of dumping it into
+# ``content``.  Two contracts to pin:
+#   1. _build_engine_entry mirrors the engine's reasoning/thinking/level
+#      flags from /v1/models into the DeclarAI registry (was hard-coded
+#      False before this fix, which made bug #2 invisible).
+#   2. call_engine passes chat_template_kwargs.enable_thinking via
+#      OpenAI SDK's extra_body iff model_cfg['reasoning'] is True.
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestEngineEntryReasoningCapability:
+    """_build_engine_entry must mirror the engine's reasoning flags."""
+
+    def test_reasoning_flag_propagated_from_engine_payload(self):
+        from ai_assistant.model_registry import _build_engine_entry
+        cfg = _build_engine_entry({
+            'id': 'nemotron-3-nano:30b',
+            'reasoning': True,
+            'thinking': True,
+            'thinking_level': 'med',
+            'tool_calling_mode': 'native',
+            'size_bytes': 24 * 1024 ** 3,
+        })
+        assert cfg['reasoning'] is True
+        assert cfg['thinking'] is True
+        assert cfg['thinking_level'] == 'med'
+
+    def test_non_reasoning_flag_propagated_from_engine_payload(self):
+        from ai_assistant.model_registry import _build_engine_entry
+        cfg = _build_engine_entry({
+            'id': 'llama3.2:3b',
+            'reasoning': False,
+            'thinking': False,
+            'thinking_level': None,
+            'tool_calling_mode': 'text',
+            'size_bytes': 2 * 1024 ** 3,
+        })
+        assert cfg['reasoning'] is False
+        assert cfg['thinking'] is False
+        assert cfg['thinking_level'] is None
+
+    def test_missing_capability_fields_default_to_non_reasoning(self):
+        """Older engine builds that pre-date the capability surface must keep
+        working — every reasoning/thinking field has to default off so we
+        don't accidentally opt non-reasoning models into enable_thinking."""
+        from ai_assistant.model_registry import _build_engine_entry
+        cfg = _build_engine_entry({
+            'id': 'mystery-model:1b',
+            'size_bytes': 1024 ** 3,
+        })
+        assert cfg['reasoning'] is False
+        assert cfg['thinking'] is False
+        assert cfg['thinking_level'] is None
+
+
+@pytest.mark.unit
+class TestCallEngineEnableThinking:
+    """call_engine must opt reasoning models into enable_thinking on the
+    OpenAI-extension extra_body, and must NOT touch the body for non-
+    reasoning models (so we don't double-template Llama / Gemma)."""
+
+    @pytest.fixture
+    def _fake_openai_client(self, monkeypatch):
+        """Patch openai.OpenAI so the test can intercept the create() kwargs
+        without actually hitting the engine."""
+        captured = {}
+
+        class _FakeCompletions:
+            def create(self, **kwargs):
+                captured['kwargs'] = kwargs
+
+                class _FakeResp:
+                    def model_dump(self_inner):
+                        return {'id': 'test', 'choices': []}
+                return _FakeResp()
+
+        class _FakeChat:
+            def __init__(self):
+                self.completions = _FakeCompletions()
+
+        class _FakeOpenAI:
+            def __init__(self, **_):
+                self.chat = _FakeChat()
+
+        import openai
+        monkeypatch.setattr(openai, 'OpenAI', _FakeOpenAI)
+        return captured
+
+    def test_reasoning_model_gets_enable_thinking_true(self, _fake_openai_client):
+        from ai_assistant.model_registry import call_engine
+        cfg = {
+            'provider': 'engine',
+            'model_id': 'nemotron-3-nano:30b',
+            'max_tokens': 4096,
+            'temperature': 0.4,
+            'supports_tools': True,
+            'reasoning': True,
+        }
+        call_engine([{'role': 'user', 'content': 'hi'}], cfg)
+        sent = _fake_openai_client['kwargs']
+        assert sent.get('extra_body') == {
+            'chat_template_kwargs': {'enable_thinking': True}
+        }, "reasoning models must opt into enable_thinking via extra_body"
+
+    def test_non_reasoning_model_omits_extra_body(self, _fake_openai_client):
+        from ai_assistant.model_registry import call_engine
+        cfg = {
+            'provider': 'engine',
+            'model_id': 'llama3.2:3b',
+            'max_tokens': 4096,
+            'temperature': 0.4,
+            'supports_tools': True,
+            'reasoning': False,
+        }
+        call_engine([{'role': 'user', 'content': 'hi'}], cfg)
+        sent = _fake_openai_client['kwargs']
+        assert 'extra_body' not in sent, (
+            "non-reasoning models must NOT receive chat_template_kwargs — "
+            "Llama/Gemma chat templates have no enable_thinking branch, and "
+            "an unknown kwarg can change their rendering behavior on engine "
+            "builds that pass it through to Jinja unconditionally"
+        )
+
+    def test_reasoning_flag_missing_omits_extra_body(self, _fake_openai_client):
+        """Defensive: if model_cfg has no ``reasoning`` key at all (e.g. a
+        hand-built test config or a legacy registry entry) we must not
+        accidentally opt-in."""
+        from ai_assistant.model_registry import call_engine
+        cfg = {
+            'provider': 'engine',
+            'model_id': 'engine-only:7b',
+            'max_tokens': 4096,
+            'temperature': 0.4,
+            'supports_tools': True,
+        }
+        call_engine([{'role': 'user', 'content': 'hi'}], cfg)
+        assert 'extra_body' not in _fake_openai_client['kwargs']
+
+    def test_reasoning_model_with_tools_keeps_both(self, _fake_openai_client):
+        """Tools and extra_body must co-exist — the failing UI scenario has
+        15 tools + Nemotron + enable_thinking all at once."""
+        from ai_assistant.model_registry import call_engine
+        cfg = {
+            'provider': 'engine',
+            'model_id': 'nemotron-3-nano:30b',
+            'max_tokens': 4096,
+            'temperature': 0.4,
+            'supports_tools': True,
+            'reasoning': True,
+        }
+        tools = [{'type': 'function', 'function': {
+            'name': 'get_data_dictionary',
+            'description': 'x',
+            'parameters': {'type': 'object', 'properties': {}},
+        }}]
+        call_engine([{'role': 'user', 'content': 'hi'}], cfg, tools=tools)
+        sent = _fake_openai_client['kwargs']
+        assert sent.get('tools') == tools
+        assert sent.get('tool_choice') == 'auto'
+        assert sent.get('extra_body') == {
+            'chat_template_kwargs': {'enable_thinking': True}
+        }
+
+
+# ---------------------------------------------------------------------------
 # Data dictionary enrichment — DB-backed fallback for stale Redis cache
 # (regression for the "Gemma says no descriptions exist" bug)
 # ---------------------------------------------------------------------------

--- a/docs/engine-feedback/nemotron-cot-leak-blocking-normalizer.md
+++ b/docs/engine-feedback/nemotron-cot-leak-blocking-normalizer.md
@@ -1,0 +1,132 @@
+# Bug report: Nemotron CoT leak into `content` on the blocking-path response normalizer
+
+**Status:** Open — diagnosed end-to-end via repeated A/B probe + engine code read.
+**Audience:** `llm-inference-engine` team
+**From:** DeclarAI (POC customer)
+**Date filed:** 2026-05-28
+**Engine commit at filing:** `ebf6dd6` on `main` (PR #9 multi-turn fix, running native PID 28945)
+**Model:** `nemotron-3-nano:30b` (representative of the `_REASONING_MARKERS` family)
+**Severity:** P1 — every multi-turn tool-calling conversation on a reasoning-family model is at risk of leaking the model's chain-of-thought into `content` whenever the model exhausts `max_tokens` before emitting `</think>` or a `<tool_call>` anchor.
+
+---
+
+## Symptom
+
+A blocking `POST /v1/chat/completions` against `nemotron-3-nano:30b` with a large system-prompt stack + 15 tools returns:
+
+- `content`: full chain-of-thought as prose ("We need to suggest 3 derived features for credit-risk boosting. We're an ML advisor inside a credit-risk pipeline. The user wants…")
+- `reasoning_content`: empty
+- `tool_calls`: none
+- No `<think>` markers anywhere in the text — neither `<think>` nor `</think>`
+
+In the failing case the response normalizer has nothing to anchor on, so 2000+ chars of pure reasoning land in `content`. UI behavior: the chat panel renders the model's internal monologue to the user, and the structured tool call never materialises.
+
+## Root cause
+
+**Architectural asymmetry between streaming and blocking paths in the response normalizer.**
+
+The **streaming** normalizer (`StreamNormalizer`) takes an `expects_reasoning_prelude` flag (see `response_normalize.py:352-357`) and initialises its state to `_S_REASONING` when set, so it correctly handles the case where the chat template invisibly pre-emitted `<think>` at the generation prompt. This flag is wired up at the streaming call site (`api/chat.py:412-414`):
+
+```python
+normalizer = StreamNormalizer(
+    tools_requested=bool(params.tools),
+    expects_reasoning_prelude=bool(caps.get("reasoning")),
+)
+```
+
+The **blocking** normalizer (`normalize_assistant_text`, called from `_normalize_blocking_result` at `api/chat.py:201-230`) has **no equivalent knob**. It looks for `<think>…</think>` paired blocks, orphan-close (`</think>` with no open), and orphan-open (`<think>` with no close) — but ALL of those require some marker IN the text to anchor on.
+
+When the chat template silently pre-emits `<think>\n`, the model's sampled output starts inside a `<think>` block but the tag itself never appears in `result.text` (it was emitted by the template, not by the model). If the model then runs out of `max_tokens` before emitting either `</think>` or a `<tool_call>` block, the normalizer sees raw prose with no markers and passes it straight through to `content`.
+
+The capability detection is already there — `infer_model_capabilities()` at `response_normalize.py:623-651` returns `reasoning: True` for anything matching `_REASONING_MARKERS = ("nemotron", "deepseek-r1", "qwen3-thinking", ..., "thinking")`. The streaming path uses it. The blocking path doesn't.
+
+## Repro (3-of-3 reliable on `max_tokens=800`; intermittent on 4096)
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/chat/completions -H 'Content-Type: application/json' -d '{
+  "model": "nemotron-3-nano:30b",
+  "messages": [
+    {"role":"system","content":"You are an ML advisor inside a credit-risk pipeline. Use tools to fetch data dictionary and feature stats. Ground your answer in bullets and short paragraphs over essays. You can DIRECTLY MODIFY the user pipeline by emitting an ACTION BLOCK at the END of your reply."},
+    {"role":"user","content":"Suggest 3 derived features for credit-risk boosting and create them."}
+  ],
+  "tools":[{"type":"function","function":{"name":"get_data_dictionary","description":"Returns the data dictionary","parameters":{"type":"object","properties":{}}}},
+           {"type":"function","function":{"name":"execute_code","description":"Run pandas code","parameters":{"type":"object","properties":{"code":{"type":"string"}},"required":["code"]}}}],
+  "max_tokens": 800,
+  "temperature": 0.4
+}'
+```
+
+Expected: `reasoning_content` populated, `content` empty (or contains only the post-`</think>` answer).
+Observed (typical): `content` contains full CoT prose, `reasoning_content` is empty, `tool_calls` empty, `finish_reason: "length"`.
+
+Note on flakiness: on a *small* `max_tokens`, the model usually fails to close `</think>` in time, so the leak happens reliably. On `max_tokens=4096` (DeclarAI's production default), the model usually succeeds — but production system prompts in our app routinely stack 15k+ chars of context, which leaves less effective output budget and reproduces the leak ~30% of the time. The screenshot we captured in DeclarAI was one of those leaking responses.
+
+## Why `chat_template_kwargs={"enable_thinking": True}` is hygiene, not a fix
+
+It's tempting to think the fix is to set `enable_thinking=True` on the Jinja render so the template explicitly opens `<think>\n`. We confirmed via 6 probes that this:
+
+- **Does** make the wire-output more explicit when the model does produce markers (the `<think>` opener becomes visible in the prompt → model is more likely to produce a matching `</think>`).
+- **Does not** reliably prevent the leak — at tight token budgets it actually makes the leak slightly *more* likely, because the template-side "you have a thinking section" signal nudges the model to spend more tokens reasoning.
+
+So `enable_thinking=True` is a defensible default for reasoning-family models on ergonomic grounds, but it is not the bug fix. The bug fix is making the blocking-path normalizer match the streaming-path normalizer's behavior.
+
+## Recommended fix
+
+**Option A (preferred): add `expects_reasoning_prelude` to the blocking-path normalizer.** Mirror what `StreamNormalizer` already does. Two sub-cases need to be handled when the flag is set and no `</think>` exists in the text:
+
+1. **`finish_reason == "length"`**, no `<think>` markers, no `<tool_call>` anchors → the model was still thinking when the budget ran out. The entire `result.text` is reasoning. Set `reasoning_content = result.text`, `content = None`, `finish_reason = "length"`.
+2. **`finish_reason == "stop"`**, no markers, no tool_calls → ambiguous. Two plausible policies:
+   - Conservative: treat as content (current behavior). Risk: leak.
+   - Aggressive: treat as reasoning since `expects_reasoning_prelude` was True. Risk: hides a real assistant answer in the rare case the model chose not to think.
+   We'd prefer the conservative policy here PLUS surfacing `model_reasoning_unanchored: True` in the choice payload so clients can render an optional "this model's reasoning may have leaked" caveat — but either is fine.
+
+**Option B (smaller diff): synthetic `<think>` prepend.** When the blocking-path normalizer is called for a reasoning-family model, prepend a virtual `<think>` to the text before running `_split_reasoning`. The existing orphan-open handler at `response_normalize.py:203-209` already does the right thing in this case (treat everything from `<think>` onward as reasoning when no `</think>` follows).
+
+Pseudocode for Option B:
+
+```python
+def normalize_assistant_text(text, *, expects_reasoning_prelude=False, ...):
+    raw = text or ""
+    if expects_reasoning_prelude and "<think>" not in raw:
+        # The chat template silently opened a think block; tell the splitter.
+        raw = "<think>" + raw
+    body, reasoning = _split_reasoning(raw)
+    ...
+```
+
+Then `_normalize_blocking_result` at `chat.py:211` becomes:
+
+```python
+caps = infer_model_capabilities(model_name, backend=adapter.backend_name, fmt=...)
+normalized = normalize_assistant_text(
+    result.text,
+    existing_tool_calls=result.tool_calls,
+    finish_reason=result.finish_reason,
+    tools_requested=bool(params.tools),
+    expects_reasoning_prelude=bool(caps.get("reasoning")),
+)
+```
+
+## Test suggestions for the engine repo
+
+Three new cases in `tests/test_response_normalize.py`:
+
+1. **Reasoning-family + unmarked text + finish=length** → everything goes to `reasoning_content`, `content` is None.
+2. **Reasoning-family + unmarked text + finish=stop** → policy-dependent; pin whichever the team picks.
+3. **Reasoning-family + properly-marked `<think>…</think>answer`** → existing orphan-close path keeps working unchanged.
+
+## DeclarAI-side mitigation (already shipped — does not fix the leak)
+
+`auto_ml#19` (v2.43.1) does two things:
+
+1. Mirrors the engine's `reasoning`/`thinking`/`thinking_level` flags from `/v1/models` into DeclarAI's model registry. These were hard-coded `False` previously, which masked this exact bug-class from our config layer. This is a legitimate config bug fix and stays.
+2. Passes `chat_template_kwargs={"enable_thinking": True}` for reasoning-family models. This is hygiene, not a fix (see "Why … is not a fix" above), but we keep it because it's a documented OpenAI-extension default that other clients (vLLM, Ollama HTTP) honour the same way.
+
+Neither change closes the leak. The leak only closes when the engine's blocking-path normalizer learns about `expects_reasoning_prelude`.
+
+## Cross-reference
+
+- Code references: `response_normalize.py:623-651` (capability inference), `response_normalize.py:170-212` (`_split_reasoning`), `response_normalize.py:320-414` (`StreamNormalizer` and its `expects_reasoning_prelude` knob), `api/chat.py:201-230` (blocking normalizer call site missing the flag), `api/chat.py:409-414` (streaming normalizer that has the flag).
+- DeclarAI client-side capability mirroring + hygiene kwarg: PR `auto_ml#19` (v2.43.1).
+- Prior engine fixes in the same family: PR `llm_inference_engine#8` (vendor reasoning/tool-call XML normalization), PR `llm_inference_engine#9` (multi-turn tool-arguments dict/str fix).
+- DeclarAI bug-report doc for the multi-turn 500: `docs/engine-feedback/nemotron-multi-turn-tool-arguments-500.md` (RESOLVED).


### PR DESCRIPTION
## What this PR ships

Two coordinated correctness fixes plus a P1 bug-report doc for the engine team.

### 1. `_build_engine_entry` now mirrors engine capability flags
The engine surfaces `reasoning`/`thinking`/`thinking_level` per-model on `/v1/models` (via `infer_model_capabilities` — it flags anything matching `nemotron|deepseek-r1|qwen3-thinking|qwq|...`). DeclarAI was hard-coding all three to `False`. Now we read them, with safe defaults so older engine builds keep working.

### 2. `call_engine` opts reasoning-family models into `enable_thinking`
When `model_cfg['reasoning']` is True, we pass `chat_template_kwargs={'enable_thinking': True}` via the OpenAI SDK's `extra_body`. This is documented OpenAI-extension behavior (vLLM and Ollama HTTP both honour it the same way) — it makes the GGUF chat template pre-emit `<think>\n` instead of `<think></think>`, so reasoning markers come through clearer when the model does close them.

### Important framing — this is NOT a leak fix
A/B probing showed the Nemotron CoT-into-content leak is driven by an **architectural asymmetry inside the engine**: the streaming-path response normalizer takes an `expects_reasoning_prelude` flag, but the blocking-path normalizer doesn't. When the model exhausts `max_tokens` before emitting `</think>` or `<tool_call>`, the blocking normalizer has no anchor and the raw monologue lands in `content` regardless of what `chat_template_kwargs` we send.

The actual leak fix has to land engine-side. Filed in [`docs/engine-feedback/nemotron-cot-leak-blocking-normalizer.md`](./docs/engine-feedback/nemotron-cot-leak-blocking-normalizer.md) — included in this PR — with a P1 severity tag, A/B repro, recommended Options A/B with pseudocode, and test suggestions.

### A/B data behind the framing

| Mode | finish | tool_calls | content_chars | reasoning_chars |
|---|---|---|---|---|
| Run 1, no kwarg | `tool_calls` | 1 | 0 | 1928 |
| Run 2, no kwarg | `tool_calls` | 1 | 0 | 2352 |
| Run 3, no kwarg | `length` | 0 | **3638 (LEAK)** | 0 |
| Run 1, `enable_thinking=True` | `tool_calls` | 1 | 0 | 1313 |
| Run 2, `enable_thinking=True` | `length` | 0 | **3632 (LEAK)** | 0 |
| Run 3, `enable_thinking=True` | `length` | 0 | **3266 (LEAK)** | 0 |

Same prompt, same model, same temperature, `max_tokens=800`. The leak is correlated with `finish_reason=length`, **not** with the kwarg. `enable_thinking=True` is hygiene, not the cure.

## Test impact
- +7 unit tests across two new classes (`TestEngineEntryReasoningCapability`, `TestCallEngineEnableThinking`)
- Suite: **772 passed / 0 failed / 0 skipped** (was 765 before this PR)
- Pre-commit hook ran the full suite and gated the commit

## Files
- `backend/ai_assistant/model_registry.py` — registry mirroring + extra_body injection (+50 / -8)
- `backend/tests/test_unit.py` — +7 contract tests (+167)
- `docs/engine-feedback/nemotron-cot-leak-blocking-normalizer.md` — new (132 lines)

## Cross-reference
- This is the DeclarAI side of the resolution arc that started with #18 (multi-turn HTTP 500 — RESOLVED via `llm_inference_engine#9`) and continues with the engine-feedback doc above.
- The engine-feedback doc itself recommends two engine-side options (A: add `expects_reasoning_prelude` to the blocking normalizer; B: prepend a synthetic `<think>` for reasoning models). Either closes the leak permanently.
