### PR TITLE
fix(v2.43.3): prevent engine 500 on multi-turn tool calling (context overflow)

### DIFF
--- a/backend/ai_assistant/views.py
+++ b/backend/ai_assistant/views.py
@@ -1062,6 +1062,34 @@ _TOOL_BUDGET_EXHAUSTED_FALLBACK = (
     "one pipeline step) and I'll answer it directly."
 )
 
+
+def _is_engine_server_error(exc: Exception) -> bool:
+    """True when an LLM call failed with a server-side (5xx) error.
+
+    The local inference engine returns a bare HTTP 500 — rather than a
+    graceful ``context_length_exceeded`` 400 — when the accumulating
+    tool-calling prompt (lite system prompt + slim context + the 15 tool
+    schemas + tool results) crosses a small-context model's window.  The
+    OpenAI SDK surfaces that as ``openai.InternalServerError`` (a subclass
+    of ``APIStatusError`` carrying ``status_code == 500``).
+
+    We detect it structurally — by ``status_code`` / ``status`` >= 500 or
+    the SDK exception class name — so ``_chat_workflow`` can degrade
+    gracefully without importing the openai exception hierarchy into the
+    view layer, and so tests can simulate it with a lightweight stand-in
+    exception that merely carries ``status_code = 500``.
+
+    Client (4xx) and connection/timeout errors return ``False`` so genuine
+    failures keep propagating instead of being silently swallowed.
+    """
+    status = getattr(exc, 'status_code', None)
+    if not isinstance(status, int):
+        status = getattr(exc, 'status', None)
+    if isinstance(status, int):
+        return status >= 500
+    return exc.__class__.__name__ in ('InternalServerError', 'APIError')
+
+
 # ---------------------------------------------------------------------------
 # Skill auto-routing — map user intent to a bundled skill
 # ---------------------------------------------------------------------------
@@ -1273,24 +1301,45 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
         if role in ('user', 'assistant') and content:
             messages.append({'role': role, 'content': content})
 
-    # ── Skill auto-routing (model-agnostic) ──
-    # Native function-callers can hit invoke_skill themselves, but text-mode
-    # models (e.g., Gemma in text tool-calling mode) often skip tool calls.
-    # Detect feature-engineering intent in the user message and pre-load the
-    # skill body so EVERY model sees the playbook before answering.
-    # The skill loader is a @prometa_tool span itself, so the auto-route is
-    # still visible in the trace chain.
+    # ── Skill auto-routing (provider-aware) ──
+    # Detect feature-engineering intent in the user message and, for cloud
+    # models, pre-load the skill body so the model sees the playbook before
+    # answering.  Engine models skip the pre-load (it overflows their small
+    # context window — see below) and instead pull the playbook on demand via
+    # the invoke_skill tool.  The skill loader is a @prometa_tool span itself,
+    # so the auto-route stays visible in the trace chain.
     auto_skill = _auto_route_skill(user_message)
+    skill_injected = False
     if auto_skill:
-        skill_body = _load_skill_traced(auto_skill)
-        messages.append({
-            'role': 'system',
-            'content': (f"The user's question matched the '{auto_skill}' skill — "
-                        f"its playbook has been pre-loaded below.  Ground your "
-                        f"answer in these patterns and cite the relevant section.\n\n"
-                        f"{skill_body}"),
-        })
         set_span_attr('declarai.skill.auto_routed', auto_skill)
+        # v2.43.3: only PRE-LOAD the full skill playbook into the system
+        # prompt for cloud models.  Engine models run on small-context local
+        # GGUFs (e.g. nemotron-3-nano:30b ≈ 8K tokens); stacking the
+        # ~2K-token playbook on top of the lite system prompt, slim context,
+        # and the 15 tool schemas leaves no room for a tool result on the
+        # follow-up turn.  Once the model calls a tool and we append the
+        # result, the prompt crosses the engine's context window and the
+        # engine returns HTTP 500 (it should 400) — which surfaced to users
+        # as "AI Assistant error: Internal Server Error" on every
+        # feature-engineering question (reproduced against nemotron-3-nano:30b
+        # at the exact production prompt sizes).  Engine models pull the same
+        # playbook on demand via the ``invoke_skill`` tool, so guidance is
+        # preserved without the fixed per-turn context cost.  This mirrors the
+        # provider-aware budget split already in ``_choose_system_prompt``
+        # (v2.40.0); cloud models have the window to absorb the pre-load and
+        # keep it.  The engine-side defect (500 instead of a graceful
+        # context_length_exceeded 400) is filed separately as engine feedback.
+        if (model_cfg or {}).get('provider', '') != 'engine':
+            skill_body = _load_skill_traced(auto_skill)
+            messages.append({
+                'role': 'system',
+                'content': (f"The user's question matched the '{auto_skill}' skill — "
+                            f"its playbook has been pre-loaded below.  Ground your "
+                            f"answer in these patterns and cite the relevant section.\n\n"
+                            f"{skill_body}"),
+            })
+            skill_injected = True
+        set_span_attr('declarai.skill.auto_injected', skill_injected)
 
     # Add current user message
     messages.append({'role': 'user', 'content': user_message})
@@ -1328,7 +1377,7 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
             context_components=_describe_context_components(
                 use_tools=use_tools,
                 has_context=bool(context),
-                auto_skill=auto_skill,
+                auto_skill=auto_skill if skill_injected else None,
                 has_history=bool(history),
             ),
         )
@@ -1341,9 +1390,30 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
     # Tool-calling loop (only for models that support function calling)
     tools = PIPELINE_TOOLS if (use_tools and model_cfg.get('supports_tools')) else None
     total_usage = {}
+    msg_obj = {}
 
     for _round in range(_MAX_TOOL_ROUNDS + 1):
-        result = _call_llm(messages, model_key, tools=tools)
+        try:
+            result = _call_llm(messages, model_key, tools=tools)
+        except Exception as exc:
+            # v2.43.3: a small-context engine model returns HTTP 500 (not a
+            # graceful context_length_exceeded 400) once the accumulating
+            # prompt — lite system prompt + slim context + the 15 tool
+            # schemas (~2.3K tokens) + tool results — crosses its window
+            # mid tool-calling.  If we've already gathered tool results,
+            # don't surface a raw "Internal Server Error": break out and let
+            # the synthesis pass below answer from the results in hand.  That
+            # pass calls the model with tools=None, dropping the tool-schema
+            # block that tips the prompt over — verified to fit where the
+            # tools-on call 500s.  Non-5xx errors (and 5xx with no tool work
+            # yet) keep propagating so genuine failures still surface.
+            if _is_engine_server_error(exc) and any(
+                    m.get('role') == 'tool' for m in messages):
+                set_span_attr('declarai.chat.engine_overflow', True)
+                set_span_attr('declarai.chat.engine_overflow_round', _round)
+                set_span_attr('declarai.chat.engine_overflow_error', str(exc)[:200])
+                break
+            raise
         _merge_usage(total_usage, result.get('usage', {}))
 
         choice = result['choices'][0]

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -4113,6 +4113,266 @@ class TestSkillAutoRouting:
 
 
 # ---------------------------------------------------------------------------
+# v2.43.3 — engine context-window overflow on multi-turn tool calling
+# ---------------------------------------------------------------------------
+# Symptom (production): every feature-engineering question to an engine
+# model (nemotron-3-nano:30b, ~8K-token window) returned "AI Assistant
+# error: Internal Server Error".  Root cause: the follow-up tool call's
+# prompt — lite system prompt + slim context + the auto-injected ~2K-token
+# skill playbook + the 15 tool schemas (~2.3K tokens) + the tool result —
+# crossed the model's context window, and the engine returned a bare HTTP
+# 500 (not a graceful context_length_exceeded 400).  Reproduced against the
+# live engine at the exact production prompt sizes.
+#
+# Two-part fix:
+#   1. Provider-aware skill injection — engine models no longer pre-load the
+#      full playbook (they pull it on demand via invoke_skill); cloud models
+#      keep it.  TestSkillAutoInjectionProviderAware pins this.
+#   2. Graceful degradation — if the engine still 5xx's mid tool-loop (e.g.
+#      the model calls both invoke_skill AND get_data_dictionary), drop the
+#      tool schemas and fall through to the synthesis pass instead of
+#      surfacing a raw 500.  TestChatWorkflowEngineOverflowDegrades pins it.
+# ---------------------------------------------------------------------------
+
+
+def _engine_or_cloud_cfg(provider):
+    """Minimal model_cfg matching what get_model_config returns."""
+    return {
+        'provider': provider,
+        'model_id': 'nemotron-3-nano:30b' if provider == 'engine' else 'gpt-5.5',
+        'supports_tools': True,
+        'max_tokens': 4096,
+        'temperature': 0.4,
+    }
+
+
+def _tool_call_response(name='get_data_dictionary', call_id='c1'):
+    """A response that asks for one tool call (content empty — the normal
+    shape for a tool-calling round)."""
+    return {
+        'choices': [{
+            'finish_reason': 'tool_calls',
+            'message': {
+                'role': 'assistant',
+                'content': None,
+                'tool_calls': [{
+                    'id': call_id, 'type': 'function',
+                    'function': {'name': name, 'arguments': '{}'},
+                }],
+            },
+        }],
+        'usage': {'prompt_tokens': 10, 'completion_tokens': 5, 'total_tokens': 15},
+    }
+
+
+def _text_response(text):
+    """A plain final answer (no tool calls, no action blocks)."""
+    return {
+        'choices': [{'finish_reason': 'stop',
+                     'message': {'role': 'assistant', 'content': text}}],
+        'usage': {'prompt_tokens': 8, 'completion_tokens': 4, 'total_tokens': 12},
+    }
+
+
+def _run_chat_workflow(monkeypatch, *, provider, call_llm,
+                       user_message='please derive new features from the existing ones',
+                       file_id=1):
+    """Execute the real _chat_workflow body with its external collaborators
+    mocked.  ``call_llm(idx, messages, tools)`` scripts each LLM round.
+
+    Returns {result, llm_calls, skill_calls} so tests can assert on the
+    response AND on what was sent to the model each round."""
+    from ai_assistant import views
+
+    monkeypatch.setattr(views, 'get_model_config',
+                        lambda k: _engine_or_cloud_cfg(provider))
+    monkeypatch.setattr(views, 'cache_list_artifacts',
+                        lambda fid: ['data_dictionary'])
+    monkeypatch.setattr(views, '_build_slim_context',
+                        lambda fid, sec: 'Pipeline: boosting\nTarget: good/bad flag')
+    monkeypatch.setattr(views, 'execute_tool_call',
+                        lambda fid, name, args: f'TOOL_RESULT[{name}]')
+    # Observability helpers → silent no-ops (they are no-ops under pytest
+    # anyway; pinning them keeps the test independent of SDK state).
+    monkeypatch.setattr(views, 'set_span_attr', lambda *a, **kw: None)
+    monkeypatch.setattr(views, 'set_session_id', lambda *a, **kw: None)
+    monkeypatch.setattr(views, 'set_customer_id', lambda *a, **kw: None)
+    monkeypatch.setattr(views, 'current_span_id', lambda: None)
+
+    skill_calls = []
+
+    def fake_load_skill(name):
+        skill_calls.append(name)
+        return f'SKILL_PLAYBOOK_BODY for {name}'
+    monkeypatch.setattr(views, '_load_skill_traced', fake_load_skill)
+
+    llm_calls = []
+
+    def fake_call_llm(messages, model_key, tools=None):
+        idx = len(llm_calls)
+        llm_calls.append({
+            'messages': [dict(m) for m in messages],
+            'tools': tools,
+            'model_key': model_key,
+        })
+        return call_llm(idx, messages, tools)
+    monkeypatch.setattr(views, '_call_llm', fake_call_llm)
+
+    fn = views._chat_workflow.__wrapped__ \
+        if hasattr(views._chat_workflow, '__wrapped__') else views._chat_workflow
+    result = fn(user_message, {}, 'general', [], file_id=file_id, model='engine-x')
+    return {'result': result, 'llm_calls': llm_calls, 'skill_calls': skill_calls}
+
+
+@pytest.mark.unit
+class TestIsEngineServerError:
+    """_is_engine_server_error gates the graceful-degradation path: True only
+    for server-side 5xx (the engine's context-overflow 500), False for 4xx /
+    connection / timeout / programming errors so genuine failures propagate."""
+
+    def test_status_code_500_is_server_error(self):
+        from ai_assistant.views import _is_engine_server_error
+
+        class E(Exception):
+            status_code = 500
+        assert _is_engine_server_error(E()) is True
+
+    def test_status_code_503_is_server_error(self):
+        from ai_assistant.views import _is_engine_server_error
+
+        class E(Exception):
+            status_code = 503
+        assert _is_engine_server_error(E()) is True
+
+    def test_status_code_400_is_not_server_error(self):
+        from ai_assistant.views import _is_engine_server_error
+
+        class E(Exception):
+            status_code = 400
+        assert _is_engine_server_error(E()) is False
+
+    def test_status_attr_variant_502(self):
+        from ai_assistant.views import _is_engine_server_error
+
+        class E(Exception):
+            status = 502
+        assert _is_engine_server_error(E()) is True
+
+    def test_internalservererror_classname_without_status(self):
+        from ai_assistant.views import _is_engine_server_error
+
+        class InternalServerError(Exception):
+            pass
+        assert _is_engine_server_error(InternalServerError()) is True
+
+    def test_plain_exception_is_not_server_error(self):
+        from ai_assistant.views import _is_engine_server_error
+        assert _is_engine_server_error(ValueError('boom')) is False
+
+    def test_connection_error_classname_is_not_server_error(self):
+        from ai_assistant.views import _is_engine_server_error
+
+        class APIConnectionError(Exception):
+            pass
+        assert _is_engine_server_error(APIConnectionError()) is False
+
+
+@pytest.mark.unit
+class TestSkillAutoInjectionProviderAware:
+    """The FE skill playbook is pre-loaded into the system prompt only for
+    cloud models; engine models skip it (it overflows their small context
+    window) and pull it on demand via the invoke_skill tool."""
+
+    def test_engine_model_does_not_preload_skill_body(self, monkeypatch):
+        out = _run_chat_workflow(
+            monkeypatch, provider='engine',
+            call_llm=lambda idx, messages, tools: _text_response('done'),
+        )
+        # The auto-router still matched (loader would be reachable), but the
+        # body must NOT have been loaded or injected for an engine model.
+        assert out['skill_calls'] == []
+        joined = ' '.join(m.get('content') or '' for m in out['llm_calls'][0]['messages'])
+        assert 'SKILL_PLAYBOOK_BODY' not in joined
+        assert 'playbook has been pre-loaded' not in joined
+
+    def test_cloud_model_preloads_skill_body(self, monkeypatch):
+        out = _run_chat_workflow(
+            monkeypatch, provider='openai',
+            call_llm=lambda idx, messages, tools: _text_response('done'),
+        )
+        assert out['skill_calls'] == ['feature-engineering']
+        joined = ' '.join(m.get('content') or '' for m in out['llm_calls'][0]['messages'])
+        assert 'SKILL_PLAYBOOK_BODY' in joined
+        assert 'playbook has been pre-loaded' in joined
+
+
+@pytest.mark.unit
+class TestChatWorkflowEngineOverflowDegrades:
+    """When the engine 5xx's mid tool-loop (context overflow after tool
+    results accumulate), the workflow degrades to the tools-off synthesis
+    pass and returns an answer — it must never surface a raw 500."""
+
+    def test_overflow_after_tool_work_degrades_to_synthesis(self, monkeypatch):
+        class _ServerErr(Exception):
+            status_code = 500
+
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            if idx == 1:
+                # Follow-up call still carries the 15 tool schemas → overflow.
+                assert tools is not None
+                raise _ServerErr('Internal Server Error')
+            # Synthesis pass: tools dropped, so it fits.
+            assert tools is None
+            return _text_response('Here are 5 derived features: ratio_a_b, ...')
+
+        out = _run_chat_workflow(monkeypatch, provider='engine', call_llm=call_llm)
+        assert out['result']['message'] == 'Here are 5 derived features: ratio_a_b, ...'
+        # round0 tool_calls, round1 overflow (caught), synthesis (tools off).
+        assert len(out['llm_calls']) == 3
+        assert out['llm_calls'][2]['tools'] is None
+
+    def test_non_server_error_propagates(self, monkeypatch):
+        class _ClientErr(Exception):
+            status_code = 400
+
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            raise _ClientErr('bad request')
+
+        with pytest.raises(_ClientErr):
+            _run_chat_workflow(monkeypatch, provider='engine', call_llm=call_llm)
+
+    def test_server_error_before_any_tool_work_propagates(self, monkeypatch):
+        class _ServerErr(Exception):
+            status_code = 500
+
+        def call_llm(idx, messages, tools):
+            raise _ServerErr('Internal Server Error')
+
+        with pytest.raises(_ServerErr):
+            _run_chat_workflow(monkeypatch, provider='engine', call_llm=call_llm)
+
+    def test_synthesis_also_failing_yields_actionable_fallback(self, monkeypatch):
+        from ai_assistant.views import _TOOL_BUDGET_EXHAUSTED_FALLBACK
+
+        class _ServerErr(Exception):
+            status_code = 500
+
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            # Both the follow-up AND the synthesis pass 5xx.
+            raise _ServerErr('Internal Server Error')
+
+        out = _run_chat_workflow(monkeypatch, provider='engine', call_llm=call_llm)
+        # No raw 500 — user sees the budget-exhausted fallback (tool work happened).
+        assert out['result']['message'] == _TOOL_BUDGET_EXHAUSTED_FALLBACK
+
+
+# ---------------------------------------------------------------------------
 # Skill supplementary file access (get_skill_file tool + Skill.read_file)
 # ---------------------------------------------------------------------------
 @pytest.mark.unit


### PR DESCRIPTION
## Problem
Every feature-engineering question on engine models (`nemotron-3-nano:30b`, ~8K-token window) returned `Error: AI Assistant error: Internal Server Error` (HTTP 500).

## Root cause
**Context-window overflow on the follow-up tool turn** — not `reasoning_content`, not response shape, not `max_tokens`. The engine-model stack is: lite system prompt (~1750 tok) + slim context (~600) + auto-injected skill playbook (~2060) + 15 tool schemas (~2300) + tool result. Call 1 fits; appending the tool result on call 2 crosses the window and the engine returns a bare HTTP 500 (instead of a graceful `context_length_exceeded` 400). Reproduced against the live engine at exact production prompt sizes.

## Fix (two parts)
1. **Provider-aware skill injection** — engine models no longer pre-load the full skill playbook into the system prompt (they pull it on demand via `invoke_skill`); cloud models keep the pre-load. Mirrors the v2.40.0 `_choose_system_prompt` budget split.
2. **Graceful degradation** — new `_is_engine_server_error()` helper + `try/except` around the tool-loop call. On a 5xx mid-loop *after* tool work, drop the tool schemas and fall through to the existing tools-off synthesis pass (verified to fit) instead of surfacing a raw 500. Non-5xx errors and 5xx-before-tool-work keep propagating.

## Verification
- **Live**: the exact failing question on `engine-nemotron-3-nano-30b` (file_id 500) now returns **HTTP 200** with a substantive answer (was 500). Logs: call 1 `200` (`get_data_dictionary`), call 2 `200`.
- **Tests**: +13 unit tests (`TestIsEngineServerError`, `TestSkillAutoInjectionProviderAware`, `TestChatWorkflowEngineOverflowDegrades`). Backend **798 passed** (was 785); frontend build + **375 Karma specs** pass.

## Notes
- Backend-only change. The engine returning 500-instead-of-400 on overflow is a separate engine-side defect worth filing as feedback.