### PR TITLE
fix(v2.44.0): stop reasoning-model CoT leak + emit Apply action for proposed code

### DIFF
--- a/backend/ai_assistant/model_registry.py
+++ b/backend/ai_assistant/model_registry.py
@@ -414,6 +414,14 @@ def _recover_reasoning_content(response: dict) -> dict:
     answer.  The original ``reasoning_content`` is preserved on the message
     for any future collapsed-CoT renderer.
 
+    v2.44.0 refinement: we promote ONLY when ``finish_reason == 'stop'`` (a
+    complete answer the engine misrouted).  When ``finish_reason == 'length'``
+    the reasoning_content is UNFINISHED chain-of-thought — the model ran out
+    of budget mid-thought — and promoting it leaks raw CoT to the user.  We
+    leave content empty in that case and tag the choice
+    ``declarai_reasoning_truncated`` so ``_chat_workflow`` runs its
+    finalization pass instead.
+
     Idempotent and defensive: tolerates missing keys / non-dict shapes and
     never raises (a salvage helper must not be able to break the chat path).
     """
@@ -434,14 +442,34 @@ def _recover_reasoning_content(response: dict) -> dict:
         if content and content.strip():
             continue
         reasoning = msg.get('reasoning_content')
-        if isinstance(reasoning, str) and reasoning.strip():
-            msg['content'] = reasoning
-            choice['declarai_reasoning_recovered'] = True
+        if not (isinstance(reasoning, str) and reasoning.strip()):
+            continue
+        # v2.44.0: do NOT promote when the model was cut off mid-thought
+        # (finish_reason == 'length').  In that case reasoning_content holds
+        # UNFINISHED chain-of-thought — not a deliverable answer — and
+        # promoting it leaks raw CoT to the user ("Okay, let's tackle this
+        # problem.  The user wants…", reproduced live as a 15.6 KB monologue).
+        # That was the exact screenshot bug.  Leaving content empty lets
+        # ``_chat_workflow``'s finalization/synthesis pass produce a clean
+        # reply from the tool results instead.  A COMPLETE answer that the
+        # engine merely misrouted into reasoning_content finishes with 'stop'
+        # (the v2.43.2 case) — those we still promote.
+        if choice.get('finish_reason') == 'length':
+            choice['declarai_reasoning_truncated'] = True
             _logger.warning(
-                "Recovered %d chars from reasoning_content into content "
-                "(engine routed an unanchored answer as reasoning).",
+                "Skipped promoting %d chars of truncated reasoning_content "
+                "(finish_reason=length) — unfinished CoT, deferring to the "
+                "finalization pass.",
                 len(reasoning),
             )
+            continue
+        msg['content'] = reasoning
+        choice['declarai_reasoning_recovered'] = True
+        _logger.warning(
+            "Recovered %d chars from reasoning_content into content "
+            "(engine routed an unanchored answer as reasoning).",
+            len(reasoning),
+        )
     return response
 
 

--- a/backend/ai_assistant/views.py
+++ b/backend/ai_assistant/views.py
@@ -1062,6 +1062,39 @@ _TOOL_BUDGET_EXHAUSTED_FALLBACK = (
     "one pipeline step) and I'll answer it directly."
 )
 
+# v2.27.2 synthesis instruction — generic forced final answer used after the
+# tool budget is exhausted with empty content (non-reasoning engine models and
+# the cloud fallback path).
+_SYNTHESIS_PROMPT = (
+    'You executed tool calls but did not produce a final answer.  Using '
+    'ONLY the tool results above plus the pipeline context, write a concise '
+    'reply to the user now.  Do not call any more tools.'
+)
+
+# v2.44.0 finalization instruction — stricter variant for reasoning-family
+# engine models (nemotron-3-nano:30b, deepseek-r1, …) whose draft was unusable:
+# empty after a truncated CoT, raw chain-of-thought prose, or code in the wrong
+# format.  Forbids CoT narration and mandates the <<<ACTION:execute_code>>>
+# block so dataset code renders an Apply button in the chat panel.
+_FINALIZE_PROMPT = (
+    'Your previous draft was NOT a usable reply — it showed internal '
+    'reasoning, was cut off, or used the wrong format.  Write the FINAL '
+    'reply to the user NOW, grounded ONLY in the tool results and pipeline '
+    'context above.  STRICT RULES:\n'
+    '1. Do NOT show your reasoning or planning.  No "okay", "let me", "we '
+    'need to", "first I will" — lead directly with the answer.\n'
+    '2. Be concise: a one-line intro, then a short bullet list or compact '
+    'table.\n'
+    '3. If you propose pandas/numpy code to modify the dataset, you MUST '
+    'emit it as EXACTLY ONE action block at the very end, in THIS exact '
+    'format — no <function=...> tags, no triple-backtick fences:\n'
+    '<<<ACTION:execute_code>>>\n'
+    '{"code": "df[\'Debt_to_Income\'] = df[\'Var_19\'] / df[\'Var_24\']'
+    '.replace(0, 1)", "description": "Create Debt-to-Income ratio"}\n'
+    '<<<END_ACTION>>>\n'
+    '4. Use REAL column names from the context.  Do NOT call any tools.'
+)
+
 
 def _is_engine_server_error(exc: Exception) -> bool:
     """True when an LLM call failed with a server-side (5xx) error.
@@ -1455,7 +1488,14 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
     # Extract final response
     assistant_message = msg_obj.get('content', '') or ''
 
-    # ── v2.27.2 synthesis pass ──────────────────────────────────────────
+    # ── v2.44.0 engine reply normalization ──────────────────────────────
+    # Before deciding on a finalization pass, clean the raw engine reply:
+    # strip <think> CoT markers and convert vendor <function=execute_code>
+    # XML (and drop other leaked tool-call XML) so the chat panel can render
+    # an Apply button.  No-op for cloud (provider='openai') replies.
+    assistant_message = _normalize_engine_reply(assistant_message, model_cfg)
+
+    # ── v2.27.2 synthesis / v2.44.0 finalization pass ───────────────────
     # Pre-v2.27.2 the loop could exit with an assistant message that has
     # `tool_calls` populated but `content=null`.  This happened when the
     # model kept calling tools through round 5 (the no-tools forced
@@ -1474,8 +1514,22 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
     # error, model returns blank), `_TOOL_BUDGET_EXHAUSTED_FALLBACK`
     # ensures the user sees an actionable message instead of a blank
     # bubble.
+    #
+    # v2.44.0: reasoning-family engine models (nemotron, …) ALSO need this
+    # pass when the reply reads as raw chain-of-thought even though it's
+    # non-empty (finish_reason='stop' but the model narrated its plan
+    # instead of answering — the reproduced run2/run4 failure modes).  For
+    # those we re-prompt with `_FINALIZE_PROMPT`, which forbids CoT and
+    # mandates the action-block format for code; the no-tools call also
+    # drops the ~2.3K-token tool schemas, freeing budget for a clean reply.
+    is_engine_reasoning = (
+        (model_cfg or {}).get('provider') == 'engine'
+        and bool((model_cfg or {}).get('reasoning'))
+    )
+    cot_leaked = is_engine_reasoning and _looks_like_cot_leak(assistant_message)
+    set_span_attr('declarai.chat.cot_leak_detected', cot_leaked)
     synthesis_required = (
-        not assistant_message.strip()
+        (not assistant_message.strip() or cot_leaked)
         and any(m.get('role') == 'tool' for m in messages)
     )
     set_span_attr('declarai.chat.synthesis_pass', synthesis_required)
@@ -1483,17 +1537,18 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
         try:
             messages.append({
                 'role': 'system',
-                'content': (
-                    'You executed tool calls but did not produce a final '
-                    'answer.  Using ONLY the tool results above plus the '
-                    'pipeline context, write a concise reply to the user '
-                    'now.  Do not call any more tools.'
-                ),
+                'content': _FINALIZE_PROMPT if is_engine_reasoning else _SYNTHESIS_PROMPT,
             })
             synth = _call_llm(messages, model_key, tools=None)
             _merge_usage(total_usage, synth.get('usage', {}))
             synth_msg = synth.get('choices', [{}])[0].get('message', {}) or {}
-            assistant_message = synth_msg.get('content', '') or ''
+            new_message = _normalize_engine_reply(
+                synth_msg.get('content', '') or '', model_cfg)
+            # If the finalization STILL reads as raw CoT, blank it so the
+            # actionable fallback copy shows instead of leaked reasoning.
+            if is_engine_reasoning and _looks_like_cot_leak(new_message):
+                new_message = ''
+            assistant_message = new_message
             set_span_attr(
                 'declarai.chat.synthesis_chars',
                 len(assistant_message),
@@ -1501,6 +1556,14 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
         except Exception as exc:  # pragma: no cover - network path
             set_span_attr('declarai.chat.synthesis_error', str(exc)[:200])
             assistant_message = ''
+
+    # v2.44.0: last-line safety net — if a reasoning model's reply is STILL
+    # raw CoT here (e.g. a no-tool-work turn that skipped the finalization
+    # pass, or finalization failed), blank it so the empty-response fallback
+    # shows instead of leaking the model's internal monologue to the user.
+    if is_engine_reasoning and _looks_like_cot_leak(assistant_message):
+        set_span_attr('declarai.chat.cot_leak_blanked', True)
+        assistant_message = ''
 
     # Cost, tokens, and conversation turns are handled by auto-instrumentation (v0.3.3+).
     # The Conversation panel reads gen_ai.prompt.user (pre-extracted by the SDK) and
@@ -1735,6 +1798,122 @@ class AIActionExecuteView(APIView):
             return Response(result, status=http_status)
         finally:
             prometa_flush()
+
+
+# ---------------------------------------------------------------------------
+# v2.44.0: engine reply normalization + chain-of-thought leak detection
+# ---------------------------------------------------------------------------
+# Reasoning-family engine models (nemotron-3-nano:30b, deepseek-r1, …) have
+# three recurring failure modes on the final-answer turn, all reproduced
+# against the live engine:
+#   (a) truncated CoT promoted into content — handled upstream in
+#       model_registry._recover_reasoning_content (no promote on
+#       finish_reason='length');
+#   (b) a FINISHED reply that is still raw CoT prose ("Okay, let's tackle…");
+#   (c) code emitted as vendor tool-call XML (<function=execute_code>…) or bare
+#       markdown fences instead of the <<<ACTION:execute_code>>> block the
+#       chat panel turns into an Apply button.
+# These helpers clean (c) deterministically and detect (b) so _chat_workflow
+# can re-prompt with a strict finalization instruction.  All are no-ops for
+# cloud (provider='openai') replies, which already follow the contract.
+
+_THINK_BLOCK_RE = _re.compile(r'<think\b[^>]*>.*?</think\s*>', _re.DOTALL | _re.IGNORECASE)
+_THINK_ORPHAN_OPEN_RE = _re.compile(r'<think\b[^>]*>.*$', _re.DOTALL | _re.IGNORECASE)
+_THINK_CLOSE_RE = _re.compile(r'</think\s*>', _re.IGNORECASE)
+_VENDOR_EXEC_FN_RE = _re.compile(
+    r'<function\s*=\s*execute_code\s*>(.*?)</function\s*>',
+    _re.DOTALL | _re.IGNORECASE,
+)
+_VENDOR_CODE_PARAM_RE = _re.compile(
+    r'<parameter\s*=\s*code\s*>(.*?)</parameter\s*>',
+    _re.DOTALL | _re.IGNORECASE,
+)
+_VENDOR_FN_ANY_RE = _re.compile(r'<function\b[^>]*>.*?</function\s*>', _re.DOTALL | _re.IGNORECASE)
+_VENDOR_FN_TRUNC_RE = _re.compile(r'<function\b[^>]*>.*$', _re.DOTALL | _re.IGNORECASE)
+# Thinking-aloud openers a polished answer would never start with.
+_COT_OPENER_RE = _re.compile(
+    r'\s*(?:okay\b|ok\b|alright\b|all right\b|so,|now,|hmm\b|well,|let me\b|'
+    r'let\'s\b|let us\b|first,|first i\b|i need to\b|i\'ll\b|i will\b|'
+    r'we need to\b|we should\b|we can\b|we\'ll\b|we have to\b|'
+    r'the user (?:wants|is asking|asked|needs)\b|'
+    r'to (?:answer|solve|tackle) this\b)',
+    _re.IGNORECASE,
+)
+
+
+def _strip_reasoning_markers(text: str) -> str:
+    """Remove ``<think>…</think>`` reasoning blocks from an engine reply."""
+    if not text or ('<think' not in text.lower() and '</think>' not in text.lower()):
+        return text
+    s = _THINK_BLOCK_RE.sub('', text)
+    # Orphan close (reasoning prelude then the answer): keep only the tail.
+    if _THINK_CLOSE_RE.search(s):
+        s = _THINK_CLOSE_RE.split(s)[-1]
+    # Orphan open (truncated CoT, never closed): drop from <think> onward.
+    s = _THINK_ORPHAN_OPEN_RE.sub('', s)
+    return s.strip()
+
+
+def _convert_vendor_tool_xml_to_actions(text: str) -> str:
+    """Convert a model-emitted ``<function=execute_code>`` tool-call into the
+    ``<<<ACTION:execute_code>>>`` block the chat panel renders as an Apply
+    button.
+
+    Weak engine models sometimes emit code as vendor function-call XML
+    (``<function=execute_code><parameter=code>…</parameter></function>``)
+    instead of the DeclarAI action-block format.  Since execute_code is a
+    DeclarAI action — not an engine tool — that XML can NEVER become a real
+    tool_call; without this conversion the user just sees raw XML and gets no
+    Apply button.  Other (real engine-tool) function-call leaks are stripped
+    by ``_normalize_engine_reply``.
+    """
+    if not text or '<function' not in text.lower():
+        return text
+
+    def _repl(match):
+        inner = match.group(1) or ''
+        pm = _VENDOR_CODE_PARAM_RE.search(inner)
+        code = (pm.group(1) if pm else inner)
+        # Drop any stray param/function tags if the wrapper was malformed.
+        code = _re.sub(r'</?(?:parameter|function)\b[^>]*>', '', code).strip()
+        if not code:
+            return ''
+        payload = json.dumps({
+            'code': code,
+            'description': 'Run the proposed pandas transformation',
+        })
+        return f'\n\n<<<ACTION:execute_code>>>\n{payload}\n<<<END_ACTION>>>'
+
+    return _VENDOR_EXEC_FN_RE.sub(_repl, text)
+
+
+def _normalize_engine_reply(text: str, model_cfg: dict) -> str:
+    """Clean a raw engine reply before action extraction (no-op for cloud).
+
+    Strips ``<think>`` reasoning markers, converts ``<function=execute_code>``
+    XML into a proper action block, and drops any other leaked vendor
+    function-call XML (real tool-call attempts the engine failed to parse).
+    """
+    if (model_cfg or {}).get('provider') != 'engine' or not text:
+        return text
+    text = _strip_reasoning_markers(text)
+    text = _convert_vendor_tool_xml_to_actions(text)
+    text = _VENDOR_FN_ANY_RE.sub('', text)
+    text = _VENDOR_FN_TRUNC_RE.sub('', text)
+    return text.strip()
+
+
+def _looks_like_cot_leak(text: str) -> bool:
+    """True when an engine reply reads as raw chain-of-thought, not an answer.
+
+    Conservative: only fires when the text OPENS with a thinking-aloud marker
+    ("Okay, let's…", "We need to…", "The user wants…") AND carries no action
+    block.  A polished final answer leads with the result, not a plan, so this
+    rarely misfires on a good reply.
+    """
+    if not text or '<<<ACTION' in text:
+        return False
+    return bool(_COT_OPENER_RE.match(text.lstrip()[:200]))
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -3774,15 +3774,32 @@ class TestRecoverReasoningContent:
         out = _recover_reasoning_content(self._resp(content=''))
         assert out['choices'][0]['message']['content'] == ''
 
-    def test_finish_reason_irrelevant_matches_aggressive_policy(self):
-        """The engine routes to reasoning_content regardless of finish_reason
-        (both 'stop' and 'length'); recovery must fire for either."""
+    def test_promotes_on_stop_skips_on_length(self):
+        """v2.44.0 contract refinement (supersedes the v2.43.2 'promote
+        regardless of finish_reason' policy): a COMPLETE answer the engine
+        misrouted into reasoning_content finishes with 'stop' and IS promoted;
+        an UNFINISHED chain-of-thought finishes with 'length' and must NOT be
+        promoted — promoting it leaks raw CoT to the user (the reproduced
+        screenshot bug).  The length case is tagged
+        ``declarai_reasoning_truncated`` and left for the finalization pass."""
         from ai_assistant.model_registry import _recover_reasoning_content
-        for fr in ('stop', 'length'):
-            out = _recover_reasoning_content(
-                self._resp(content='', reasoning='ans', finish_reason=fr)
-            )
-            assert out['choices'][0]['message']['content'] == 'ans', fr
+        # stop → promote (complete answer misrouted to reasoning_content)
+        out = _recover_reasoning_content(
+            self._resp(content='', reasoning='ans', finish_reason='stop')
+        )
+        assert out['choices'][0]['message']['content'] == 'ans'
+        assert out['choices'][0].get('declarai_reasoning_recovered') is True
+        # length → skip (truncated CoT); content stays empty + tagged truncated
+        out2 = _recover_reasoning_content(
+            self._resp(content='', reasoning='Okay, let me think…',
+                       finish_reason='length')
+        )
+        msg2 = out2['choices'][0]['message']
+        assert msg2['content'] == ''  # NOT promoted
+        assert 'declarai_reasoning_recovered' not in out2['choices'][0]
+        assert out2['choices'][0].get('declarai_reasoning_truncated') is True
+        # original reasoning preserved for any future collapsed-CoT renderer
+        assert msg2['reasoning_content'] == 'Okay, let me think…'
 
     def test_idempotent(self):
         from ai_assistant.model_registry import _recover_reasoning_content
@@ -4135,7 +4152,7 @@ class TestSkillAutoRouting:
 # ---------------------------------------------------------------------------
 
 
-def _engine_or_cloud_cfg(provider):
+def _engine_or_cloud_cfg(provider, reasoning=False):
     """Minimal model_cfg matching what get_model_config returns."""
     return {
         'provider': provider,
@@ -4143,6 +4160,7 @@ def _engine_or_cloud_cfg(provider):
         'supports_tools': True,
         'max_tokens': 4096,
         'temperature': 0.4,
+        'reasoning': reasoning,
     }
 
 
@@ -4176,7 +4194,7 @@ def _text_response(text):
 
 def _run_chat_workflow(monkeypatch, *, provider, call_llm,
                        user_message='please derive new features from the existing ones',
-                       file_id=1):
+                       file_id=1, reasoning=False):
     """Execute the real _chat_workflow body with its external collaborators
     mocked.  ``call_llm(idx, messages, tools)`` scripts each LLM round.
 
@@ -4185,7 +4203,7 @@ def _run_chat_workflow(monkeypatch, *, provider, call_llm,
     from ai_assistant import views
 
     monkeypatch.setattr(views, 'get_model_config',
-                        lambda k: _engine_or_cloud_cfg(provider))
+                        lambda k: _engine_or_cloud_cfg(provider, reasoning))
     monkeypatch.setattr(views, 'cache_list_artifacts',
                         lambda fid: ['data_dictionary'])
     monkeypatch.setattr(views, '_build_slim_context',
@@ -4370,6 +4388,223 @@ class TestChatWorkflowEngineOverflowDegrades:
         out = _run_chat_workflow(monkeypatch, provider='engine', call_llm=call_llm)
         # No raw 500 — user sees the budget-exhausted fallback (tool work happened).
         assert out['result']['message'] == _TOOL_BUDGET_EXHAUSTED_FALLBACK
+
+
+# ---------------------------------------------------------------------------
+# v2.44.0: engine reply normalization + CoT-leak detection helpers.
+#
+# Reasoning-family engine models (nemotron-3-nano:30b, …) leak chain-of-thought
+# into content and emit code in the wrong format (vendor <function=...> XML or
+# bare markdown fences) instead of the <<<ACTION:execute_code>>> block the chat
+# panel renders as an Apply button.  These helpers clean that up.
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestEngineReplyNormalization:
+    """_strip_reasoning_markers / _convert_vendor_tool_xml_to_actions /
+    _normalize_engine_reply / _looks_like_cot_leak."""
+
+    def test_strip_paired_think_block(self):
+        from ai_assistant.views import _strip_reasoning_markers
+        assert _strip_reasoning_markers('<think>plan</think>The answer.') == 'The answer.'
+        assert _strip_reasoning_markers('A.<think>plan</think>') == 'A.'
+
+    def test_strip_orphan_close(self):
+        from ai_assistant.views import _strip_reasoning_markers
+        # reasoning prelude then answer, only the close tag present
+        assert _strip_reasoning_markers('reasoning prose</think>The answer.') == 'The answer.'
+
+    def test_strip_orphan_open_truncated(self):
+        from ai_assistant.views import _strip_reasoning_markers
+        # truncated CoT — open tag, never closed → drop from <think> on
+        assert _strip_reasoning_markers('Answer.<think>still thinking') == 'Answer.'
+        assert _strip_reasoning_markers('<think>only thinking, no answer') == ''
+
+    def test_strip_noop_without_markers(self):
+        from ai_assistant.views import _strip_reasoning_markers
+        assert _strip_reasoning_markers('Plain answer.') == 'Plain answer.'
+
+    def test_vendor_exec_xml_becomes_action_block(self):
+        from ai_assistant.views import (
+            _convert_vendor_tool_xml_to_actions, _extract_actions,
+        )
+        raw = ("Here is the code:\n<function=execute_code>\n"
+               "<parameter=code>\ndf['X'] = df['A'] / df['B']\n"
+               "</parameter>\n</function>")
+        out = _convert_vendor_tool_xml_to_actions(raw)
+        assert '<<<ACTION:execute_code>>>' in out
+        actions, clean = _extract_actions(out)
+        assert len(actions) == 1
+        assert actions[0]['type'] == 'execute_code'
+        assert actions[0]['payload']['code'] == "df['X'] = df['A'] / df['B']"
+        assert 'Here is the code:' in clean
+
+    def test_vendor_exec_xml_without_param_wrapper(self):
+        from ai_assistant.views import _convert_vendor_tool_xml_to_actions
+        raw = "<function=execute_code>df['Y'] = 2</function>"
+        out = _convert_vendor_tool_xml_to_actions(raw)
+        assert '<<<ACTION:execute_code>>>' in out
+        assert "df['Y'] = 2" in out
+
+    def test_vendor_conversion_noop_without_function_tag(self):
+        from ai_assistant.views import _convert_vendor_tool_xml_to_actions
+        assert _convert_vendor_tool_xml_to_actions('no tags here') == 'no tags here'
+
+    def test_normalize_is_noop_for_cloud(self):
+        from ai_assistant.views import _normalize_engine_reply
+        raw = '<think>cot</think>answer'
+        # provider='openai' → untouched even though markers are present
+        assert _normalize_engine_reply(raw, {'provider': 'openai'}) == raw
+
+    def test_normalize_engine_strips_and_converts(self):
+        from ai_assistant.views import _normalize_engine_reply, _extract_actions
+        raw = ("<think>deciding</think>Create a ratio.\n"
+               "<function=execute_code><parameter=code>df['R']=df['A']/df['B']"
+               "</parameter></function>")
+        out = _normalize_engine_reply(raw, {'provider': 'engine'})
+        assert '<think>' not in out
+        actions, clean = _extract_actions(out)
+        assert actions and actions[0]['payload']['code'] == "df['R']=df['A']/df['B']"
+        assert 'Create a ratio.' in clean
+
+    def test_normalize_drops_leaked_non_exec_function_xml(self):
+        from ai_assistant.views import _normalize_engine_reply
+        raw = 'Summary text.\n<function=get_feature_stats>\n</function>'
+        out = _normalize_engine_reply(raw, {'provider': 'engine'})
+        assert '<function' not in out
+        assert out == 'Summary text.'
+
+    def test_cot_leak_detected_on_thinking_openers(self):
+        from ai_assistant.views import _looks_like_cot_leak
+        assert _looks_like_cot_leak("Okay, let's tackle this. The user wants…")
+        assert _looks_like_cot_leak('We need to derive several features first.')
+        assert _looks_like_cot_leak('The user wants new columns.')
+        assert _looks_like_cot_leak('Let me think about which ratios help.')
+
+    def test_cot_leak_not_flagged_for_clean_answer(self):
+        from ai_assistant.views import _looks_like_cot_leak
+        assert not _looks_like_cot_leak('**Proposed features**\n- Debt_to_Income')
+        assert not _looks_like_cot_leak('Here are 5 derived features you can add.')
+        assert not _looks_like_cot_leak('')
+
+    def test_cot_leak_ignored_when_action_block_present(self):
+        from ai_assistant.views import _looks_like_cot_leak
+        # Even with a CoT opener, an action block makes the reply usable.
+        assert not _looks_like_cot_leak(
+            "Okay, here.\n<<<ACTION:execute_code>>>\n{}\n<<<END_ACTION>>>")
+
+
+@pytest.mark.unit
+class TestChatWorkflowFinalization:
+    """v2.44.0: reasoning-family engine models get a strict finalization
+    re-prompt when their reply is raw CoT, and vendor-XML code is converted
+    to an Apply action without an extra LLM call."""
+
+    def test_cot_leak_triggers_finalization_reprompt(self, monkeypatch):
+        from ai_assistant.views import _FINALIZE_PROMPT
+
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            if idx == 1:
+                # Finished reply that is raw chain-of-thought (finish=stop).
+                return _text_response("Okay, let's tackle this. We need to "
+                                      "derive ratios from the columns.")
+            # Finalization pass: tools dropped, strict prompt appended.
+            assert tools is None
+            return _text_response('**Derived features**\n- Debt_to_Income')
+
+        out = _run_chat_workflow(monkeypatch, provider='engine',
+                                 reasoning=True, call_llm=call_llm)
+        assert out['result']['message'] == '**Derived features**\n- Debt_to_Income'
+        assert len(out['llm_calls']) == 3
+        # The strict finalization instruction was the one appended.
+        finalize_msgs = [m for m in out['llm_calls'][2]['messages']
+                         if m.get('content') == _FINALIZE_PROMPT]
+        assert finalize_msgs, 'finalization prompt not sent'
+
+    def test_vendor_xml_code_becomes_apply_action_no_extra_call(self, monkeypatch):
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            return _text_response(
+                "Create a debt-to-income ratio:\n<function=execute_code>\n"
+                "<parameter=code>\ndf['DTI'] = df['Var_19'] / df['Var_24']\n"
+                "</parameter>\n</function>")
+
+        out = _run_chat_workflow(monkeypatch, provider='engine',
+                                 reasoning=True, call_llm=call_llm)
+        # No finalization round needed — deterministic conversion handled it.
+        assert len(out['llm_calls']) == 2
+        actions = out['result'].get('actions') or []
+        assert len(actions) == 1
+        assert actions[0]['type'] == 'execute_code'
+        assert actions[0]['payload']['code'] == "df['DTI'] = df['Var_19'] / df['Var_24']"
+        assert 'debt-to-income' in out['result']['message'].lower()
+
+    def test_clean_reply_with_action_passes_through(self, monkeypatch):
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            return _text_response(
+                '**Features**\n- DTI\n\n<<<ACTION:execute_code>>>\n'
+                '{"code": "df[\'DTI\']=df[\'A\']/df[\'B\']", "description": "DTI"}\n'
+                '<<<END_ACTION>>>')
+
+        out = _run_chat_workflow(monkeypatch, provider='engine',
+                                 reasoning=True, call_llm=call_llm)
+        # Clean answer + action → no finalization re-prompt.
+        assert len(out['llm_calls']) == 2
+        assert out['result']['message'] == '**Features**\n- DTI'
+        assert out['result']['actions'][0]['type'] == 'execute_code'
+
+    def test_finalization_still_leaking_yields_fallback(self, monkeypatch):
+        from ai_assistant.views import _TOOL_BUDGET_EXHAUSTED_FALLBACK
+
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            if idx == 1:
+                return _text_response('We need to think harder about this.')
+            # Finalization ALSO leaks CoT → blanked → fallback copy shown.
+            return _text_response('Okay, let me reconsider the columns.')
+
+        out = _run_chat_workflow(monkeypatch, provider='engine',
+                                 reasoning=True, call_llm=call_llm)
+        assert out['result']['message'] == _TOOL_BUDGET_EXHAUSTED_FALLBACK
+        assert len(out['llm_calls']) == 3
+
+    def test_cloud_cot_opener_not_finalized(self, monkeypatch):
+        # A cloud model reply that happens to open with "Okay," must NOT be
+        # treated as a leak (normalization + finalization are engine-only).
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            return _text_response("Okay, here's the analysis you asked for.")
+
+        out = _run_chat_workflow(monkeypatch, provider='openai',
+                                 call_llm=call_llm)
+        assert out['result']['message'] == "Okay, here's the analysis you asked for."
+        assert len(out['llm_calls']) == 2
+
+    def test_non_reasoning_engine_uses_generic_synthesis_on_empty(self, monkeypatch):
+        # A non-reasoning engine model with empty final content still gets the
+        # generic synthesis pass (not the strict reasoning finalizer).
+        from ai_assistant.views import _SYNTHESIS_PROMPT
+
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            if idx == 1:
+                return _text_response('')  # empty → synthesis required
+            assert tools is None
+            return _text_response('Here is the summary.')
+
+        out = _run_chat_workflow(monkeypatch, provider='engine',
+                                 reasoning=False, call_llm=call_llm)
+        assert out['result']['message'] == 'Here is the summary.'
+        synth_msgs = [m for m in out['llm_calls'][2]['messages']
+                      if m.get('content') == _SYNTHESIS_PROMPT]
+        assert synth_msgs, 'generic synthesis prompt not sent'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
Reasoning-family engine models (nemotron-3-nano:30b) failed on the final-answer turn in two ways, reproduced live ~30% of the time:
1. **Raw chain-of-thought leaked to the chat panel** — e.g. *"Okay, let's tackle this. The user wants…"*.
2. **No Apply button** — when the model proposed dataset code it came as vendor `<function=execute_code>` XML / bare fences instead of the `<<<ACTION:execute_code>>>` block.

## Root cause
- `v2.43.2`'s `_recover_reasoning_content` promoted `reasoning_content` → `content` **regardless of `finish_reason`**. On `finish_reason=='length'` that promoted **unfinished CoT** straight to the user.
- `execute_code` is a DeclarAI action, not an engine tool, so vendor function-call XML could never become a real `tool_call` — the user just saw raw XML with no Apply button.

## Fix
- **`model_registry._recover_reasoning_content`** — promote **only on `finish_reason=='stop'`** (a complete misrouted answer); on `'length'` leave content empty + tag `declarai_reasoning_truncated` so the workflow finalizes instead.
- **`views`** — new helpers `_strip_reasoning_markers`, `_convert_vendor_tool_xml_to_actions`, `_normalize_engine_reply`, `_looks_like_cot_leak` (all no-ops for cloud `provider='openai'`).
- **`views._chat_workflow`** — normalize the engine reply, then run a strict **finalization re-prompt** (`_FINALIZE_PROMPT`) when the draft is empty or reads as raw CoT; forbids narration and mandates the action-block format. Last-line safety net blanks residual CoT so the actionable fallback shows.

## Tests
- Updated the `v2.43.2` `finish_reason` contract test (`stop` promotes / `length` skips).
- Added `TestEngineReplyNormalization` (12) + `TestChatWorkflowFinalization` (6).
- **Pre-commit gate: 817 passed** across unit/regression/functional/integration/UAT.

## Live verification (Nemotron, the exact failing question)
**12/12 runs clean** — no CoT leak, no vendor XML, an `execute_code` Apply action every time:
```
Suggested derived features:
- Debt_to_Income: ratio of outstanding overdraft balance (Var_19) to monthly net income (Var_24)
- Income_to_Limit: ratio of monthly...
```

## Scope
Engine reasoning models only; cloud (GPT) and non-reasoning engine (Gemma) paths are untouched (verified by `test_normalize_is_noop_for_cloud` and `test_cloud_cot_opener_not_finalized`).