### PR TITLE
fix(v2.44.2): mitigate Nemotron topic drift + file engine 8k-truncation issue

### DIFF
--- a/backend/ai_assistant/views.py
+++ b/backend/ai_assistant/views.py
@@ -1082,27 +1082,67 @@ _SYNTHESIS_PROMPT = (
 # rationale was buried in chain-of-thought.  Forbids CoT narration, REQUIRES a
 # user-facing explanation, and mandates the <<<ACTION:execute_code>>> block so
 # dataset code renders an Apply button in the chat panel.
+# v2.44.2: rule #1 + the generic action-block example below were added to
+# stop the prompt itself from seeding the WRONG topic.  The prior wording
+# led with feature-table guidance and a concrete ``Debt_to_Income`` example,
+# which — on the tools-off fallback after an overflow, with a prior
+# feature-engineering turn still in history — biased reasoning models into
+# regenerating that feature table instead of answering the user's actual
+# (e.g. data-purification) question.  The feature-table format is now
+# explicitly CONDITIONAL on the user having asked for features.
 _FINALIZE_PROMPT = (
     'Your previous draft was NOT a usable reply — it showed internal '
     'reasoning, was cut off, used the wrong format, OR proposed code with no '
-    'explanation.  Write the FINAL reply to the user NOW, grounded ONLY in '
-    'the tool results and pipeline context above.  STRICT RULES:\n'
-    '1. Do NOT show your private reasoning or planning.  No "okay", "let me", '
+    'explanation.  Write the FINAL reply to the user NOW, answering their '
+    'MOST RECENT question, grounded ONLY in the tool results and pipeline '
+    'context above.  STRICT RULES:\n'
+    '1. Answer the CURRENT question directly.  Do NOT continue, repeat, or '
+    'reuse the format of a previous turn\'s topic unless the user explicitly '
+    'asked you to.\n'
+    '2. Do NOT show your private reasoning or planning.  No "okay", "let me", '
     '"we need to", "first I will" — lead directly with the answer.\n'
-    '2. EXPLAIN your proposal so the user understands it — never reply with '
-    'code alone.  When you create or transform features, give a one-line '
-    'intro, THEN a markdown table with these columns: Feature | Formula / '
-    'transformation | Meaning | Why it helps the model.  One row per feature, '
-    'using the REAL column names and numbers from the context.\n'
-    '3. If you propose pandas/numpy code to modify the dataset, you MUST emit '
+    '3. EXPLAIN your proposal so the user understands it — never reply with '
+    'code alone.  ONLY when the user asked you to create or transform '
+    'features, give a one-line intro THEN a markdown table with columns: '
+    'Feature | Formula / transformation | Meaning | Why it helps the model '
+    '(one row per feature, REAL column names).  For any other question, use '
+    'whatever format best fits that question.\n'
+    '4. If you propose pandas/numpy code to modify the dataset, you MUST emit '
     'it as EXACTLY ONE action block at the very end, in THIS exact format — '
     'no <function=...> tags, no triple-backtick fences, and NO import '
     'statements (pd and np are already available):\n'
     '<<<ACTION:execute_code>>>\n'
-    '{"code": "df[\'Debt_to_Income\'] = df[\'Var_19\'] / df[\'Var_24\']'
-    '.replace(0, 1)", "description": "Create Debt-to-Income ratio"}\n'
+    '{"code": "df[\'new_column\'] = df[\'Var_19\'] / df[\'Var_24\']'
+    '.replace(0, 1)", "description": "Short description of the operation"}\n'
     '<<<END_ACTION>>>\n'
-    '4. Do NOT call any tools.'
+    '5. Do NOT call any tools.'
+)
+
+# v2.44.2 — per-turn topic anchor.  Reasoning-family engine models on a small
+# context window occasionally anchor on the PREVIOUS turn (e.g. a
+# just-created feature table) and answer THAT topic instead of the current
+# question — reproduced from a screenshot where a data-purification question
+# was answered with the prior turn's derived-features table.  When earlier
+# turns exist, inject this short instruction immediately before the user
+# message so the model treats the current question as standalone.  Cheap
+# (~50 tokens) and provider-agnostic; a no-op for the first turn and harmless
+# for cloud models that don't drift.
+#
+# v2.44.3 — reword to kill a literal-mirroring failure.  The prior phrasing
+# "Answer the user's NEXT message AS A STANDALONE QUESTION" was parsed by
+# nemotron-3-nano:30b as an instruction to PRODUCE a standalone question, so it
+# echoed the user's prompt back reframed as a question (e.g. "what are the
+# purification steps … how to sort/configure them?" → "Which purification
+# steps should be prioritized …?") instead of answering — reproduced from a
+# screenshot.  The anchor now states the next message IS a question and the
+# model must ANSWER it, explicitly forbidding echoing it back or replying with
+# a question of its own.
+_TURN_FOCUS_PROMPT = (
+    'The user\'s NEXT message is a NEW, self-contained question about the '
+    'CURRENT pipeline step.  ANSWER it directly with concrete analysis.  Do '
+    'NOT restate, rephrase, or echo the question back, and NEVER reply with a '
+    'question of your own.  Do NOT continue, repeat, or reuse the format of '
+    'the previous turn\'s topic unless the user explicitly refers back to it.'
 )
 
 
@@ -1383,6 +1423,17 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
             })
             skill_injected = True
         set_span_attr('declarai.skill.auto_injected', skill_injected)
+
+    # ── v2.44.2: per-turn topic anchor ─────────────────────────────────
+    # When prior turns are present, re-anchor the model on the current
+    # question right before it (see _TURN_FOCUS_PROMPT).  Skipped on the
+    # first turn — there's no previous topic to drift toward.  ``has_history``
+    # is stamped so a recurrence of the topic-drift screenshot is filterable
+    # in the trace (inspect prometa.raw.rendered_prompt + the completion).
+    set_span_attr('declarai.chat.has_history', bool(history))
+    if history:
+        messages.append({'role': 'system', 'content': _TURN_FOCUS_PROMPT})
+        set_span_attr('declarai.chat.turn_focus_injected', True)
 
     # Add current user message
     messages.append({'role': 'user', 'content': user_message})

--- a/backend/scripts/probe_topic_drift.py
+++ b/backend/scripts/probe_topic_drift.py
@@ -1,0 +1,103 @@
+"""Repro probe: does Nemotron answer the data-purification question, or drift
+back to the previous feature-engineering topic when that turn is in history?
+
+Run from host:  python3 backend/scripts/probe_topic_drift.py
+"""
+import json
+import sys
+import urllib.request
+
+URL = "http://localhost:8001/api/ai-assistant/chat/"
+
+PRIOR_FEATURE_ANSWER = (
+    "Proposed derived features to boost predictive performance:\n\n"
+    "| Feature | Formula / transformation | Meaning | Why it helps the model |\n"
+    "|---|---|---|---|\n"
+    "| Debt_To_Income | Var_19 / Var_24 | Ratio of outstanding overdraft balance to monthly net income | Normalizes exposure by ability to pay |\n"
+    "| Credit_Utilization | Var_19 / (Var_4 + 1) | Outstanding balance divided by previous credit limit | Strong credit-risk signal |\n"
+    "| Income_Verification_Diff | Var_30 - Var_28 | Difference between verified income and declared net income | Flags income inconsistency |\n"
+    "| Income_Verification_Ratio | Var_30 / Var_28 | Ratio of verified to declared net income | Scale-invariant inconsistency |\n"
+    "| Legal_Action_Count | Var_3 + Var_11 + Var_37 | Count of legal-action flags across multiple sources | Aggregates sparse red flags |\n"
+    "| App_Velocity_1m_6m | Var_8 / (Var_9 + 1) | Short-term vs long-term application velocity | Captures credit-seeking intensity |\n"
+    "| Total_Recent_Applications | Var_8 + Var_9 + Var_10 | Sum of recent applications | Recent demand for credit |\n"
+    "| OD_Utilization | Var_19 / (Var_20 + 1) | Overdraft utilization | Utilization-style risk signal |\n"
+    "\nThe following action will create these engineered columns directly in the dataset."
+)
+
+CONTEXT = {
+    "pipeline_config": {
+        "target_definition": "good/bad flag of credit applications within the 12 months period of its usage",
+        "pipeline_type": "boosting",
+        "purifier_options": [1, 2, 3, 4, 7, 11, 17, 23, 28, 32],
+    },
+    "selected_features": [
+        "FE_Debt_To_Income", "FE_Credit_Utilization", "FE_Income_Verification_Diff",
+        "FE_Income_Verification_Ratio", "FE_Legal_Action_Count", "FE_App_Velocity_1m_6m",
+        "FE_Total_Recent_Applications", "FE_OD_Utilization",
+    ],
+}
+
+HISTORY = [
+    {"role": "user", "content": (
+        "according to the project goal and the feature descriptions we have, "
+        "which new features can be derived from others in the aim of increasing "
+        "the predictive performance of boosting algorithms. create these "
+        "suggested features in our dataset.")},
+    {"role": "assistant", "content": PRIOR_FEATURE_ANSWER},
+]
+
+PURIFICATION_Q = (
+    "what are the data purification steps in the flow? how to sort them while "
+    "implementing and configure them better according to the data and problem we have?")
+
+PURIFICATION_TERMS = (
+    "purif", "duplicate drop", "zero-variance", "sparsity", "missing-drop",
+    "outlier", "correlation drop", "perfect-correlation", "row-wise", "column-wise",
+)
+FEATURE_DRIFT_TERMS = (
+    "debt_to_income", "credit_utilization", "income_verification",
+    "derived feature", "proposed derived", "legal_action_count", "boost predictive",
+)
+
+
+def classify(msg: str) -> str:
+    low = msg.lower()
+    pur = sum(t in low for t in PURIFICATION_TERMS)
+    drift = sum(t in low for t in FEATURE_DRIFT_TERMS)
+    if drift > pur:
+        return "DRIFT (wrong topic: features)"
+    if pur > 0:
+        return "ON-TOPIC (purification)"
+    return "UNCLEAR"
+
+
+def run(i: int, with_history: bool):
+    body = {
+        "message": PURIFICATION_Q,
+        "model": "nemotron-3-nano:30b",
+        "file_id": 502,
+    }
+    body["section"] = "data_quality"
+    body["context"] = CONTEXT
+    if with_history:
+        body["history"] = HISTORY
+    req = urllib.request.Request(
+        URL, data=json.dumps(body).encode(), headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=600) as r:
+            d = json.loads(r.read().decode())
+    except Exception as exc:  # noqa: BLE001
+        print(f"RUN {i} ({'hist' if with_history else 'nohist'}): ERROR {exc}")
+        return
+    msg = d.get("message", "") or ""
+    usage = d.get("usage", {}) or {}
+    print(f"RUN {i} ({'hist' if with_history else 'nohist'}): "
+          f"{classify(msg)} | chars={len(msg)} "
+          f"completion_tokens={usage.get('completion_tokens')} | "
+          f"head={msg[:80]!r}")
+
+
+if __name__ == "__main__":
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 6
+    for i in range(1, n + 1):
+        run(i, with_history=True)

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -4194,7 +4194,7 @@ def _text_response(text):
 
 def _run_chat_workflow(monkeypatch, *, provider, call_llm,
                        user_message='please derive new features from the existing ones',
-                       file_id=1, reasoning=False):
+                       file_id=1, reasoning=False, history=None):
     """Execute the real _chat_workflow body with its external collaborators
     mocked.  ``call_llm(idx, messages, tools)`` scripts each LLM round.
 
@@ -4238,7 +4238,8 @@ def _run_chat_workflow(monkeypatch, *, provider, call_llm,
 
     fn = views._chat_workflow.__wrapped__ \
         if hasattr(views._chat_workflow, '__wrapped__') else views._chat_workflow
-    result = fn(user_message, {}, 'general', [], file_id=file_id, model='engine-x')
+    result = fn(user_message, {}, 'general', history or [],
+                file_id=file_id, model='engine-x')
     return {'result': result, 'llm_calls': llm_calls, 'skill_calls': skill_calls}
 
 
@@ -4322,6 +4323,105 @@ class TestSkillAutoInjectionProviderAware:
         joined = ' '.join(m.get('content') or '' for m in out['llm_calls'][0]['messages'])
         assert 'SKILL_PLAYBOOK_BODY' in joined
         assert 'playbook has been pre-loaded' in joined
+
+
+@pytest.mark.unit
+class TestChatWorkflowTurnFocusAnchor:
+    """v2.44.2: when prior turns exist, a short topic-anchor system message is
+    injected immediately before the user message so reasoning models answer
+    the CURRENT question instead of drifting back to the previous turn's topic
+    (the data-purification-answered-as-features screenshot).  First turn (no
+    history) must NOT inject it."""
+
+    _PURIF_Q = ('what are the data purification steps in the flow? how to sort '
+                'them while implementing and configure them better?')
+    _HISTORY = [
+        {'role': 'user', 'content': 'which new features can be derived? create them.'},
+        {'role': 'assistant', 'content': 'Proposed derived features:\n| Feature | Formula |\n| Debt_To_Income | Var_19/Var_24 |'},
+    ]
+
+    def test_turn_focus_injected_when_history_present(self, monkeypatch):
+        from ai_assistant.views import _TURN_FOCUS_PROMPT
+        out = _run_chat_workflow(
+            monkeypatch, provider='engine', reasoning=True,
+            user_message=self._PURIF_Q, history=self._HISTORY,
+            call_llm=lambda idx, messages, tools: _text_response('done'),
+        )
+        msgs = out['llm_calls'][0]['messages']
+        contents = [m.get('content') or '' for m in msgs]
+        assert _TURN_FOCUS_PROMPT in contents
+        # It must sit immediately before the current user message.
+        user_idx = max(i for i, m in enumerate(msgs)
+                       if m.get('role') == 'user' and m.get('content') == self._PURIF_Q)
+        assert msgs[user_idx - 1].get('content') == _TURN_FOCUS_PROMPT
+        assert msgs[user_idx - 1].get('role') == 'system'
+
+    def test_turn_focus_absent_on_first_turn(self, monkeypatch):
+        from ai_assistant.views import _TURN_FOCUS_PROMPT
+        out = _run_chat_workflow(
+            monkeypatch, provider='engine', reasoning=True,
+            user_message=self._PURIF_Q, history=[],
+            call_llm=lambda idx, messages, tools: _text_response('done'),
+        )
+        contents = [m.get('content') or '' for m in out['llm_calls'][0]['messages']]
+        assert _TURN_FOCUS_PROMPT not in contents
+
+    def test_turn_focus_injected_for_cloud_models_too(self, monkeypatch):
+        # Provider-agnostic — harmless for cloud, useful if a cloud model ever drifts.
+        from ai_assistant.views import _TURN_FOCUS_PROMPT
+        out = _run_chat_workflow(
+            monkeypatch, provider='openai',
+            user_message=self._PURIF_Q, history=self._HISTORY,
+            call_llm=lambda idx, messages, tools: _text_response('done'),
+        )
+        contents = [m.get('content') or '' for m in out['llm_calls'][0]['messages']]
+        assert _TURN_FOCUS_PROMPT in contents
+
+    def test_turn_focus_does_not_instruct_producing_a_question(self):
+        # v2.44.3 regression: the prior wording ("Answer the user's NEXT
+        # message AS A STANDALONE QUESTION") made nemotron-3-nano:30b echo the
+        # user's prompt back reframed as a question instead of answering.  The
+        # anchor must NEVER tell the model to produce / phrase a question.
+        from ai_assistant.views import _TURN_FOCUS_PROMPT
+        lowered = _TURN_FOCUS_PROMPT.lower()
+        assert 'as a standalone question' not in lowered
+        # It must direct the model to ANSWER, not to mirror the prompt.
+        assert 'answer' in lowered
+        assert ('echo' in lowered or 'restate' in lowered or 'rephrase' in lowered)
+        assert 'never reply with a question' in lowered
+
+    def test_turn_focus_still_blocks_previous_topic_drift(self):
+        # The v2.44.2 anti-drift guarantee must survive the v2.44.3 reword.
+        from ai_assistant.views import _TURN_FOCUS_PROMPT
+        lowered = _TURN_FOCUS_PROMPT.lower()
+        assert 'previous turn' in lowered
+        assert 'current' in lowered
+
+
+@pytest.mark.unit
+class TestFinalizePromptIsTopicNeutral:
+    """v2.44.2: the finalization prompt must NOT seed the feature-engineering
+    topic.  Its feature-table guidance is CONDITIONAL on the user asking for
+    features, it leads by anchoring on the current question, and its code
+    example uses a generic column name (not Debt_to_Income)."""
+
+    def test_finalize_prompt_anchors_current_question(self):
+        from ai_assistant.views import _FINALIZE_PROMPT
+        low = _FINALIZE_PROMPT.lower()
+        assert 'most recent question' in low
+        assert 'answer the current question' in low
+
+    def test_finalize_prompt_feature_table_is_conditional(self):
+        from ai_assistant.views import _FINALIZE_PROMPT
+        # The table is gated behind 'ONLY when the user asked ... features'.
+        assert 'only when the user asked you to create or transform' in _FINALIZE_PROMPT.lower()
+
+    def test_finalize_prompt_example_is_generic(self):
+        from ai_assistant.views import _FINALIZE_PROMPT
+        # The concrete Debt_to_Income seed (which biased the drift) is gone.
+        assert 'Debt_to_Income' not in _FINALIZE_PROMPT
+        assert 'Debt-to-Income' not in _FINALIZE_PROMPT
+        assert "new_column" in _FINALIZE_PROMPT
 
 
 @pytest.mark.unit

--- a/docs/engine-feedback/nemotron-context-window-8k-answer-truncation.md
+++ b/docs/engine-feedback/nemotron-context-window-8k-answer-truncation.md
@@ -1,0 +1,116 @@
+# Bug report: `n_ctx=8192` is too small for reasoning-family chat — long answers truncate mid-render (`finish_reason="length"`)
+
+**Status:** Open — diagnosed end-to-end via live engine probes + engine config read.
+**Audience:** `llm-inference-engine` team
+**From:** DeclarAI (POC customer)
+**Date filed:** 2026-05-30
+**Engine at filing:** native build, `uvicorn inference_engine.main:app` on `127.0.0.1:8080` (PID 1603), `llama_cpp` backend, `N_CTX=8192` (from `.env` / `config.py:51` default).
+**Model:** `nemotron-3-nano:30b` (`reasoning: true`, `thinking: true`, `thinking_level: "med"`, `backend: llama_cpp`) — representative of the reasoning/thinking family.
+**Severity:** P2 — every sufficiently long structured answer from a reasoning-family model is silently truncated mid-output. The user is left with a half-rendered table and no indication the answer was cut off. Intermittent (depends on answer + reasoning length), not a crash.
+
+---
+
+## TL;DR
+
+The engine's context window is **`n_ctx = 8192`**. For a *reasoning* model that window is shared, in a single turn, by:
+
+1. the prompt (system + context + tool schemas + **tool results**, e.g. a 53-feature data dictionary), plus
+2. the hidden `reasoning_content` (the model's thinking), plus
+3. the visible `content` (the actual answer).
+
+`llama.cpp` caps generation at `min(max_tokens, n_ctx − prompt_tokens)`. When prompt + thinking + answer would exceed 8192, generation stops at `finish_reason="length"` and the answer is chopped — typically mid-markdown-table. Raising the client's `max_tokens` cannot fix this; the binding limit is `n_ctx`.
+
+This is the same 8192-token ceiling behind the **multi-turn tool-calling 500** that DeclarAI currently works around client-side (auto_ml `v2.43.3`). Both symptoms disappear if `n_ctx` is raised.
+
+---
+
+## Symptom
+
+A blocking `POST /v1/chat/completions` to `nemotron-3-nano:30b` asking for a long, structured answer (two markdown tables) returns a reply whose last line is a half-written table row, e.g.:
+
+```
+## 2. How to pick the concrete IDs for your problem
+| Step | Recommended ID(s)          ← cut off here; no separator row, no data rows
+```
+
+`finish_reason` on that final round is `"length"`. `content` is non-empty and well-formed up to the cut, so no downstream "empty answer" guard fires — the truncated table renders straight to the chat panel.
+
+## Root cause
+
+`n_ctx` is fixed at 8192 for all models (`src/inference_engine/config.py:51` → `n_ctx: int = Field(default=8192)`, `.env: N_CTX=8192`, passed to `Llama(n_ctx=settings.n_ctx)` at `src/inference_engine/adapters/llama_cpp.py:198,208`). 8192 is far below `nemotron-3-nano`'s trained context (`n_ctx_train` is much larger). Reasoning models are the worst case because thinking tokens consume the same window before the answer is even started.
+
+## Repro (against the running engine)
+
+### A. The context ceiling is 8192 (prompt alone overflows past it)
+
+```python
+# probe prompt sizes with a trivial max_tokens=16
+for n in (6000, 9000, 16000, 30000, 60000):
+    prompt = "Repeat OK. Context: " + ("data " * n)
+    client.chat.completions.create(model="nemotron-3-nano:30b",
+        messages=[{"role": "user", "content": prompt}], max_tokens=16)
+```
+
+Observed:
+
+```
+prompt ~6000 tokens → OK   (usage.prompt_tokens=6022)
+prompt ~9000 tokens → 500 Internal Server Error   ← prompt exceeds n_ctx
+prompt ~16000/30000/60000 → 500 Internal Server Error
+```
+
+So the hard ceiling sits between 6,022 and ~9,000 tokens — i.e. the configured 8192. NB: this surfaces as an **HTTP 500**, not a clean `400 context_length_exceeded` (see "Secondary ask" below).
+
+### B. Reasoning + answer share the budget and truncate together
+
+```python
+# tiny prompt, but ask for an exhaustive multi-table answer, cap at 4096
+r = client.chat.completions.create(model="nemotron-3-nano:30b",
+    messages=[{"role":"system","content":"Answer in exhaustive markdown with multiple big tables."},
+              {"role":"user","content":"List ALL data purification steps with two large tables. Be exhaustive."}],
+    max_tokens=4096, temperature=0.4,
+    extra_body={"chat_template_kwargs": {"enable_thinking": True}})
+```
+
+Observed:
+
+```
+finish_reason: length
+usage.completion_tokens: 4096          ← hit the budget exactly
+reasoning_content chars: 6310          ← ~1.6K tokens spent thinking
+content chars: 11009                   ← answer truncated mid-row:
+   "... | 51 | **Data-Quality Reporting** | Generate summary tables ... |"
+```
+
+The 4096-token completion budget was split between reasoning and answer; the answer was cut off. In production the limit is `n_ctx − prompt`, which is smaller still once real tool-result prompts are included.
+
+### C. Production shape
+
+In DeclarAI's UI the per-turn prompt routinely includes a large tool result (a 53-feature data dictionary). The visible answer therefore gets only `8192 − prompt − reasoning` tokens — enough for short answers, but long two-table answers overrun it and truncate.
+
+## Recommended fix
+
+**Raise `n_ctx` substantially for chat / tool-calling workloads** — e.g. a default of **32768** (or size it per-model from the GGUF's `n_ctx_train`, capped by a memory budget). `nemotron-3-nano:30b` supports far more than 8K. On the 128 GB unified-memory target box the extra KV-cache cost is acceptable; if memory is the concern, gate the larger window behind a per-model or per-deployment setting rather than a global 8192.
+
+Raising `n_ctx` fixes this report **and** retires the DeclarAI client-side workaround for the multi-turn 500 (auto_ml `v2.43.3`), since both are caused by the same 8192 ceiling.
+
+### Secondary asks (lower priority, previously raised)
+
+1. **Return `400 context_length_exceeded`, not `500`, on prompt overflow.** Repro A overflows the window and surfaces as an opaque `500 Internal Server Error`. A typed 4xx (with the limit in the body) lets clients degrade deterministically instead of pattern-matching on 500s. (Cross-ref: auto_ml `v2.43.3` has to treat a 500-with-prior-tool-results as "context overflow" heuristically.)
+2. **Reasoning/thinking budget knob (`reasoning_max_tokens` / `thinking_budget`).** Re-raising follow-up #2 from `nemotron-cot-leak-blocking-normalizer.md`: capping thinking would reserve window for the answer and directly reduce the truncation in repro B. Complementary to raising `n_ctx`.
+
+## Test suggestions for the engine repo
+
+1. Load `nemotron-3-nano:30b`; assert the effective `n_ctx` is ≥ the configured value and ideally derived from `n_ctx_train`.
+2. Prompt just over the configured `n_ctx` → expect a typed `400 context_length_exceeded`, not a 500.
+3. Reasoning-family model + `max_tokens` set so `prompt + reasoning + answer` would exceed the window → assert the response still completes (or that a thinking-budget cap leaves room for a non-truncated answer).
+
+## DeclarAI side — no client change planned
+
+The only real fix is engine-side (`n_ctx`). DeclarAI is **not** shipping a client-side mitigation for this: `max_tokens` cannot raise the ceiling, and a continuation pass under an 8192 window would itself overflow (the continuation prompt = original prompt + the large partial answer). We'll wait on the engine fix. Existing client-side guards (`v2.43.3` overflow handling, `v2.44.x` finalization) remain as-is and can be simplified once `n_ctx` is raised.
+
+## Cross-reference
+
+- Engine config: `src/inference_engine/config.py:51` (`n_ctx` default 8192), `.env: N_CTX=8192`, `src/inference_engine/adapters/llama_cpp.py:198,208` (`n_ctx=settings.n_ctx`).
+- Related engine feedback: `docs/engine-feedback/nemotron-cot-leak-blocking-normalizer.md` (RESOLVED; follow-up #2 = thinking budget), `docs/engine-feedback/nemotron-multi-turn-500-arguments-shape.md` (RESOLVED).
+- DeclarAI client-side context-overflow workaround this would retire: auto_ml `v2.43.3` (`backend/ai_assistant/views.py`, tool-loop `except` at the `_call_llm` call — treats a 500-after-tool-results as overflow and falls through to a no-tools synthesis).

--- a/docs/engine-feedback/nemotron-cot-leak-blocking-normalizer.md
+++ b/docs/engine-feedback/nemotron-cot-leak-blocking-normalizer.md
@@ -1,6 +1,7 @@
 # Bug report: Nemotron CoT leak into `content` on the blocking-path response normalizer
 
-**Status:** Open — diagnosed end-to-end via repeated A/B probe + engine code read.
+**Status:** RESOLVED (2026-05-30) — engine blocking-path normalizer fix verified live; chain-of-thought no longer leaks into `content`. Two optional ergonomic follow-ups remain (see [Residual follow-ups](#residual-follow-ups-optional-low-priority)).
+**Originally filed:** Open — diagnosed end-to-end via repeated A/B probe + engine code read.
 **Audience:** `llm-inference-engine` team
 **From:** DeclarAI (POC customer)
 **Date filed:** 2026-05-28
@@ -10,7 +11,39 @@
 
 ---
 
-## Symptom
+## Resolution (2026-05-30 — engine fix verified live)
+
+The `llm-inference-engine` team shipped the blocking-path fix (the AGGRESSIVE `expects_reasoning_prelude` policy — unanchored text on a reasoning-family model routes to `reasoning_content` regardless of `finish_reason`, making the blocking path byte-symmetric with `StreamNormalizer`). DeclarAI re-probed `nemotron-3-nano:30b` live against the running engine and confirms the P1 leak is **closed**.
+
+**`finish_reason == "length"`** (tight `max_tokens=350` — the original failure condition):
+- `content` length: **0** — no CoT in `content`
+- `reasoning_content` length: 1438 — the unfinished thought is correctly routed here (`"We need to propose 3-5 new features derived from existing ones…"`)
+- choice keys: `['finish_reason', 'index', 'logprobs', 'message']`
+
+**`finish_reason == "stop"`** (`max_tokens` ∈ {4096, 8192, 16384} — realistic UI prompt stack: lite system prompt + 3.8 KB slim context + skill snippet + 12 tools):
+- `content`: clean formatted answer (a `**Proposed derived features**` markdown table)
+- `reasoning_content`: 4936–6689 chars, cleanly separated
+- no markers leaked into `content` at any budget
+
+So the P1 symptom (raw chain-of-thought rendered to the user) no longer reproduces. The original recommendation — **Option A point 1** (on `finish_reason=="length"`: `reasoning_content=text`, `content=None`) — is implemented and working.
+
+### DeclarAI client-side refinement (`auto_ml` v2.44.0)
+
+The aggressive policy moved the burden to the client for one sub-case: when `finish_reason=="length"`, `reasoning_content` holds UNFINISHED thought, not a deliverable answer. v2.44.0:
+- `_recover_reasoning_content` promotes `reasoning_content`→`content` ONLY on `finish_reason=="stop"` (a complete answer the engine merely misrouted); on `"length"` it leaves `content` empty and tags the choice `declarai_reasoning_truncated`.
+- `_chat_workflow` then runs a strict finalization re-prompt (tools off) to produce a clean answer from the tool results already in hand.
+- Live recheck: **12/12** runs of the original failing question returned a clean answer with an `execute_code` Apply action and zero CoT leak.
+
+## Residual follow-ups (optional, low priority)
+
+Neither blocks DeclarAI; both are ergonomic improvements for any reasoning-family client.
+
+1. **Structured truncation flag (P3, small).** The choice payload exposes no signal that reasoning was truncated — keys are just `['finish_reason', 'index', 'logprobs', 'message']`. Clients must infer it from `content=="" AND reasoning_content!="" AND finish_reason=="length"`. Re-raising **Option A point 2** below: surface `reasoning_truncated: true` (or `model_reasoning_unanchored: true`) on the choice so every client doesn't reimplement the same heuristic.
+2. **Reasoning/thinking budget knob (P3–P4, feature).** Root cause of the residual `finish_reason=="length"` empty-answer case: on large prompt stacks the model spends its entire `max_tokens` thinking and never emits an answer. A `reasoning_max_tokens` / `thinking_budget` (cap thinking, then force the answer) would fix this at the source. DeclarAI's finalization pass handles it adequately for now.
+
+---
+
+## Symptom (as originally filed)
 
 A blocking `POST /v1/chat/completions` against `nemotron-3-nano:30b` with a large system-prompt stack + 15 tools returns:
 


### PR DESCRIPTION
## Summary
Client-side mitigation for the rare case where the reasoning-family engine model answers the **previous** turn's topic (notably feature-engineering) instead of the user's current question. Backend-only; provider-agnostic. Also files the engine-team issue for `n_ctx=8192` mid-answer truncation (no client fix — engine context window is root cause).

## Changes
- **Per-turn topic anchor** (`views.py`): inject a short system message immediately before the user message when chat history exists, re-anchoring the model on the current question (skipped on first turn).
- **De-biased `_FINALIZE_PROMPT`** (`views.py`): lead with "answer the MOST RECENT question"; make the feature-table format **conditional** on the user asking for features; replace the topic-seeding `Debt_to_Income` example with generic `new_column`.
- **Observability** (`views.py`): stamp `declarai.chat.has_history` and `declarai.chat.turn_focus_injected` for trace filtering if drift recurs.
- **Tests**: `TestChatWorkflowTurnFocusAnchor` (3) + `TestFinalizePromptIsTopicNeutral` (3); harness extended to accept history.
- **Docs**: engine-team issue for 8k context-window truncation; CoT-leak resolution doc update.
- **Scripts**: `probe_topic_drift.py` repro harness.

## Verification
- Backend full suite: **834 passed** (666 unit / 34 regression / 111 functional / 14 integration / 9 UAT)
- Frontend production build: **passed**
- Frontend Karma: **380/380**
- E2E Playwright: not run (local browser binary version-mismatch — environment, not a regression)

## Caveat
This is a mitigation for a rare, non-reproduced model behavior, not a confirmed root-cause fix. Observability stamps added to capture a trace if it recurs.