### PR TITLE
[codex] Add assistant knowledge bank RAG

### DIFF
--- a/backend/ai_assistant/intent_classifier.py
+++ b/backend/ai_assistant/intent_classifier.py
@@ -11,9 +11,9 @@ import re
 from typing import Iterable
 
 
-CLASSIFIER_VERSION = "intent-v1"
+CLASSIFIER_VERSION = "intent-v2-rag"
 
-INTENT_LABELS = ("A", "B", "C", "D", "E")
+INTENT_LABELS = ("A", "B", "C", "D", "E", "R")
 
 INTENT_LABEL_NAMES = {
     "A": "general_information_gathering",
@@ -21,6 +21,7 @@ INTENT_LABEL_NAMES = {
     "C": "current_status_information_gathering",
     "D": "configuration_editing_execution",
     "E": "flow_process_execution",
+    "R": "knowledge_bank_rag_call",
 }
 
 INTENT_LABEL_DESCRIPTIONS = {
@@ -29,13 +30,14 @@ INTENT_LABEL_DESCRIPTIONS = {
     "C": "Current flow status, flags, configuration, results, or data inspection.",
     "D": "Edit/update flow configuration, parameters, metadata, or data.",
     "E": "Trigger a pipeline/process step, or move backward/forward in the flow.",
+    "R": "Retrieve stable platform guidance, disclosure, glossary, or user-manual docs.",
 }
 
 _LABEL_SET = set(INTENT_LABELS)
 
 
 def normalize_intent_labels(labels) -> list[str]:
-    """Return unique A-E labels in canonical order, ignoring invalid input."""
+    """Return unique known labels in canonical order, ignoring invalid input."""
     if labels is None:
         return []
     if isinstance(labels, str):
@@ -87,7 +89,7 @@ def classify_query_intents(user_message: str,
                            *,
                            section: str = "",
                            context: dict | None = None) -> dict:
-    """Classify a free-text user message into one or more A-E labels.
+    """Classify a free-text user message into one or more intent labels.
 
     The implementation decomposes compound requests into short clauses, labels
     each clause, then unions the results in canonical order.
@@ -200,6 +202,17 @@ _GENERAL_INFO_RE = re.compile(
     re.IGNORECASE,
 )
 
+_RAG_TERMS_RE = re.compile(
+    r"\b("
+    r"rag|knowledge bank|manual|user manual|guide|guideline|documentation|docs|"
+    r"glossary|terminology|term|terms|abbreviation|abbreviations|definition|"
+    r"define|disclosure|assumption|assumptions|calculation|calculations|"
+    r"formula|formulas|methodology|rationale|capabilities|how to use|"
+    r"assistant usage|settings|configurations"
+    r")\b",
+    re.IGNORECASE,
+)
+
 
 def _classify_segment(segment: str, *, section: str, has_context: bool) -> list[str]:
     lower = segment.lower()
@@ -211,6 +224,12 @@ def _classify_segment(segment: str, *, section: str, has_context: bool) -> list[
     has_config_edit = bool(_CONFIG_EDIT_RE.search(segment))
     has_execution = bool(_EXECUTION_RE.search(segment))
     has_general_info = bool(_GENERAL_INFO_RE.search(segment))
+    has_direct_rag_term = bool(_RAG_TERMS_RE.search(segment))
+    has_explicit_current_anchor = bool(re.search(
+        r"\b(current|ongoing|now|status|state|progress|result|results|my|this|these|our)\b",
+        lower,
+    ))
+    is_doc_only_query = has_direct_rag_term and not has_explicit_current_anchor
     section_is_pipeline = bool(section and section != "general")
 
     if has_execution and (has_flow_term or section_is_pipeline):
@@ -219,14 +238,18 @@ def _classify_segment(segment: str, *, section: str, has_context: bool) -> list[
     if has_config_edit and (
         has_flow_term
         or section_is_pipeline
-        or re.search(r"\b(config|setting|parameter|threshold|feature|column|note|ranking|algorithm)\b",
-                     lower)
+        or re.search(
+            r"\b(config|setting|parameter|threshold|feature|column|note|"
+            r"ranking|algorithm|max_features|min_features|top_k|n_jobs)\b",
+            lower,
+        )
     ):
         labels.add("D")
 
     is_command = has_config_edit or has_execution
     if (
         not is_command
+        and not is_doc_only_query
         and (
             has_current_term
             or (section_is_pipeline and (has_context or has_flow_term))
@@ -241,4 +264,31 @@ def _classify_segment(segment: str, *, section: str, has_context: bool) -> list[
     if has_general_info and not labels.intersection({"B", "C", "D", "E"}):
         labels.add("A")
 
+    if _should_call_knowledge_bank(
+        has_direct_rag_term=has_direct_rag_term,
+        has_general_info=has_general_info,
+        has_flow_info=has_flow_info,
+        has_current_term=has_current_term,
+        has_config_edit=has_config_edit,
+        has_execution=has_execution,
+    ):
+        labels.add("R")
+
     return [label for label in INTENT_LABELS if label in labels]
+
+
+def _should_call_knowledge_bank(*,
+                                has_direct_rag_term: bool,
+                                has_general_info: bool,
+                                has_flow_info: bool,
+                                has_current_term: bool,
+                                has_config_edit: bool,
+                                has_execution: bool) -> bool:
+    """Return True when stable docs should be retrieved for this segment."""
+    if has_config_edit or has_execution:
+        return False
+    if has_direct_rag_term:
+        return True
+    if has_current_term:
+        return False
+    return has_general_info or has_flow_info

--- a/backend/ai_assistant/knowledge_bank.py
+++ b/backend/ai_assistant/knowledge_bank.py
@@ -1,0 +1,231 @@
+"""Deterministic retrieval over DeclarAI's versioned knowledge bank.
+
+The knowledge bank is intentionally small, curated Markdown.  A lexical scorer
+is enough here and keeps chat independent from embedding services, vector
+stores, migrations, or background indexing jobs.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+import re
+
+from .prometa_config import set_span_attr, tool as prometa_tool
+
+
+KNOWLEDGE_BANK_DIR = (
+    Path(__file__).resolve().parents[2] / "docs" / "knowledge-bank"
+)
+
+MAX_SNIPPET_CHARS = 1400
+DEFAULT_MAX_CHUNKS = 4
+DEFAULT_MAX_CONTEXT_CHARS = 5200
+
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_+-]*")
+_HEADING_RE = re.compile(r"^(#{1,3})\s+(.+?)\s*$")
+_STOP_WORDS = frozenset({
+    "a", "about", "after", "all", "an", "and", "are", "as", "at",
+    "be", "by", "can", "do", "does", "for", "from", "give", "has",
+    "have", "how", "i", "in", "is", "it", "me", "my", "of", "on",
+    "or", "our", "should", "show", "tell", "the", "their", "this",
+    "to", "use", "used", "using", "what", "when", "where", "which",
+    "why", "with", "you",
+})
+
+
+@dataclass(frozen=True)
+class KnowledgeChunk:
+    chunk_id: str
+    source: str
+    title: str
+    heading: str
+    content: str
+    tokens: tuple[str, ...]
+
+
+def _tokenize(text: str) -> list[str]:
+    return [
+        token
+        for token in _TOKEN_RE.findall((text or "").lower())
+        if token not in _STOP_WORDS and len(token) > 1
+    ]
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", (value or "").lower()).strip("-")
+    return slug or "section"
+
+
+def _read_title(path: Path, text: str) -> str:
+    for line in text.splitlines():
+        match = _HEADING_RE.match(line)
+        if match and match.group(1) == "#":
+            return match.group(2).strip()
+    return path.stem.replace("-", " ").title()
+
+
+def _make_chunk(path: Path, title: str, heading: str,
+                lines: list[str]) -> KnowledgeChunk | None:
+    content = "\n".join(lines).strip()
+    if not content:
+        return None
+    chunk_id = f"{path.stem}#{_slugify(heading)}"
+    weighted_text = f"{title}\n{heading}\n{content}"
+    return KnowledgeChunk(
+        chunk_id=chunk_id,
+        source=path.name,
+        title=title,
+        heading=heading,
+        content=content,
+        tokens=tuple(_tokenize(weighted_text)),
+    )
+
+
+def _parse_markdown(path: Path) -> list[KnowledgeChunk]:
+    text = path.read_text(encoding="utf-8")
+    title = _read_title(path, text)
+    chunks: list[KnowledgeChunk] = []
+    current_heading = title
+    current_lines: list[str] = []
+
+    for line in text.splitlines():
+        match = _HEADING_RE.match(line)
+        if match:
+            maybe_chunk = _make_chunk(path, title, current_heading, current_lines)
+            if maybe_chunk:
+                chunks.append(maybe_chunk)
+            current_heading = match.group(2).strip()
+            current_lines = [line]
+        else:
+            current_lines.append(line)
+
+    maybe_chunk = _make_chunk(path, title, current_heading, current_lines)
+    if maybe_chunk:
+        chunks.append(maybe_chunk)
+    return chunks
+
+
+@lru_cache(maxsize=1)
+def load_knowledge_chunks() -> tuple[KnowledgeChunk, ...]:
+    """Load and chunk all Markdown files from the user-facing docs folder."""
+    if not KNOWLEDGE_BANK_DIR.exists():
+        return tuple()
+
+    chunks: list[KnowledgeChunk] = []
+    for path in sorted(KNOWLEDGE_BANK_DIR.glob("*.md")):
+        chunks.extend(_parse_markdown(path))
+    return tuple(chunks)
+
+
+def _score_chunk(chunk: KnowledgeChunk, query_terms: list[str]) -> float:
+    if not query_terms:
+        return 0.0
+
+    counts = Counter(chunk.tokens)
+    heading_terms = set(_tokenize(f"{chunk.title} {chunk.heading} {chunk.source}"))
+    haystack = " ".join(chunk.tokens)
+    score = 0.0
+
+    for term in query_terms:
+        if term in counts:
+            score += counts[term]
+        if term in heading_terms:
+            score += 3.0
+
+    for first, second in zip(query_terms, query_terms[1:]):
+        if f"{first} {second}" in haystack:
+            score += 4.0
+
+    # Reward chunks that cover a larger share of the distinct query terms.
+    coverage = len(set(query_terms).intersection(counts)) / max(len(set(query_terms)), 1)
+    return score + coverage * 5.0
+
+
+def _clip_snippet(text: str, max_chars: int = MAX_SNIPPET_CHARS) -> str:
+    clean = (text or "").strip()
+    if len(clean) <= max_chars:
+        return clean
+    cut = clean.rfind("\n", 0, max_chars)
+    if cut < max_chars // 2:
+        cut = clean.rfind(" ", 0, max_chars)
+    if cut < max_chars // 2:
+        cut = max_chars
+    return clean[:cut].rstrip() + "\n..."
+
+
+def _format_context(results: list[dict]) -> str:
+    if not results:
+        return ""
+
+    lines = [
+        "Knowledge bank context retrieved for this turn.",
+        "Use these snippets for stable platform guidance, terminology, and technical disclosure.",
+        "For current pipeline values, still use live pipeline tools rather than these docs.",
+    ]
+    for idx, item in enumerate(results, start=1):
+        lines.append("")
+        lines.append(
+            f"[KB{idx}] {item['title']} / {item['heading']} "
+            f"(source: {item['source']})"
+        )
+        lines.append(item["snippet"])
+    return "\n".join(lines)
+
+
+@prometa_tool(name="knowledge-bank-rag")
+def retrieve_knowledge_context(query: str,
+                               *,
+                               max_chunks: int = DEFAULT_MAX_CHUNKS,
+                               max_context_chars: int = DEFAULT_MAX_CONTEXT_CHARS) -> dict:
+    """Retrieve knowledge-bank snippets for a user query."""
+    query_terms = _tokenize(query or "")
+    chunks = load_knowledge_chunks()
+    ranked = []
+
+    for chunk in chunks:
+        score = _score_chunk(chunk, query_terms)
+        if score > 0:
+            ranked.append((score, chunk))
+
+    ranked.sort(key=lambda item: (-item[0], item[1].source, item[1].heading))
+
+    results: list[dict] = []
+    used_chars = 0
+    for score, chunk in ranked[:max(max_chunks * 3, max_chunks)]:
+        snippet = _clip_snippet(chunk.content)
+        next_chars = len(snippet)
+        if results and used_chars + next_chars > max_context_chars:
+            break
+        results.append({
+            "chunk_id": chunk.chunk_id,
+            "source": chunk.source,
+            "title": chunk.title,
+            "heading": chunk.heading,
+            "score": round(score, 3),
+            "snippet": snippet,
+        })
+        used_chars += next_chars
+        if len(results) >= max_chunks:
+            break
+
+    context = _format_context(results)
+    set_span_attr("declarai.rag.called", True)
+    set_span_attr("declarai.rag.query_chars", len(query or ""))
+    set_span_attr("declarai.rag.result_count", len(results))
+    set_span_attr("declarai.rag.context_chars", len(context))
+    set_span_attr(
+        "declarai.rag.sources",
+        ",".join(dict.fromkeys(item["source"] for item in results)),
+    )
+    set_span_attr(
+        "declarai.rag.chunk_ids",
+        ",".join(item["chunk_id"] for item in results),
+    )
+
+    return {
+        "query": query or "",
+        "results": results,
+        "context": context,
+    }

--- a/backend/ai_assistant/views.py
+++ b/backend/ai_assistant/views.py
@@ -25,6 +25,7 @@ from .tool_executor import execute_tool_call, _load_skill_traced
 from .skill_registry import get_skill
 from .cache import cache_list_artifacts
 from .intent_classifier import resolve_intent_classification
+from .knowledge_bank import retrieve_knowledge_context
 from .model_registry import (
     get_model_config, list_models, DEFAULT_MODEL,
     call_openai, call_engine, MODEL_REGISTRY,
@@ -1331,7 +1332,8 @@ def _compute_role_boundaries(messages: list,
 def _describe_context_components(use_tools: bool,
                                  has_context: bool,
                                  auto_skill: Optional[str],
-                                 has_history: bool) -> list[str]:
+                                 has_history: bool,
+                                 has_knowledge_bank: bool = False) -> list[str]:
     """Enumerate the knowledge sources blended into this prompt.
 
     Consumed by the AML C6 (dynamic context assembly) detector via
@@ -1344,6 +1346,8 @@ def _describe_context_components(use_tools: bool,
         parts.append('slim_context')
     elif has_context:
         parts.append('legacy_full_context')
+    if has_knowledge_bank:
+        parts.append('knowledge_bank')
     if has_history:
         parts.append('conversation_history')
     if auto_skill:
@@ -1367,7 +1371,7 @@ def _sum_tool_message_tokens(messages: list) -> int:
 
 
 def _stamp_intent_attrs(intent: dict) -> None:
-    """Expose the resolved A-E intent labels to Prometa span attributes."""
+    """Expose the resolved intent labels to Prometa span attributes."""
     labels = intent.get('labels') or []
     label_names = intent.get('label_names') or []
     labels_csv = ','.join(labels)
@@ -1459,6 +1463,27 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
             'content': f'The user is currently viewing the following pipeline output '
                        f'(section: {section}):\n\n{context_str}',
         })
+
+    # ── Knowledge-bank RAG ───────────────────────────────────────────
+    # The deterministic intent classifier owns the decision to retrieve
+    # stable docs.  When it emits R, pull compact Markdown snippets from the
+    # versioned knowledge bank and inject them as system context.  Live
+    # pipeline tools still handle current file-specific values.
+    rag_result = None
+    has_knowledge_bank_context = False
+    if 'R' in (intent.get('labels') or []):
+        rag_result = retrieve_knowledge_context(user_message)
+        knowledge_context = (rag_result or {}).get('context') or ''
+        if knowledge_context:
+            messages.append({
+                'role': 'system',
+                'content': knowledge_context,
+            })
+            has_knowledge_bank_context = True
+        set_span_attr('declarai.rag.in_prompt', has_knowledge_bank_context)
+    else:
+        set_span_attr('declarai.rag.called', False)
+        set_span_attr('declarai.rag.in_prompt', False)
 
     # Add conversation history (last 20 messages to stay within token limits)
     for msg in history[-20:]:
@@ -1556,6 +1581,7 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
                 has_context=bool(context),
                 auto_skill=auto_skill if skill_injected else None,
                 has_history=bool(history),
+                has_knowledge_bank=has_knowledge_bank_context,
             ),
         )
     # Stamp the user query alone on the declarai-chat workflow span (not
@@ -1810,6 +1836,16 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
         'intent_labels': intent['labels'],
         'intent_source': intent['source'],
     }
+    if rag_result and rag_result.get('results'):
+        response_data['rag_sources'] = [
+            {
+                'source': item['source'],
+                'title': item['title'],
+                'heading': item['heading'],
+                'chunk_id': item['chunk_id'],
+            }
+            for item in rag_result['results']
+        ]
     if actions:
         response_data['actions'] = actions
         # v2.38.0: snapshot the chat span id so the frontend can pass it

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -4242,7 +4242,7 @@ class TestAssistantIntentClassifier:
 
         out = classify_query_intents('What is PSI in general?')
 
-        assert out['labels'] == ['A']
+        assert out['labels'] == ['A', 'R']
         assert out['preclassified'] is False
 
     def test_pipeline_flow_mechanism_question_is_b(self):
@@ -4250,7 +4250,7 @@ class TestAssistantIntentClassifier:
 
         out = classify_query_intents('How does the default preprocessing flow work?')
 
-        assert out['labels'] == ['B']
+        assert out['labels'] == ['B', 'R']
 
     def test_current_status_question_is_c(self):
         from ai_assistant.intent_classifier import classify_query_intents
@@ -4262,6 +4262,15 @@ class TestAssistantIntentClassifier:
         )
 
         assert out['labels'] == ['C']
+
+    def test_user_manual_question_includes_rag_label(self):
+        from ai_assistant.intent_classifier import classify_query_intents
+
+        out = classify_query_intents(
+            'Show me the platform manual and glossary for assistant usage.'
+        )
+
+        assert out['labels'] == ['R']
 
     def test_compound_edit_and_execute_question_is_d_and_e(self):
         from ai_assistant.intent_classifier import classify_query_intents
@@ -4287,6 +4296,32 @@ class TestAssistantIntentClassifier:
         assert out['labels'] == ['C']
         assert out['source'] == 'get_ai_support_button'
         assert out['preclassified'] is True
+
+
+@pytest.mark.unit
+class TestKnowledgeBankRetrieval:
+    """Knowledge-bank retrieval returns cited snippets from versioned docs."""
+
+    def test_retrieves_glossary_context_for_metric_question(self):
+        from ai_assistant.knowledge_bank import retrieve_knowledge_context
+
+        out = retrieve_knowledge_context('What does PSI mean?')
+
+        assert out['results']
+        assert '[KB1]' in out['context']
+        joined = '\n'.join(r['snippet'] for r in out['results'])
+        assert 'Population Stability Index' in joined
+        assert any(r['source'] == 'terminology-glossary.md'
+                   for r in out['results'])
+
+    def test_retrieves_assistant_guide_for_usage_question(self):
+        from ai_assistant.knowledge_bank import retrieve_knowledge_context
+
+        out = retrieve_knowledge_context('How should I use the assistant actions?')
+
+        assert out['results']
+        sources = {r['source'] for r in out['results']}
+        assert 'assistant-usage-and-action-guide.md' in sources
 
 
 # ---------------------------------------------------------------------------
@@ -4401,6 +4436,39 @@ def _run_chat_workflow(monkeypatch, *, provider, call_llm,
     result = fn(user_message, {}, 'general', history or [],
                 file_id=file_id, model='engine-x')
     return {'result': result, 'llm_calls': llm_calls, 'skill_calls': skill_calls}
+
+
+@pytest.mark.unit
+class TestKnowledgeBankRagWorkflow:
+    """When intent includes R, _chat_workflow retrieves and injects docs."""
+
+    def test_rag_intent_injects_knowledge_bank_context(self, monkeypatch):
+        out = _run_chat_workflow(
+            monkeypatch, provider='openai',
+            user_message='What does PSI mean in the DeclarAI platform?',
+            call_llm=lambda idx, messages, tools: _text_response('PSI means stability.'),
+        )
+
+        assert out['result']['intent_labels'] == ['A', 'R']
+        assert out['result']['rag_sources']
+        joined = '\n'.join(m.get('content') or ''
+                           for m in out['llm_calls'][0]['messages'])
+        assert 'Knowledge bank context retrieved for this turn.' in joined
+        assert '[KB1]' in joined
+        assert 'Population Stability Index' in joined
+
+    def test_non_rag_turn_does_not_inject_knowledge_bank_context(self, monkeypatch):
+        out = _run_chat_workflow(
+            monkeypatch, provider='openai',
+            user_message='Set max_features to 20 and then start SFS.',
+            call_llm=lambda idx, messages, tools: _text_response('Prepared.'),
+        )
+
+        assert out['result']['intent_labels'] == ['D', 'E']
+        assert 'rag_sources' not in out['result']
+        joined = '\n'.join(m.get('content') or ''
+                           for m in out['llm_calls'][0]['messages'])
+        assert 'Knowledge bank context retrieved for this turn.' not in joined
 
 
 @pytest.mark.unit
@@ -9463,6 +9531,20 @@ class TestPromptRenderRoleBoundaryHelpers:
         assert parts == [
             'system_prompt', 'slim_context', 'conversation_history',
             'skill:feature-engineering', 'user_query',
+        ], parts
+
+    def test_describe_context_components_places_knowledge_bank_after_context(self):
+        """Knowledge-bank context is injected after slim/legacy pipeline
+        context and before history so stable docs do not outrank live data."""
+        from ai_assistant.views import _describe_context_components
+        parts = _describe_context_components(
+            use_tools=True, has_context=False,
+            auto_skill='feature-engineering', has_history=True,
+            has_knowledge_bank=True,
+        )
+        assert parts == [
+            'system_prompt', 'slim_context', 'knowledge_bank',
+            'conversation_history', 'skill:feature-engineering', 'user_query',
         ], parts
 
     def test_describe_context_components_minimal_path(self):

--- a/docs/knowledge-bank/README.md
+++ b/docs/knowledge-bank/README.md
@@ -1,0 +1,32 @@
+# DeclarAI Knowledge Bank
+
+This folder is the source of truth for platform guidance that the DeclarAI
+assistant can retrieve during chat turns. The assistant uses these documents
+when its intent classifier adds the `R` retrieval label to a user query.
+
+## Documents
+
+- `platform-guideline-user-manual.md` explains the platform flow, user-facing
+  capabilities, dependencies between stages, settings, and assistant usage.
+- `technical-disclosure.md` explains the data-science decisions, calculations,
+  assumptions, and rationale behind each pipeline step.
+- `terminology-glossary.md` defines the technical terms, metrics, abbreviations,
+  and platform labels that users see in the product.
+- `assistant-usage-and-action-guide.md` explains how to work with the assistant,
+  including when it answers, when it retrieves knowledge, when it uses live
+  pipeline tools, and when it proposes executable actions.
+- `model-governance-review-checklist.md` gives a practical review checklist for
+  analysts and validators before they rely on or export a model.
+
+## Retrieval Contract
+
+The knowledge bank is intentionally versioned with the application. It should
+describe DeclarAI's actual behavior, not generic AutoML behavior. When a
+workflow, calculation, threshold, or action path changes, update the relevant
+knowledge-bank document in the same pull request as the product change.
+
+The assistant retrieval layer chunks Markdown sections, ranks them with a
+deterministic lexical scorer, and injects compact cited snippets into the chat
+prompt only when the classifier includes `R`. This keeps ordinary status or
+execution turns focused on live pipeline artifacts while still giving
+documentation-grade answers for manual, glossary, and disclosure questions.

--- a/docs/knowledge-bank/assistant-usage-and-action-guide.md
+++ b/docs/knowledge-bank/assistant-usage-and-action-guide.md
@@ -1,0 +1,125 @@
+# Assistant Usage and Action Guide
+
+## What the Assistant Can Do
+
+The DeclarAI assistant has four modes of help:
+
+- Explain platform workflow and data-science concepts.
+- Retrieve stable guidance from the knowledge bank.
+- Inspect current pipeline data through live tools.
+- Prepare executable actions that the user can apply.
+
+These modes can combine in one turn. For example, a user may ask what VIF means,
+which current features have high VIF, and whether to exclude one of them. The
+assistant should retrieve glossary context, call the selected-features or VIF
+tool, and then propose a reversible feature-usage action if appropriate.
+
+## When Knowledge-Bank Retrieval Is Used
+
+Knowledge-bank retrieval is used for stable documentation questions:
+
+- "How does the platform work?"
+- "What are the pipeline steps?"
+- "What does PSI mean?"
+- "Explain SFS stopping criteria."
+- "What calculations are made in modeling?"
+- "What assumptions does the purifier make?"
+- "How should I use the assistant?"
+- "Give me the glossary for SHAP, VIF, PR-AUC, and PSI."
+
+Knowledge-bank retrieval should not replace live pipeline tools when the user is
+asking about current data, current settings, current metrics, or a current run.
+
+## When Live Pipeline Tools Are Used
+
+Live tools retrieve current artifacts for the loaded file. The assistant should
+use tools when the user asks about:
+
+- Current selected features, SHAP, gain, or VIF.
+- Current SFS results or progress.
+- Current data-quality summary, PSI, CSI, missingness, or drift.
+- Current encoding plan, ordinal rankings, or unique values.
+- Current pipeline configuration or purifier options.
+- Current split validation or target rates.
+- Current notes.
+
+If a specific number, feature name, metric value, selected option, or status is
+needed, the assistant should use a live tool instead of answering from memory.
+
+## When Actions Are Proposed
+
+Actions are proposed when the user asks to change something or run a pipeline
+step. The assistant should explain what will happen and why, then emit one
+action block at the end of the reply.
+
+Supported action types:
+
+- `execute_code`: create or modify dataset columns with pandas/numpy.
+- `update_metadata`: update data dictionary fields.
+- `update_config`: change model usage, feature usage, purifier selections,
+  split settings, or algorithm choice.
+- `set_ordinal_ranking`: rank ordinal category values and mark the feature as
+  ordinal.
+- `start_data_purifier`: run preprocessing.
+- `apply_encoding`: apply the encoding plan.
+- `start_modeling`: train the selected model.
+- `start_sfs`: start Sequential Feature Selection.
+- `start_hyperparameter`: start hyperparameter tuning.
+- `update_notes`: add, edit, or delete pipeline notes.
+
+## One-Action Rule
+
+The assistant should emit at most one action block per chat turn. If a workflow
+requires multiple steps, it should choose the most upstream action first, then
+wait for the resulting state before proposing the next action.
+
+Example: if the user asks to rank an ordinal feature and then start modeling,
+the assistant should first set the ordinal ranking. On the next turn, after the
+ranking is applied and encoding is ready, it can apply encoding or start
+modeling as appropriate.
+
+## Reversible Configuration Before Destructive Mutation
+
+When the user wants to exclude a feature from modeling or SFS, the assistant
+should prefer `update_config` with feature usage set to `drop`. It should not
+use `execute_code` to permanently delete the column unless the user explicitly
+asks for dataset mutation.
+
+This keeps cached artifacts valid and lets the user reverse the decision.
+
+## Assistant Intent Labels
+
+The backend classifies each free-text turn before LLM work:
+
+- `A`: General information or data-science education.
+- `B`: Platform or pipeline-flow explanation.
+- `C`: Current status, metrics, results, settings, or data inspection.
+- `D`: Configuration or data editing.
+- `E`: Pipeline process execution.
+- `R`: Knowledge-bank retrieval should be used.
+
+Labels can be combined. A single question can be both `C` and `R` when it asks
+for a current result and a definition.
+
+## Good User Prompts
+
+Good prompts are specific about whether the user wants explanation, inspection,
+or action.
+
+Examples:
+
+- "Explain PSI and show which current variables have PSI > 0.25."
+- "What does the backward SFS stopping criterion mean for my run?"
+- "Set Var_17 to drop because of VIF, but do not start SFS yet."
+- "Apply encoding after checking whether any ordinal rankings are missing."
+- "Start backward SFS with ROC-AUC stopping at 1 percent change."
+
+## Assistant Boundaries
+
+The assistant should not invent feature names, metric values, or current
+settings. It should use current pipeline tools for live data and knowledge-bank
+retrieval for stable platform documentation.
+
+The assistant should not claim that a process has started unless it emits the
+matching action block. It should not silently chain multiple pipeline run steps
+in one response.

--- a/docs/knowledge-bank/model-governance-review-checklist.md
+++ b/docs/knowledge-bank/model-governance-review-checklist.md
@@ -1,0 +1,90 @@
+# Model Governance and Review Checklist
+
+## Purpose
+
+This checklist helps analysts and validators review a DeclarAI pipeline before
+relying on the model, exporting artifacts, or moving toward deployment.
+
+## Data Declaration Review
+
+- Target variable is explicitly selected.
+- Target definition is documented in business terms.
+- ID, timestamp, operational-only, and leakage-prone fields are excluded from
+  modeling.
+- Feature descriptions are complete enough for review.
+- Level of Measurement values are checked for categorical and ordinal features.
+- Binary flags are verified as predictors, targets, or exclusions.
+
+## Data Purifier Review
+
+- Selected purifier options match the intended data-cleaning policy.
+- Threshold options are not more aggressive than the project can justify.
+- Dropped columns and removed rows are reviewed.
+- Outlier clipping is appropriate for the business and does not hide meaningful
+  rare events.
+- Rare-category merging is reviewed for minority-class or protected-group risk.
+- The processed file exists before downstream modeling steps are run.
+
+## Split and Stability Review
+
+- Split strategy matches the deployment scenario.
+- Out-of-time split is used when time ordering is material.
+- Train and test target rates are reasonable.
+- PSI, CSI, missingness, and distribution-shift flags are reviewed.
+- High-drift features are either justified, transformed, excluded, or monitored.
+
+## Encoding Review
+
+- Native categorical handling is appropriate for the selected algorithm.
+- Fallback strategies are documented.
+- Ordinal features have complete rankings.
+- High-cardinality categoricals are checked for leakage and overfitting risk.
+- Encoding decisions align with Level of Measurement.
+
+## Modeling Review
+
+- Algorithm choice is documented.
+- Cross-validation metrics are reviewed with class balance in mind.
+- ROC-AUC and PR-AUC are interpreted together for imbalanced targets.
+- SHAP and gain are compared instead of relying on one importance signal.
+- Combined Score is used as a ranking aid, not as a substitute for business
+  review.
+- VIF and correlated features are reviewed for redundancy.
+
+## SFS Review
+
+- SFS method is appropriate for the modeling goal.
+- Stopping criteria are documented.
+- Minimum and maximum feature counts are justified.
+- Top-K and worker settings are recorded.
+- Backward and forward results are interpreted according to their direction.
+- The chosen feature subset balances performance, stability, simplicity, and
+  business meaning.
+
+## Hyperparameter Review
+
+- Tuning is run after a reasonably stable feature set is chosen.
+- Search method and trial count are documented.
+- Primary metric aligns with the business objective.
+- Validation curves are reviewed for overfitting or unstable settings.
+- Tuning gains are compared against baseline model performance.
+
+## Assistant and Action Review
+
+- Assistant recommendations are grounded in live tool results or knowledge-bank
+  citations.
+- Applied actions are reversible where possible.
+- Feature exclusions use feature usage rather than permanent column deletion
+  unless destructive mutation was explicitly intended.
+- Notes capture why important changes were made.
+- No assistant response is treated as approval without human review.
+
+## Deployment Readiness
+
+- Data, preprocessing, encoding, feature-selection, and tuning decisions are
+  traceable.
+- Performance and stability metrics are acceptable for the intended use case.
+- Feature explanations are understandable to non-developer stakeholders.
+- Known limitations, data gaps, and assumptions are documented.
+- Monitoring requirements are defined for future data drift and performance
+  decay.

--- a/docs/knowledge-bank/platform-guideline-user-manual.md
+++ b/docs/knowledge-bank/platform-guideline-user-manual.md
@@ -1,0 +1,207 @@
+# Platform Guideline and User Manual
+
+## Purpose
+
+DeclarAI is a guided model-development platform for tabular supervised machine
+learning, with the current product centered on binary classification and
+credit-risk style modeling. The core workflow is declarative: the analyst
+declares data roles, pipeline settings, feature usage, encoding choices, and
+run steps; the platform executes those choices and preserves the resulting
+artifacts for review.
+
+## Main Capabilities
+
+DeclarAI supports these primary capabilities:
+
+- File upload and data declaration for CSV and Excel inputs.
+- Data dictionary generation with editable descriptions, measurement levels,
+  and model-usage flags.
+- Data purifier configuration and execution.
+- Train/test split setup, including random and out-of-time strategies.
+- Data quality review with stability and distribution metrics.
+- Categorical encoding analysis with native categorical handling as the
+  preferred path for boosting models.
+- Model training, cross-validation, explainability, and feature ranking.
+- Sequential Feature Selection (SFS), including forward, backward, and
+  forward-from-backward workflows.
+- Hyperparameter tuning after a selected feature set is available.
+- Pipeline notes that preserve analyst rationale at key review points.
+- AI assistant support for explanation, inspection, configuration proposals,
+  and executable pipeline actions.
+
+## Pipeline Stages
+
+DeclarAI is organized as a progressive workflow. Each stage depends on the
+outputs of earlier stages.
+
+1. Data Declaration
+2. Data Purifier
+3. Data Quality Summary
+4. Categorical Feature Encoding
+5. Modeling
+6. Sequential Feature Selection
+7. Hyperparameter Tuning
+8. Evaluation and deployment surfaces, currently evolving
+
+The user should not treat these stages as isolated screens. For example, model
+performance depends on data declaration, purifier selections, split strategy,
+encoding readiness, and the chosen feature set.
+
+## Data Declaration
+
+The analyst uploads data, confirms the parser settings, reviews a preview, and
+declares the target variable. DeclarAI generates a data dictionary with feature
+names, inferred data types, Level of Measurement, descriptions, and model-usage
+flags.
+
+Important user actions:
+
+- Mark the target variable explicitly.
+- Exclude IDs, timestamps, leakage columns, and operational-only columns from
+  modeling by setting Model_Usage_YN to `No`.
+- Add or improve feature descriptions so modeling and assistant guidance can
+  use business context.
+- Correct Level of Measurement where automatic inference is ambiguous.
+
+## Data Purifier
+
+The Data Purifier applies selected preprocessing options and creates the
+processed file consumed downstream. Options are selected from the canonical
+catalog of 34 choices. Standalone options can be combined freely. Threshold
+families are mutually exclusive within their group, so the user should choose
+one correlation threshold, one sparsity threshold, one missingness threshold,
+one combined sparsity/missingness threshold, one numeric outlier clipping band,
+and one categorical rare-level merge threshold when those families are used.
+
+The purifier is not a hidden AutoML step. The user chooses the options, and the
+summary reports what changed.
+
+## Split Configuration
+
+DeclarAI supports random split and out-of-time split. A random split is useful
+for ordinary development when the sample is not time ordered. An out-of-time
+split is preferred when the deployment setting depends on future data behaving
+like a later time window.
+
+The user should review target rates and row counts across full, train, and test
+sets. A split that creates severe target imbalance or unrealistic time leakage
+should be corrected before modeling.
+
+## Data Quality Summary
+
+The Data Quality Summary helps the user identify stability, missingness,
+distribution drift, and variable-health issues before training. It should be
+used to confirm that data is plausible and that risky variables are flagged
+early.
+
+Common review questions:
+
+- Which variables have high missingness?
+- Which variables drift between train and test?
+- Are any variables dominated by one value?
+- Are any features excluded from modeling and why?
+
+## Categorical Feature Encoding
+
+DeclarAI prefers native categorical handling for supported boosting models. The
+encoding plan still matters: it identifies categorical features, measurement
+levels, unique values, fallback strategies, and ordinal ranking needs.
+
+When a feature is ordinal, the user should provide a ranking of category values.
+Ranking is a modeling decision, not a formatting detail. If the ranking is wrong,
+the model can learn the wrong monotonic order.
+
+## Modeling
+
+Modeling trains the selected boosting algorithm, computes cross-validation
+results, records model performance, calculates explainability artifacts, and
+builds the selected-features table. The selected-features table combines SHAP,
+gain, and VIF-style multicollinearity signals so the analyst can distinguish
+predictive value from redundancy.
+
+Before starting modeling, confirm:
+
+- Data purifier has run and produced a processed file.
+- Encoding plan is ready.
+- Ordinal features have rankings where required.
+- Model_Usage_YN has excluded identifiers, timestamps, and leakage columns.
+- Algorithm selection is intentional.
+
+## Sequential Feature Selection
+
+Sequential Feature Selection is used after modeling to test smaller feature
+subsets under cross-validation. Backward selection starts with all candidate
+features and removes weak contributors. Forward selection starts with no
+features and adds strong contributors. Forward-from-backward starts from a
+survivor set at a chosen backward step and then performs forward selection
+inside that pool.
+
+SFS is controlled by stopping criteria:
+
+- Monitored metrics, such as ROC-AUC or PR-AUC.
+- Percentage-change thresholds.
+- Minimum and maximum feature counts.
+- Parallel jobs and top-K candidate settings.
+
+The last SFS row is the point where stopping criteria fired. It is not
+automatically proof that every possible feature was tested.
+
+## Hyperparameter Tuning
+
+Hyperparameter tuning runs after SFS has produced a candidate feature set. It
+can use grid, random, Bayesian, or automatic search-method selection. The
+automatic method estimates grid cost using candidate count, CV folds, and
+worker count, then chooses a practical search strategy.
+
+Users should tune only after feature selection is reasonably stable. Tuning a
+large, unstable, or leakage-prone feature set can make the model look better
+without improving deployment readiness.
+
+## Assistant Usage
+
+The assistant can answer conceptual questions, explain platform workflow, fetch
+live pipeline artifacts, inspect current results, and propose executable
+actions. It should be treated as an analyst copilot: it can help reason and
+prepare changes, but the user remains responsible for accepting applied actions
+and validating business assumptions.
+
+Use the assistant for:
+
+- Explaining a pipeline stage or metric.
+- Asking what a current result means.
+- Reviewing selected features, SHAP, VIF, SFS, or data quality.
+- Asking which purifier or encoding settings are appropriate.
+- Preparing one-click actions such as updating model usage, setting ordinal
+  rankings, starting preprocessing, applying encoding, starting modeling,
+  starting SFS, or starting hyperparameter tuning.
+
+## Settings and Configuration Summary
+
+Key settings include:
+
+- Target variable and target definition.
+- Feature descriptions and Level of Measurement.
+- Model_Usage_YN for inclusion or exclusion from modeling.
+- Purifier option IDs and thresholds.
+- Split strategy, date column, cutoff, and random percentage.
+- Algorithm selection.
+- Encoding native/fallback behavior and ordinal rankings.
+- SFS methods, stopping criteria, `n_jobs`, and `top_k`.
+- Hyperparameter search method, iterations, CV folds, workers, metric, and
+  enabled parameter ranges.
+
+## Practical Operating Pattern
+
+For a high-quality modeling run:
+
+1. Upload data and confirm the parser settings.
+2. Declare target and document features.
+3. Exclude IDs, timestamps, and obvious leakage.
+4. Choose purifier options and split strategy.
+5. Run preprocessing and review the purifier summary.
+6. Review data quality and split validation.
+7. Resolve encoding and ordinal ranking decisions.
+8. Train the model and inspect CV, SHAP, gain, and VIF.
+9. Use SFS to evaluate smaller feature sets.
+10. Tune hyperparameters on the selected feature set.
+11. Document decisions with notes and export artifacts for review.

--- a/docs/knowledge-bank/technical-disclosure.md
+++ b/docs/knowledge-bank/technical-disclosure.md
@@ -1,0 +1,214 @@
+# Technical Disclosure
+
+## Scope
+
+This document explains what data-science decisions DeclarAI makes, what it
+calculates, and why those calculations exist. It is written for platform users,
+model validators, and technical reviewers who need to understand the assumptions
+behind the pipeline.
+
+## General Modeling Assumptions
+
+DeclarAI currently focuses on tabular supervised binary classification. In
+credit-risk style projects, the target is usually an event indicator such as
+default, fraud, churn, or another adverse outcome. The platform assumes the user
+can identify the target variable and can separate legitimate predictors from
+identifiers, timestamps, leakage fields, and administrative fields.
+
+The platform favors transparent, reviewable transformations over opaque
+automation. Automatic inference is used to accelerate work, but user-declared
+settings remain the governing source of truth.
+
+## Data Type and Measurement-Level Decisions
+
+At declaration time, DeclarAI infers data type from the uploaded file and assigns
+a Level of Measurement where possible. These inferred labels are starting
+points. The user can correct them because measurement level is a modeling
+decision.
+
+Common assumptions:
+
+- Numeric columns may be continuous, ordinal, binary, identifiers, or encoded
+  categories.
+- Object/string columns are usually categorical, but they may encode dates,
+  identifiers, or ordered categories.
+- Binary columns can be true predictive flags, target variables, or leakage
+  flags depending on business meaning.
+- Ordinal categories require a meaningful user-approved order.
+
+## Data Purifier Decisions
+
+The purifier applies user-selected rules from a canonical catalog. It does not
+search for all possible preprocessing strategies automatically. Each selected
+option exists to remove a specific data-quality risk.
+
+Standalone options:
+
+- Column-wise duplicate drop removes redundant columns with identical values.
+- Row-wise duplicate drop removes duplicate records.
+- Zero-variance drop removes features that carry no signal.
+- Perfect-correlation drop removes one feature from a perfectly correlated pair.
+
+Threshold families:
+
+- Correlation-drop removes one of two highly correlated features at or above the
+  selected threshold. Lower thresholds are more aggressive.
+- Sparsity-drop removes features dominated by zero-like values at or above the
+  selected threshold.
+- Missing-drop removes features whose missing ratio meets or exceeds the
+  selected threshold.
+- Combined sparsity/missingness drop uses max(zero_ratio, missing_ratio) and
+  removes columns at or above the selected threshold.
+- Numeric outlier quantile clipping caps numeric values to selected lower and
+  upper quantiles.
+- Categorical rare-level merge groups rare categories below the selected
+  frequency threshold.
+
+The reason for these rules is practical: remove or cap data defects that can
+destabilize model training, reduce generalization, or make review artifacts
+harder to interpret.
+
+## Train/Test Split Decisions
+
+The split creates an out-of-sample evaluation set. DeclarAI supports random and
+out-of-time split strategies.
+
+Random split assumes the sample is exchangeable enough that random partitioning
+approximates future data. Out-of-time split assumes time ordering matters and
+that later observations better represent deployment behavior.
+
+The platform calculates row counts and target rates for the full, train, and
+test samples. Large target-rate differences can indicate sampling risk,
+temporal drift, or insufficient event volume.
+
+## Data Quality Calculations
+
+Data Quality Summary calculations help determine whether a feature is stable and
+usable.
+
+Population Stability Index (PSI) compares feature distributions between train
+and test or across time windows. A common rule of thumb is:
+
+- PSI < 0.10: stable.
+- PSI 0.10 to 0.25: moderate shift.
+- PSI > 0.25: significant shift.
+
+Characteristic Stability Index (CSI) applies a similar distribution-shift idea
+to categorical feature characteristics. Jensen-Shannon Divergence compares
+probability distributions in a bounded, symmetric way.
+
+Missing percentage, unique counts, distribution summaries, and data-type labels
+are calculated so analysts can spot variables that may need exclusion, special
+handling, or business review.
+
+## Encoding Decisions
+
+DeclarAI prefers native categorical support for boosting models when available
+because it avoids unnecessary information loss from manual encoding. The
+encoding plan still records fallback strategies because not all categorical
+variables are equally safe to pass natively.
+
+Fallback assumptions:
+
+- Nominal features have no natural order. Label encoding can be used as a
+  fallback, but the user should be cautious because integer labels can imply an
+  artificial order to some models.
+- Ordinal features have a meaningful rank order. DeclarAI expects explicit
+  rankings for ordinal categories so the ordering is reviewable.
+- Very low-cardinality categoricals may be one-hot encoded in fallback paths.
+- High-cardinality categorical features may need target encoding, but target
+  encoding should be reviewed for leakage and overfitting risk.
+
+## Modeling Calculations
+
+Modeling trains a selected boosting algorithm and records performance and
+explainability outputs. Binary targets are handled as classification outcomes.
+The platform uses cross-validation to estimate model performance more robustly
+than a single split.
+
+Common metrics:
+
+- ROC-AUC measures ranking ability across classification thresholds.
+- PR-AUC focuses on precision and recall and is often more informative for rare
+  positive classes.
+- Precision is the share of predicted positives that are true positives.
+- Recall is the share of actual positives that the model captures.
+- F1 balances precision and recall.
+- Log-loss penalizes overconfident wrong probabilities.
+
+The platform does not treat one metric as universally best. The right metric
+depends on the business objective and class balance.
+
+## Explainability Calculations
+
+SHAP values estimate how much each feature contributes to individual model
+predictions. Mean absolute SHAP impact summarizes global importance. Signed
+impact indicates whether high feature values generally push predictions upward
+or downward, subject to the model and data distribution.
+
+Gain importance comes from the tree model and measures how much splits on a
+feature improved the objective during training. SHAP and gain can disagree
+because they measure different things.
+
+DeclarAI combines SHAP percentile and gain percentile using a geometric mean.
+The calculation is:
+
+1. Convert absolute SHAP impact to an ECDF percentile.
+2. Convert gain importance to an ECDF percentile.
+3. Compute sqrt(SHAP_percentile * Gain_percentile).
+
+This rewards features that rank well on both explainability and model-split
+importance while reducing scale mismatch between SHAP and gain.
+
+## VIF and Multicollinearity
+
+Variance Inflation Factor (VIF) estimates how predictable one feature is from
+the other features. High VIF indicates multicollinearity risk. Common review
+thresholds are:
+
+- VIF <= 5: usually acceptable.
+- VIF 5 to 10: elevated.
+- VIF > 10: severe.
+
+High VIF does not always mean a feature must be dropped. The user should compare
+VIF with SHAP, gain, business meaning, and SFS behavior.
+
+## Sequential Feature Selection Decisions
+
+SFS evaluates feature subsets through repeated model fits. Backward selection
+starts from all candidate features and removes weak contributors. Forward
+selection starts from none and adds strong contributors. Forward-from-backward
+uses a backward survivor set as the candidate pool for forward selection.
+
+SFS stops according to configured criteria, not necessarily after exhausting all
+possible subsets. Stopping criteria include monitored metrics, percentage-change
+thresholds, minimum features, and maximum features.
+
+Top-K candidate screening is a performance optimization. It does not mean the
+platform is proving that all non-top-K candidates are useless.
+
+## Hyperparameter Tuning Decisions
+
+Hyperparameter tuning searches model settings after a feature set is chosen.
+Grid search is exhaustive over a configured grid but can be expensive. Random
+search samples configurations and is useful for larger spaces. Bayesian search
+uses prior results to choose promising next configurations. The automatic mode
+uses estimated fit count per worker to choose a practical strategy.
+
+The platform records the requested method, resolved method, number of trials,
+primary metric, and validation-curve outputs so reviewers can understand the
+search.
+
+## Assistant Retrieval and Tool Decisions
+
+The assistant uses three context sources:
+
+- Knowledge-bank retrieval for stable platform documentation, terminology, and
+  technical disclosure.
+- Live pipeline tools for current user data, settings, metrics, and artifacts.
+- Executable action proposals for user-approved pipeline changes.
+
+Knowledge-bank retrieval should answer "how does this work?" and "what does
+this term mean?" Live tools should answer "what is happening in my current
+pipeline?" Action blocks should only appear when the user asks to change or run
+something, or when the assistant offers a concrete applyable recommendation.

--- a/docs/knowledge-bank/terminology-glossary.md
+++ b/docs/knowledge-bank/terminology-glossary.md
@@ -1,0 +1,204 @@
+# Terminology Glossary
+
+## Action Block
+
+A structured assistant response section that the chat panel turns into an
+Apply button. Action blocks can update metadata, update configuration, execute
+code, start pipeline runs, apply encoding, start modeling, start SFS, start
+hyperparameter tuning, or update notes.
+
+## AI Assistant
+
+The embedded DeclarAI copilot. It can explain concepts, retrieve platform
+documentation, inspect current pipeline artifacts through tools, and prepare
+actions for the user to apply.
+
+## AUC
+
+Area Under the Curve. In DeclarAI, AUC usually refers to ROC-AUC unless stated
+otherwise.
+
+## Backward Selection
+
+An SFS method that starts with all candidate features and removes one feature at
+each step. Early removed features are usually weaker contributors under the
+configured evaluation setup.
+
+## CatBoost
+
+A gradient-boosting algorithm with strong native support for categorical
+features. It is one of the intended boosting-family algorithms for DeclarAI.
+
+## CSI
+
+Characteristic Stability Index. A categorical stability metric used to detect
+distribution shift in categorical features or feature characteristics.
+
+## CV
+
+Cross-validation. A model-evaluation method that trains and evaluates across
+multiple folds to estimate performance more robustly than one train/test split.
+
+## Data Declaration
+
+The stage where users upload data, confirm parsing, declare a target, and review
+the data dictionary.
+
+## Data Dictionary
+
+The table of feature metadata: feature name, description, data type, Level of
+Measurement, model-usage flag, and related fields.
+
+## Data Purifier
+
+The preprocessing stage where selected rules remove duplicates, constant
+features, highly correlated features, sparse or missing-heavy features, and
+outlier issues.
+
+## ECDF
+
+Empirical Cumulative Distribution Function. DeclarAI uses ECDF percentiles to
+place SHAP impact and gain importance on comparable rank scales before
+computing the Combined Score.
+
+## Encoding Plan
+
+The per-feature plan for categorical handling. It records measurement level,
+unique values, native strategy, fallback strategy, and ordinal-ranking needs.
+
+## Feature Usage
+
+The keep/drop decision in the selected-features table. Dropping via feature
+usage excludes a feature from SFS/modeling workflows without permanently
+deleting the column from the dataset.
+
+## Forward Selection
+
+An SFS method that starts with no features and adds one feature at each step.
+Early added features are usually the strongest individual contributors under
+the configured evaluation setup.
+
+## Forward-from-Backward
+
+An SFS workflow where the user chooses a backward-selection cut step and then
+runs forward selection using the remaining features at that step as the
+candidate pool.
+
+## Gain
+
+Tree split gain importance. It measures how much a feature's splits improved
+the tree objective during model training.
+
+## Hyperparameter
+
+A model setting chosen before or during training, such as max depth, learning
+rate, number of estimators, regularization strength, or sampling fraction.
+
+## IV
+
+Information Value. A credit-risk metric often used with Weight of Evidence
+binning to evaluate predictive strength. It may appear in domain discussions
+even when the current boosting pipeline does not require scorecard binning.
+
+## JSD
+
+Jensen-Shannon Divergence. A bounded, symmetric distribution-distance metric
+used to compare probability distributions.
+
+## Leakage
+
+Information that would not be available at prediction time or that directly
+reveals the target. Leakage can make validation metrics look unrealistically
+strong and must be excluded.
+
+## Level of Measurement
+
+The semantic measurement type of a feature. Common values include nominal,
+ordinal, continuous, binary, interval, ratio, or unknown. It affects encoding
+and interpretation.
+
+## LightGBM
+
+A gradient-boosting algorithm with efficient training and native categorical
+handling.
+
+## Model_Usage_YN
+
+The data dictionary flag that controls whether a column is included for
+modeling. Use `No` for IDs, timestamps, leakage fields, and operational-only
+columns.
+
+## Native Categorical Handling
+
+Passing categorical features to a boosting algorithm in a way the algorithm can
+handle directly, instead of forcing manual one-hot, ordinal, or label encoding.
+
+## OOT Split
+
+Out-of-time split. A validation split where later observations are held out to
+simulate future deployment behavior.
+
+## PR-AUC
+
+Area under the Precision-Recall curve. It is especially useful for imbalanced
+binary classification where the positive class is rare.
+
+## Precision
+
+The share of predicted positives that are true positives.
+
+## PSI
+
+Population Stability Index. A distribution-shift metric often reviewed with
+rules of thumb: below 0.10 is stable, 0.10 to 0.25 is moderate shift, and above
+0.25 is significant shift.
+
+## Recall
+
+The share of actual positives that the model correctly captures. Also called
+sensitivity or true positive rate.
+
+## ROC-AUC
+
+Area under the Receiver Operating Characteristic curve. It measures ranking
+quality across thresholds.
+
+## SFS
+
+Sequential Feature Selection. A stepwise feature-subset search that can run
+forward, backward, or forward-from-backward.
+
+## SHAP
+
+SHapley Additive exPlanations. SHAP values estimate feature contribution to
+individual predictions. Mean absolute SHAP summarizes global feature impact.
+
+## Split Validation
+
+The review of full/train/test row counts and target rates after a split is
+created.
+
+## Target Definition
+
+The business meaning of the target variable. The assistant should tie modeling
+advice back to the target definition when it is available.
+
+## Top-K Candidates
+
+An SFS performance optimization that fully evaluates only the best quick-screened
+candidates at each step.
+
+## VIF
+
+Variance Inflation Factor. A multicollinearity metric. Values above 5 deserve
+review; values above 10 are usually severe.
+
+## WOE
+
+Weight of Evidence. A credit-risk transformation that maps bins or categories to
+log odds. It is common in scorecards and may be discussed as a domain concept.
+
+## XGBoost
+
+A gradient-boosting algorithm commonly used for tabular classification. DeclarAI
+supports it as a primary boosting model and can use native categorical handling.

--- a/frontend/src/app/services/ai-assistant.service.ts
+++ b/frontend/src/app/services/ai-assistant.service.ts
@@ -9,7 +9,7 @@ export interface AiAction {
   editedPayload?: any;
 }
 
-export type AiIntentLabel = 'A' | 'B' | 'C' | 'D' | 'E';
+export type AiIntentLabel = 'A' | 'B' | 'C' | 'D' | 'E' | 'R';
 
 export interface PendingAiContext {
   context: any;

--- a/frontend/src/app/services/data.service.ts
+++ b/frontend/src/app/services/data.service.ts
@@ -482,7 +482,7 @@ export class DataService {
   sendAiChat(message: string, context: any, section: string,
              history: Array<{role: string; content: string}>,
              fileId?: number, model?: string,
-             intentLabels?: Array<'A' | 'B' | 'C' | 'D' | 'E'>,
+             intentLabels?: Array<'A' | 'B' | 'C' | 'D' | 'E' | 'R'>,
              intentSource?: string): Observable<any> {
     const body: any = { message, context, section, history };
     if (fileId != null) {


### PR DESCRIPTION
## Summary
- add a versioned DeclarAI knowledge bank with platform manual, technical disclosure, glossary, assistant guide, and governance checklist
- add deterministic Markdown retrieval and inject cited knowledge snippets when the intent classifier emits the new R label
- extend assistant intent labels and response metadata, plus frontend intent-label typing

## Validation
- docker pre-commit gate: backend 905 tests across unit/regression/functional/integration/UAT, frontend production build, 411 Karma specs
- docker pre-push gate: backend 905 tests across unit/regression/functional/integration/UAT, frontend build, 411 Karma specs
- focused pytest: AssistantIntentClassifier, KnowledgeBankRetrieval, KnowledgeBankRagWorkflow, context component ordering