### PR TITLE
fix(v2.44.1): elaborate engine code-only replies with feature rationale

### DIFF
--- a/backend/ai_assistant/views.py
+++ b/backend/ai_assistant/views.py
@@ -714,8 +714,12 @@ asking a generic conceptual question with no pipeline-specific reference
 
 ═══ ACTIONABLE OPERATIONS ═══
 You can DIRECTLY MODIFY the user's pipeline by emitting an ACTION BLOCK at
-the END of your reply.  Always use REAL column names.  Briefly explain
-WHAT and WHY first, then emit the block.
+the END of your reply.  Always use REAL column names.  Put your explanation
+in the VISIBLE answer, NEVER in hidden reasoning: lead with WHAT you propose
+and WHY.  When you create or transform features, FIRST write a one-line intro
+and a markdown table — Feature | Formula | Meaning | Why it helps the model,
+one row per feature — THEN emit the action block.  A bare code block with no
+explanation is NOT acceptable.
 
 ─── execute_code ───  Run pandas/numpy on `df` (no imports; only pd, np).
 <<<ACTION:execute_code>>>
@@ -1073,26 +1077,32 @@ _SYNTHESIS_PROMPT = (
 
 # v2.44.0 finalization instruction — stricter variant for reasoning-family
 # engine models (nemotron-3-nano:30b, deepseek-r1, …) whose draft was unusable:
-# empty after a truncated CoT, raw chain-of-thought prose, or code in the wrong
-# format.  Forbids CoT narration and mandates the <<<ACTION:execute_code>>>
-# block so dataset code renders an Apply button in the chat panel.
+# empty after a truncated CoT, raw chain-of-thought prose, code in the wrong
+# format, OR (v2.44.1) a bare code block with no explanation because the
+# rationale was buried in chain-of-thought.  Forbids CoT narration, REQUIRES a
+# user-facing explanation, and mandates the <<<ACTION:execute_code>>> block so
+# dataset code renders an Apply button in the chat panel.
 _FINALIZE_PROMPT = (
     'Your previous draft was NOT a usable reply — it showed internal '
-    'reasoning, was cut off, or used the wrong format.  Write the FINAL '
-    'reply to the user NOW, grounded ONLY in the tool results and pipeline '
-    'context above.  STRICT RULES:\n'
-    '1. Do NOT show your reasoning or planning.  No "okay", "let me", "we '
-    'need to", "first I will" — lead directly with the answer.\n'
-    '2. Be concise: a one-line intro, then a short bullet list or compact '
-    'table.\n'
-    '3. If you propose pandas/numpy code to modify the dataset, you MUST '
-    'emit it as EXACTLY ONE action block at the very end, in THIS exact '
-    'format — no <function=...> tags, no triple-backtick fences:\n'
+    'reasoning, was cut off, used the wrong format, OR proposed code with no '
+    'explanation.  Write the FINAL reply to the user NOW, grounded ONLY in '
+    'the tool results and pipeline context above.  STRICT RULES:\n'
+    '1. Do NOT show your private reasoning or planning.  No "okay", "let me", '
+    '"we need to", "first I will" — lead directly with the answer.\n'
+    '2. EXPLAIN your proposal so the user understands it — never reply with '
+    'code alone.  When you create or transform features, give a one-line '
+    'intro, THEN a markdown table with these columns: Feature | Formula / '
+    'transformation | Meaning | Why it helps the model.  One row per feature, '
+    'using the REAL column names and numbers from the context.\n'
+    '3. If you propose pandas/numpy code to modify the dataset, you MUST emit '
+    'it as EXACTLY ONE action block at the very end, in THIS exact format — '
+    'no <function=...> tags, no triple-backtick fences, and NO import '
+    'statements (pd and np are already available):\n'
     '<<<ACTION:execute_code>>>\n'
     '{"code": "df[\'Debt_to_Income\'] = df[\'Var_19\'] / df[\'Var_24\']'
     '.replace(0, 1)", "description": "Create Debt-to-Income ratio"}\n'
     '<<<END_ACTION>>>\n'
-    '4. Use REAL column names from the context.  Do NOT call any tools.'
+    '4. Do NOT call any tools.'
 )
 
 
@@ -1527,14 +1537,30 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
         and bool((model_cfg or {}).get('reasoning'))
     )
     cot_leaked = is_engine_reasoning and _looks_like_cot_leak(assistant_message)
+    # v2.44.1: a reasoning model that buries its rationale in chain-of-thought
+    # (which we strip) and emits ONLY an execute_code action block — the user
+    # gets an Apply button with no explanation of what the new features mean or
+    # why they help.  Elaborate via the same finalization pass so the answer
+    # reads like the cloud models do (intro + feature table + Apply).
+    code_only = is_engine_reasoning and _is_code_only_reply(assistant_message)
     set_span_attr('declarai.chat.cot_leak_detected', cot_leaked)
+    set_span_attr('declarai.chat.code_only_reply', code_only)
     synthesis_required = (
         (not assistant_message.strip() or cot_leaked)
         and any(m.get('role') == 'tool' for m in messages)
-    )
+    ) or code_only
     set_span_attr('declarai.chat.synthesis_pass', synthesis_required)
     if synthesis_required:
+        # Preserve the original action block(s) so an elaboration pass that
+        # forgets to re-emit the code can't strip the user's Apply button.
+        preserved_actions = (
+            _ACTION_BLOCK_RE.findall(assistant_message) if code_only else []
+        )
         try:
+            # For a code-only reply, show the model its own proposed code so the
+            # elaboration explains THOSE exact features rather than a fresh set.
+            if code_only:
+                messages.append({'role': 'assistant', 'content': assistant_message})
             messages.append({
                 'role': 'system',
                 'content': _FINALIZE_PROMPT if is_engine_reasoning else _SYNTHESIS_PROMPT,
@@ -1548,6 +1574,16 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
             # actionable fallback copy shows instead of leaked reasoning.
             if is_engine_reasoning and _looks_like_cot_leak(new_message):
                 new_message = ''
+            # If elaboration produced an explanation but dropped the action,
+            # re-attach the original block(s) so Apply still renders.
+            if (preserved_actions and new_message.strip()
+                    and not _HAS_ACTION_RE.search(new_message)):
+                new_message = (new_message.rstrip() + '\n\n'
+                               + '\n\n'.join(preserved_actions))
+            # Never downgrade a working code-only reply to empty — if
+            # elaboration failed, keep the original (functional) action block.
+            if code_only and not new_message.strip():
+                new_message = assistant_message
             assistant_message = new_message
             set_span_attr(
                 'declarai.chat.synthesis_chars',
@@ -1555,7 +1591,10 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
             )
         except Exception as exc:  # pragma: no cover - network path
             set_span_attr('declarai.chat.synthesis_error', str(exc)[:200])
-            assistant_message = ''
+            # Preserve a functional code-only reply on failure; only the
+            # genuinely empty / CoT-leak paths fall through to the fallback.
+            if not code_only:
+                assistant_message = ''
 
     # v2.44.0: last-line safety net — if a reasoning model's reply is STILL
     # raw CoT here (e.g. a no-tool-work turn that skipped the finalization
@@ -1914,6 +1953,48 @@ def _looks_like_cot_leak(text: str) -> bool:
     if not text or '<<<ACTION' in text:
         return False
     return bool(_COT_OPENER_RE.match(text.lstrip()[:200]))
+
+
+# Full <<<ACTION:…>>>…<<<END_ACTION>>> block (any type), tolerant of 2-3
+# brackets — used to size the explanatory prose around an action and to
+# re-attach the original block if an elaboration pass drops it.
+_ACTION_BLOCK_RE = _re.compile(
+    r'<{2,3}\s*ACTION\s*:\s*\w+\s*>{2,3}.*?<{2,3}\s*/?\s*END_ACTION\s*>{2,3}',
+    _re.DOTALL | _re.IGNORECASE,
+)
+# Opening delimiter only — cheap "does this reply contain an action?" check.
+_HAS_ACTION_RE = _re.compile(r'<{2,3}\s*ACTION\s*:', _re.IGNORECASE)
+# execute_code specifically — feature creation / dataset transformations.  We
+# only run the rationale-elaboration pass for these (not config/start actions,
+# whose one-line confirmations don't need a feature table).
+_EXEC_ACTION_RE = _re.compile(r'<{2,3}\s*ACTION\s*:\s*execute_code\s*>{2,3}', _re.IGNORECASE)
+# Minimum words of explanatory prose (excluding any action block) we expect
+# alongside a proposed code action.  Below this, a reasoning-family model has
+# almost certainly buried its rationale in chain-of-thought and emitted code
+# only — the user sees an Apply button with no explanation.
+_MIN_RATIONALE_WORDS = 25
+
+
+def _prose_without_actions(text: str) -> str:
+    """Return *text* with any ``<<<ACTION>>>`` blocks removed (for prose sizing)."""
+    if not text:
+        return ''
+    return _ACTION_BLOCK_RE.sub('', text).strip()
+
+
+def _is_code_only_reply(text: str) -> bool:
+    """True when a reply proposes ``execute_code`` but barely explains it.
+
+    Reasoning-family engine models sometimes route the entire rationale into
+    chain-of-thought (which we strip) and emit only the ``execute_code`` action
+    block.  The user then gets an Apply button with no explanation of WHAT the
+    new features mean or WHY they help — the exact complaint this guards
+    against.  Scoped to ``execute_code`` so config/start confirmations (which
+    legitimately need only a one-liner) never trigger an elaboration pass.
+    """
+    if not text or not _EXEC_ACTION_RE.search(text):
+        return False
+    return len(_prose_without_actions(text).split()) < _MIN_RATIONALE_WORDS
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -4492,6 +4492,45 @@ class TestEngineReplyNormalization:
         assert not _looks_like_cot_leak(
             "Okay, here.\n<<<ACTION:execute_code>>>\n{}\n<<<END_ACTION>>>")
 
+    # ── v2.44.1: code-only / thin-rationale detection ──────────────────
+    def test_prose_without_actions_strips_block(self):
+        from ai_assistant.views import _prose_without_actions
+        txt = ('Intro line.\n<<<ACTION:execute_code>>>\n{"code": "df[\'X\']=1"}\n'
+               '<<<END_ACTION>>>\nTrailing note.')
+        out = _prose_without_actions(txt)
+        assert '<<<ACTION' not in out
+        assert 'Intro line.' in out and 'Trailing note.' in out
+
+    def test_code_only_true_for_bare_exec_action(self):
+        from ai_assistant.views import _is_code_only_reply
+        # An execute_code block with no surrounding explanation.
+        assert _is_code_only_reply(
+            '<<<ACTION:execute_code>>>\n'
+            '{"code": "df[\'DTI\']=df[\'A\']/df[\'B\']", "description": "DTI"}\n'
+            '<<<END_ACTION>>>')
+        # A one-line intro is still too thin to count as a rationale.
+        assert _is_code_only_reply(
+            'Here is the code:\n<<<ACTION:execute_code>>>\n'
+            '{"code": "df[\'X\']=1"}\n<<<END_ACTION>>>')
+
+    def test_code_only_false_when_well_explained(self):
+        from ai_assistant.views import _is_code_only_reply
+        rich = ('The debt-to-income ratio divides committed debt by income to '
+                'capture repayment burden, a classic credit-risk signal that '
+                'helps the boosting model rank applicants by default risk more '
+                'reliably across the whole population.')
+        assert not _is_code_only_reply(
+            rich + '\n<<<ACTION:execute_code>>>\n{"code": "df[\'X\']=1"}\n<<<END_ACTION>>>')
+
+    def test_code_only_false_without_exec_action(self):
+        from ai_assistant.views import _is_code_only_reply
+        # No execute_code at all → never a code-only reply.
+        assert not _is_code_only_reply('Just a plain text answer with no code.')
+        # A config action (not execute_code) is a one-liner by design.
+        assert not _is_code_only_reply(
+            'Dropping Var_3.\n<<<ACTION:update_config>>>\n'
+            '{"updates": []}\n<<<END_ACTION>>>')
+
 
 @pytest.mark.unit
 class TestChatWorkflowFinalization:
@@ -4527,13 +4566,19 @@ class TestChatWorkflowFinalization:
             if idx == 0:
                 return _tool_call_response('get_data_dictionary')
             return _text_response(
-                "Create a debt-to-income ratio:\n<function=execute_code>\n"
+                "The debt-to-income ratio measures how much of a borrower's "
+                "monthly income is already committed to debt, computed as "
+                "Var_19 divided by Var_24. Higher values signal greater "
+                "repayment strain and correlate strongly with default risk, "
+                "making it a powerful predictor for the boosting model.\n"
+                "<function=execute_code>\n"
                 "<parameter=code>\ndf['DTI'] = df['Var_19'] / df['Var_24']\n"
                 "</parameter>\n</function>")
 
         out = _run_chat_workflow(monkeypatch, provider='engine',
                                  reasoning=True, call_llm=call_llm)
-        # No finalization round needed — deterministic conversion handled it.
+        # No finalization round needed — deterministic conversion handled it,
+        # and the substantial explanation means no rationale-elaboration pass.
         assert len(out['llm_calls']) == 2
         actions = out['result'].get('actions') or []
         assert len(actions) == 1
@@ -4542,19 +4587,24 @@ class TestChatWorkflowFinalization:
         assert 'debt-to-income' in out['result']['message'].lower()
 
     def test_clean_reply_with_action_passes_through(self, monkeypatch):
+        rich = ('The debt-to-income ratio (DTI) divides total debt by income '
+                'to capture repayment burden — a classic credit-risk signal '
+                'that helps the boosting model separate good applicants from '
+                'bad ones more cleanly across the population.')
+
         def call_llm(idx, messages, tools):
             if idx == 0:
                 return _tool_call_response('get_data_dictionary')
             return _text_response(
-                '**Features**\n- DTI\n\n<<<ACTION:execute_code>>>\n'
+                rich + '\n\n<<<ACTION:execute_code>>>\n'
                 '{"code": "df[\'DTI\']=df[\'A\']/df[\'B\']", "description": "DTI"}\n'
                 '<<<END_ACTION>>>')
 
         out = _run_chat_workflow(monkeypatch, provider='engine',
                                  reasoning=True, call_llm=call_llm)
-        # Clean answer + action → no finalization re-prompt.
+        # Clean, well-explained answer + action → no finalization re-prompt.
         assert len(out['llm_calls']) == 2
-        assert out['result']['message'] == '**Features**\n- DTI'
+        assert out['result']['message'] == rich
         assert out['result']['actions'][0]['type'] == 'execute_code'
 
     def test_finalization_still_leaking_yields_fallback(self, monkeypatch):
@@ -4605,6 +4655,113 @@ class TestChatWorkflowFinalization:
         synth_msgs = [m for m in out['llm_calls'][2]['messages']
                       if m.get('content') == _SYNTHESIS_PROMPT]
         assert synth_msgs, 'generic synthesis prompt not sent'
+
+
+@pytest.mark.unit
+class TestChatWorkflowCodeOnlyElaboration:
+    """v2.44.1: a reasoning-family engine model that emits ONLY an execute_code
+    action (rationale lost to chain-of-thought) gets an elaboration pass so the
+    user sees an explanation alongside the Apply button — matching the cloud
+    models' behaviour."""
+
+    _BARE = ('<<<ACTION:execute_code>>>\n'
+             '{"code": "df[\'DTI\']=df[\'Var_19\']/df[\'Var_24\']", '
+             '"description": "DTI"}\n<<<END_ACTION>>>')
+
+    def test_code_only_reply_triggers_elaboration(self, monkeypatch):
+        from ai_assistant.views import _FINALIZE_PROMPT
+        rationale = ('The debt-to-income ratio captures repayment burden and '
+                     'is a strong default predictor for boosting models, '
+                     'computed from Var_19 over Var_24 across all applicants.')
+
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            if idx == 1:
+                return _text_response(self._BARE)  # code only, no rationale
+            # Elaboration pass: tools dropped, strict finalize prompt appended.
+            assert tools is None
+            return _text_response(rationale + '\n\n' + self._BARE)
+
+        out = _run_chat_workflow(monkeypatch, provider='engine',
+                                 reasoning=True, call_llm=call_llm)
+        assert len(out['llm_calls']) == 3
+        # Strict finalize prompt was sent, and the model's OWN draft was shown
+        # back to it so the explanation matches the proposed code.
+        final_msgs = out['llm_calls'][2]['messages']
+        assert any(m.get('content') == _FINALIZE_PROMPT for m in final_msgs)
+        assert any(m.get('role') == 'assistant' and 'execute_code' in (m.get('content') or '')
+                   for m in final_msgs)
+        # User now sees the rationale AND keeps the Apply action.
+        assert 'repayment burden' in out['result']['message']
+        assert out['result']['actions'][0]['type'] == 'execute_code'
+
+    def test_elaboration_dropped_action_is_reattached(self, monkeypatch):
+        rationale = ('Debt-to-income measures how committed a borrower already '
+                     'is, a classic credit-risk signal that sharpens the '
+                     'boosting model ranking across good and bad applicants.')
+
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            if idx == 1:
+                return _text_response(self._BARE)
+            # Elaboration explains but FORGETS to re-emit the action block.
+            return _text_response(rationale)
+
+        out = _run_chat_workflow(monkeypatch, provider='engine',
+                                 reasoning=True, call_llm=call_llm)
+        # Original action re-attached so Apply still renders.
+        assert 'repayment' in out['result']['message'] or 'credit-risk' in out['result']['message']
+        actions = out['result'].get('actions') or []
+        assert len(actions) == 1
+        assert actions[0]['type'] == 'execute_code'
+        assert actions[0]['payload']['code'] == "df['DTI']=df['Var_19']/df['Var_24']"
+
+    def test_elaboration_empty_preserves_original_code(self, monkeypatch):
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            if idx == 1:
+                return _text_response(self._BARE)
+            return _text_response('')  # elaboration produced nothing usable
+
+        out = _run_chat_workflow(monkeypatch, provider='engine',
+                                 reasoning=True, call_llm=call_llm)
+        # Functional code is never downgraded to empty — Apply survives.
+        actions = out['result'].get('actions') or []
+        assert len(actions) == 1
+        assert actions[0]['type'] == 'execute_code'
+        assert out['result']['message'].strip()  # generic synthesized copy
+
+    def test_config_action_not_elaborated(self, monkeypatch):
+        # A thin reply whose action is update_config (not execute_code) must
+        # NOT trigger an elaboration pass — confirmations are one-liners.
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            return _text_response(
+                'Dropping Var_3.\n<<<ACTION:update_config>>>\n'
+                '{"updates": [{"key": "feature_usage", "column": "Var_3", '
+                '"value": "drop"}]}\n<<<END_ACTION>>>')
+
+        out = _run_chat_workflow(monkeypatch, provider='engine',
+                                 reasoning=True, call_llm=call_llm)
+        assert len(out['llm_calls']) == 2  # no elaboration
+        assert out['result']['actions'][0]['type'] == 'update_config'
+
+    def test_non_reasoning_engine_code_only_not_elaborated(self, monkeypatch):
+        # code-only elaboration is reasoning-family only; a non-reasoning
+        # engine model's bare action passes through untouched.
+        def call_llm(idx, messages, tools):
+            if idx == 0:
+                return _tool_call_response('get_data_dictionary')
+            return _text_response(self._BARE)
+
+        out = _run_chat_workflow(monkeypatch, provider='engine',
+                                 reasoning=False, call_llm=call_llm)
+        assert len(out['llm_calls']) == 2  # no elaboration
+        assert out['result']['actions'][0]['type'] == 'execute_code'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
Reasoning-family engine models (`nemotron-3-nano:30b`) intermittently route their entire rationale into chain-of-thought (which we strip to prevent CoT leaks) and emit **only** an `<<<ACTION:execute_code>>>` block. The user then sees an Apply button with no explanation of what the new features mean or why they help — unlike the cloud models, which always explain.

Reproduced as intermittent on the live engine (same 53-feature dataset, file 502): most runs narrate a rich rationale, but some emit code only.

## Fix
- **New detector** `_is_code_only_reply` — flags an `execute_code` reply with <25 words of prose (rationale lost to CoT). Scoped to `execute_code` only, so config/start confirmations stay one-liners.
- **Broadened finalization trigger** in `_chat_workflow` — a code-only reply now runs an elaboration pass that shows the model its own draft and re-prompts. Safety rails: re-attaches the original action if the pass drops it; never downgrades working code to empty.
- **`_FINALIZE_PROMPT` rewritten** — requires an intro + `Feature | Formula | Meaning | Why it helps` table, forbids code-only replies, bans `import` statements in action code.
- **Lite system prompt** — reasoning models told to put explanations in the visible answer, never hidden reasoning.

## Tests
- +9 unit tests (4 helper, 5 end-to-end elaboration paths).
- Full pre-commit gate green: **826 tests** across unit/regression/functional/integration/UAT.
- **Live**: 6/6 nemotron-3-nano:30b runs now return a rationale table + Apply action, 0 code-only.

Follow-on to #23 (v2.44.0).