### PR TITLE
Collect assistant feedback and send it to Prometa

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Model deployment interface (under development):
 
 The backend's AI Assistant emits structured agent telemetry through
 [`prometa-sdk`](https://github.com/prometa-ai/orchestra-python-sdk)
-(≥ 0.5.0) to the **Prometa Agentic Lifecycle Intelligence Platform**
+(≥ 0.9.0) to the **Prometa Agentic Lifecycle Intelligence Platform**
 for tracing, evaluation, and lifecycle governance.
 
 **Integration point**:
@@ -293,6 +293,8 @@ without Prometa wired up.
 - AML v0.4 instrumentation primitives (`guardrail`, `pii_filter`,
   `memory_read`, `record_retry_attempt`, …) for the platform's
   41-feature agent-maturity scoring.
+- Assistant-answer feedback helpers (`record_user_feedback`,
+  `set_user_feedback`) for thumbs, ratings, and redacted user comments.
 
 See the [SDK README](https://github.com/prometa-ai/orchestra-python-sdk)
 for the complete API surface and the platform's
@@ -406,7 +408,7 @@ auto-ml/
 | python-magic | ≥ 0.4 | MIME-type detection for uploaded files |
 | django-cors-headers | ≥ 4.3 | Cross-origin requests (frontend ↔ backend) |
 | openai | ≥ 1.0 | LLM client for AI Assistant action layer |
-| [prometa-sdk](https://github.com/prometa-ai/orchestra-python-sdk) | ≥ 0.5.0 | Agent telemetry — emits OTLP traces to the Prometa platform via `@prometa.workflow / .agent / .tool` decorators |
+| [prometa-sdk](https://github.com/prometa-ai/orchestra-python-sdk) | ≥ 0.9.0 | Agent telemetry — emits OTLP traces and assistant-answer feedback to the Prometa platform |
 | redis | ≥ 5.0 | Cache + session store for AI Assistant |
 
 ### Frontend

--- a/backend/ai_assistant/feedback.py
+++ b/backend/ai_assistant/feedback.py
@@ -1,0 +1,311 @@
+"""Assistant response feedback collection for Prometa.
+
+The chat UI sends feedback after the assistant turn has completed, so this
+module validates the payload, redacts obvious PII by default, and records a
+dedicated Prometa ``feedback.record`` span with the best target ids available.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .prometa_config import (
+    flush as prometa_flush,
+    has_active_span,
+    record_user_feedback,
+    set_user_feedback,
+)
+
+
+DEFAULT_FEEDBACK_SOURCE = 'declarai-ai-chat-panel'
+MAX_COMMENT_CHARS = 4096
+MAX_ID_CHARS = 256
+MAX_SOURCE_CHARS = 80
+
+_TOKEN_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.:-]*$')
+_EMAIL_RE = re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b')
+_SSN_RE = re.compile(r'\b\d{3}-\d{2}-\d{4}\b')
+_PHONE_RE = re.compile(
+    r'(?<!\d)(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}(?!\d)'
+)
+_LONG_NUMBER_RE = re.compile(r'\b\d{9,}\b')
+
+
+class FeedbackValidationError(ValueError):
+    """Structured validation failure for the feedback API."""
+
+    def __init__(self, errors: dict[str, str]):
+        super().__init__('invalid feedback payload')
+        self.errors = errors
+
+
+@dataclass(frozen=True)
+class AssistantFeedback:
+    liked: bool | None
+    rating: int | None
+    comment: str | None
+    source: str
+    feedback_id: str
+    user_id: str | None
+    submitted_at: str
+    target_trace_id: str | None
+    target_span_id: str | None
+    target_session_id: str | None
+    comment_redacted: bool = False
+
+    def prometa_kwargs(self) -> dict[str, Any]:
+        return {
+            'liked': self.liked,
+            'rating': self.rating,
+            'comment': self.comment,
+            'source': self.source,
+            'feedback_id': self.feedback_id,
+            'user_id': self.user_id,
+            'submitted_at': self.submitted_at,
+            'target_trace_id': self.target_trace_id,
+            'target_span_id': self.target_span_id,
+            'target_session_id': self.target_session_id,
+        }
+
+
+def normalize_feedback_payload(data: dict[str, Any], request=None) -> AssistantFeedback:
+    errors: dict[str, str] = {}
+    allow_pii = _allow_pii(data)
+
+    liked = _normalize_liked(data.get('liked'), errors)
+    rating = _normalize_rating(data.get('rating'), errors)
+    comment, comment_redacted = _normalize_comment(
+        data.get('comment'), allow_pii=allow_pii, errors=errors)
+
+    if liked is None and rating is None and not comment:
+        errors['feedback'] = 'Provide liked, rating, or comment.'
+
+    source = _normalize_source(data.get('source'))
+    feedback_id = _normalize_id(data.get('feedback_id')) or str(uuid.uuid4())
+    submitted_at = _normalize_submitted_at(data.get('submitted_at'), errors)
+
+    target_trace_id = _first_valid_id(data, 'target_trace_id', 'trace_id', 'chat_trace_id')
+    target_span_id = _first_valid_id(data, 'target_span_id', 'span_id', 'chat_span_id')
+    target_session_id = _first_valid_id(
+        data,
+        'target_session_id',
+        'session_id',
+        'conversation_id',
+        'chat_session_id',
+    )
+    if target_session_id is None:
+        file_id = _normalize_file_id(data.get('file_id'))
+        if file_id is not None:
+            target_session_id = f'declarai-file-{file_id}'
+
+    user_id = _normalize_user_id(
+        data.get('user_id') or _request_user_id(request),
+        allow_pii=allow_pii,
+    )
+
+    if errors:
+        raise FeedbackValidationError(errors)
+
+    return AssistantFeedback(
+        liked=liked,
+        rating=rating,
+        comment=comment,
+        source=source,
+        feedback_id=feedback_id,
+        user_id=user_id,
+        submitted_at=submitted_at,
+        target_trace_id=target_trace_id,
+        target_span_id=target_span_id,
+        target_session_id=target_session_id,
+        comment_redacted=comment_redacted,
+    )
+
+
+def submit_feedback_to_prometa(feedback: AssistantFeedback,
+                               *, prefer_active_span: bool = False) -> dict[str, Any]:
+    kwargs = feedback.prometa_kwargs()
+    recorded = False
+    method = 'record_user_feedback'
+
+    if prefer_active_span and has_active_span():
+        recorded = set_user_feedback(**kwargs)
+        method = 'set_user_feedback'
+
+    if not recorded:
+        recorded = record_user_feedback(**kwargs)
+        method = 'record_user_feedback'
+
+    return {
+        'status': 'success',
+        'feedback_id': feedback.feedback_id,
+        'prometa_recorded': recorded,
+        'prometa_method': method,
+        'comment_redacted': feedback.comment_redacted,
+        'user_id_included': bool(feedback.user_id),
+        'target': {
+            'trace_id': feedback.target_trace_id,
+            'span_id': feedback.target_span_id,
+            'session_id': feedback.target_session_id,
+        },
+    }
+
+
+def _allow_pii(data: dict[str, Any]) -> bool:
+    if data.get('allow_pii') is True or data.get('allow_pii_feedback') is True:
+        return True
+    return os.environ.get('PROMETA_FEEDBACK_ALLOW_PII') == '1'
+
+
+def _normalize_liked(value: Any, errors: dict[str, str]) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    errors['liked'] = 'liked must be a boolean.'
+    return None
+
+
+def _normalize_rating(value: Any, errors: dict[str, str]) -> int | None:
+    if value is None or value == '':
+        return None
+    if isinstance(value, bool):
+        errors['rating'] = 'rating must be an integer from 1 to 5.'
+        return None
+    try:
+        rating = int(value)
+    except (TypeError, ValueError):
+        errors['rating'] = 'rating must be an integer from 1 to 5.'
+        return None
+    if rating < 1 or rating > 5:
+        errors['rating'] = 'rating must be an integer from 1 to 5.'
+        return None
+    return rating
+
+
+def _normalize_comment(value: Any, *, allow_pii: bool,
+                       errors: dict[str, str]) -> tuple[str | None, bool]:
+    if value is None:
+        return None, False
+    comment = str(value).strip()
+    if not comment:
+        return None, False
+    if len(comment) > MAX_COMMENT_CHARS:
+        errors['comment'] = f'comment must be {MAX_COMMENT_CHARS} characters or fewer.'
+        return None, False
+    if allow_pii:
+        return comment, False
+
+    redacted = comment
+    redacted = _EMAIL_RE.sub('[redacted-email]', redacted)
+    redacted = _SSN_RE.sub('[redacted-ssn]', redacted)
+    redacted = _PHONE_RE.sub('[redacted-phone]', redacted)
+    redacted = _LONG_NUMBER_RE.sub('[redacted-number]', redacted)
+    return redacted, redacted != comment
+
+
+def _normalize_source(value: Any) -> str:
+    source = str(value or DEFAULT_FEEDBACK_SOURCE).strip()[:MAX_SOURCE_CHARS]
+    return source if _TOKEN_RE.match(source) else DEFAULT_FEEDBACK_SOURCE
+
+
+def _normalize_submitted_at(value: Any, errors: dict[str, str]) -> str:
+    if value is None or value == '':
+        return _utc_now_iso()
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str) and len(value) <= 128:
+        try:
+            dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        except ValueError:
+            errors['submitted_at'] = 'submitted_at must be an ISO timestamp.'
+            return _utc_now_iso()
+    else:
+        errors['submitted_at'] = 'submitted_at must be an ISO timestamp.'
+        return _utc_now_iso()
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def _first_valid_id(data: dict[str, Any], *names: str) -> str | None:
+    for name in names:
+        value = _normalize_id(data.get(name))
+        if value:
+            return value
+    return None
+
+
+def _normalize_id(value: Any, *, max_chars: int = MAX_ID_CHARS) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or len(text) > max_chars:
+        return None
+    return text if _TOKEN_RE.match(text) else None
+
+
+def _normalize_file_id(value: Any) -> int | None:
+    try:
+        file_id = int(value)
+    except (TypeError, ValueError):
+        return None
+    return file_id if file_id > 0 else None
+
+
+def _normalize_user_id(value: Any, *, allow_pii: bool) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or len(text) > 128:
+        return None
+    if allow_pii:
+        return text
+    if _EMAIL_RE.search(text) or _PHONE_RE.search(text) or _SSN_RE.search(text):
+        return None
+    return text if _TOKEN_RE.match(text) else None
+
+
+def _request_user_id(request) -> str | None:
+    user = getattr(request, 'user', None)
+    if not user or not getattr(user, 'is_authenticated', False):
+        return None
+    value = getattr(user, 'id', None)
+    if value is not None:
+        return str(value)
+    get_username = getattr(user, 'get_username', None)
+    if callable(get_username):
+        return get_username()
+    return getattr(user, 'username', None)
+
+
+@method_decorator(csrf_exempt, name='dispatch')
+class AIFeedbackView(APIView):
+    """POST /api/ai-assistant/feedback/"""
+
+    def post(self, request, *args, **kwargs):
+        try:
+            feedback = normalize_feedback_payload(request.data, request=request)
+            result = submit_feedback_to_prometa(feedback, prefer_active_span=False)
+            return Response(result, status=status.HTTP_200_OK)
+        except FeedbackValidationError as exc:
+            return Response(
+                {'status': 'error', 'errors': exc.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        finally:
+            prometa_flush()

--- a/backend/ai_assistant/prometa_config.py
+++ b/backend/ai_assistant/prometa_config.py
@@ -746,6 +746,22 @@ def current_span_id():
         return None
 
 
+def current_trace_id():
+    """Return the trace_id of the currently-active Prometa span, or None.
+
+    Prometa SDK 0.9.0 exposes ``current_span_id()`` publicly, while trace
+    id access still lives on the active span object.  This wrapper keeps
+    that best-effort lookup in one place so callers can target feedback
+    records without depending on SDK-private modules directly.
+    """
+    try:
+        from prometa import _context
+        span = _context.current_span()
+        return getattr(span, 'trace_id', None) if span is not None else None
+    except Exception:
+        return None
+
+
 def set_input_ref(ref_span_id) -> bool:
     """Declare that the active span consumed ``ref_span_id``'s output.
 
@@ -787,5 +803,37 @@ def set_input_ref(ref_span_id) -> bool:
         return False
     try:
         return bool(_sdk_set_input_ref(str(ref_span_id)))
+    except Exception:
+        return False
+
+
+def set_user_feedback(**kwargs) -> bool:
+    """Stamp user feedback on the currently-active Prometa span if possible.
+
+    This is the in-trace path.  UI-submitted feedback normally arrives
+    after ``declarai-chat`` has ended and should use
+    ``record_user_feedback`` instead.
+    """
+    try:
+        from prometa import set_user_feedback as _sdk_set_user_feedback
+    except ImportError:
+        return False
+    try:
+        return bool(_sdk_set_user_feedback(**kwargs))
+    except Exception:
+        return False
+
+
+def record_user_feedback(**kwargs) -> bool:
+    """Emit a standalone Prometa ``feedback.record`` span if configured."""
+    p = get_prometa()
+    if p is None:
+        return False
+    try:
+        from prometa import record_user_feedback as _sdk_record_user_feedback
+    except ImportError:
+        return False
+    try:
+        return bool(_sdk_record_user_feedback(**kwargs))
     except Exception:
         return False

--- a/backend/ai_assistant/views.py
+++ b/backend/ai_assistant/views.py
@@ -17,7 +17,7 @@ from rest_framework.views import APIView
 from .prometa_config import (
     workflow, agent, tool, flush as prometa_flush,
     set_span_attr, set_session_id, set_customer_id, set_request_model,
-    model_route, plan_generate, current_span_id, set_input_ref,
+    model_route, plan_generate, current_span_id, current_trace_id, set_input_ref,
     prompt_render,
 )
 from .tool_definitions import PIPELINE_TOOLS
@@ -1420,9 +1420,11 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
     set_span_attr('declarai.section', section or 'general')
     set_span_attr('declarai.model', model_key)
     _stamp_intent_attrs(intent)
+    session_id = None
     if file_id is not None:
+        session_id = f'declarai-file-{file_id}'
         set_span_attr('declarai.file_id', file_id)
-        set_session_id(f'declarai-file-{file_id}')
+        set_session_id(session_id)
         # v2.30.0 (Phase 2): per-span customer_id override.  Joins every
         # span emitted from this chat turn — and its child agent / tool /
         # cache spans via parent-attribute inheritance — under one
@@ -1846,21 +1848,22 @@ def _chat_workflow(user_message: str, context: dict, section: str, history: list
             }
             for item in rag_result['results']
         ]
+    # v2.45.0: snapshot target ids for assistant-answer feedback.  The
+    # feedback POST arrives after this workflow has ended, so the backend
+    # records a standalone ``feedback.record`` span and needs best-effort
+    # ids to attach it back to the original turn.  ``current_span_id()``
+    # is also still used by action Apply as the cross-trace parent link.
+    chat_span_id = current_span_id()
+    if chat_span_id:
+        response_data['chat_span_id'] = str(chat_span_id)
+    chat_trace_id = current_trace_id()
+    if chat_trace_id:
+        response_data['chat_trace_id'] = str(chat_trace_id)
+    if session_id:
+        response_data['chat_session_id'] = session_id
+
     if actions:
         response_data['actions'] = actions
-        # v2.38.0: snapshot the chat span id so the frontend can pass it
-        # back when applying any of these actions.  ``current_span_id()``
-        # returns None when:
-        #   * SDK is unavailable (test mode, dev box without endpoint)
-        #   * we're outside any @workflow / @tool / @agent context
-        # In all cases the frontend treats a missing id as "no cross-
-        # trace link" and skips the link header on the apply call, so
-        # the legacy v2.25.0..v2.37.0 behaviour is preserved.  The
-        # link is purely-additive observability sugar — it never
-        # changes action dispatch semantics.
-        chat_span_id = current_span_id()
-        if chat_span_id:
-            response_data['chat_span_id'] = str(chat_span_id)
 
     return response_data
 

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -6,6 +6,7 @@ from feature_card.views import FeatureCardViewSet
 from preprocessing.views import PreprocessingApplyView, PreprocessingOptionsView, PreprocessingRunView, PreprocessingDatqDetailView, PreprocessingDatqTimeseriesView, PreprocessingDatqSummaryRowView, PreprocessingStatusView
 from modeling.views import ModelingStartView, ModelingStatusView, FeatureExplainabilityView, SFSResultsView, SFSStartView, SFSStatusView, SFSStopView, VifDetailView, PipelineRunListView, PipelineRunCreateView, PipelineRunDetailView, PipelineReportView, HyperparamStartView, HyperparamStatusView, HyperparamStopView, HyperparamResultsView
 from encoding.views import EncodingAnalyzeView, EncodingApplyView
+from ai_assistant.feedback import AIFeedbackView
 from ai_assistant.views import AIAssistantView, AIActionExecuteView, AICachePushView, AIModelListView
 from django.conf import settings
 from django.conf.urls.static import static
@@ -45,6 +46,7 @@ urlpatterns = [
     path('api/pipeline/<int:pk>/report/', PipelineReportView.as_view(), name='pipeline-report'),
     path('api/ai-assistant/chat/', AIAssistantView.as_view(), name='ai-assistant-chat'),
     path('api/ai-assistant/execute-action/', AIActionExecuteView.as_view(), name='ai-assistant-execute-action'),
+    path('api/ai-assistant/feedback/', AIFeedbackView.as_view(), name='ai-assistant-feedback'),
     path('api/ai-assistant/cache/', AICachePushView.as_view(), name='ai-assistant-cache'),
     path('api/ai-assistant/models/', AIModelListView.as_view(), name='ai-assistant-models'),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,7 @@ statsmodels>=0.14
 
 # AI Assistant
 openai>=1.0
-prometa-sdk==0.7.1
+prometa-sdk==0.9.0
 redis>=5.0
 
 # Testing dependencies

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -4389,7 +4389,8 @@ def _text_response(text):
 
 def _run_chat_workflow(monkeypatch, *, provider, call_llm,
                        user_message='please derive new features from the existing ones',
-                       file_id=1, reasoning=False, history=None):
+                       file_id=1, reasoning=False, history=None,
+                       span_id=None, trace_id=None):
     """Execute the real _chat_workflow body with its external collaborators
     mocked.  ``call_llm(idx, messages, tools)`` scripts each LLM round.
 
@@ -4410,7 +4411,8 @@ def _run_chat_workflow(monkeypatch, *, provider, call_llm,
     monkeypatch.setattr(views, 'set_span_attr', lambda *a, **kw: None)
     monkeypatch.setattr(views, 'set_session_id', lambda *a, **kw: None)
     monkeypatch.setattr(views, 'set_customer_id', lambda *a, **kw: None)
-    monkeypatch.setattr(views, 'current_span_id', lambda: None)
+    monkeypatch.setattr(views, 'current_span_id', lambda: span_id)
+    monkeypatch.setattr(views, 'current_trace_id', lambda: trace_id)
 
     skill_calls = []
 
@@ -7049,6 +7051,156 @@ class TestCrossTraceRefs:
             'action_executor.py must import set_input_ref from '
             'prometa_config (v2.38.0)'
         )
+
+
+# ---------------------------------------------------------------------------
+# v2.45.0: assistant-response feedback → Prometa feedback.record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAssistantResponseFeedback:
+    """Feedback API validation and Prometa SDK call wiring."""
+
+    class _FakeRequest:
+        def __init__(self, data):
+            self.data = data
+            self.user = None
+
+    def test_feedback_view_requires_a_signal(self):
+        from ai_assistant.feedback import AIFeedbackView
+
+        resp = AIFeedbackView().post(self._FakeRequest({
+            'target_span_id': 'span-1',
+        }))
+
+        assert resp.status_code == 400
+        assert resp.data['errors']['feedback'] == 'Provide liked, rating, or comment.'
+
+    def test_feedback_view_validates_liked_and_rating(self):
+        from ai_assistant.feedback import AIFeedbackView
+
+        resp = AIFeedbackView().post(self._FakeRequest({
+            'liked': 'yes',
+            'rating': 6,
+        }))
+
+        assert resp.status_code == 400
+        assert 'liked' in resp.data['errors']
+        assert 'rating' in resp.data['errors']
+
+    def test_feedback_records_prometa_event_with_target_ids(self, monkeypatch):
+        from ai_assistant import feedback as feedback_mod
+
+        captured = {}
+        monkeypatch.setattr(feedback_mod, 'record_user_feedback',
+                            lambda **kw: captured.update(kw) or True)
+        monkeypatch.setattr(feedback_mod, 'set_user_feedback',
+                            lambda **kw: (_ for _ in ()).throw(AssertionError('set_user_feedback should not be used')))
+        monkeypatch.setattr(feedback_mod, 'prometa_flush', lambda: None)
+
+        resp = feedback_mod.AIFeedbackView().post(self._FakeRequest({
+            'liked': True,
+            'rating': 5,
+            'comment': 'Clear and helpful.',
+            'source': 'declarai-ai-chat-panel',
+            'feedback_id': 'feedback-1',
+            'user_id': 'analyst-123',
+            'submitted_at': '2026-06-05T01:02:03Z',
+            'chat_trace_id': 'trace-abc',
+            'chat_span_id': 'span-def',
+            'conversation_id': 'declarai-file-42',
+        }))
+
+        assert resp.status_code == 200
+        assert resp.data['prometa_recorded'] is True
+        assert resp.data['prometa_method'] == 'record_user_feedback'
+        assert captured == {
+            'liked': True,
+            'rating': 5,
+            'comment': 'Clear and helpful.',
+            'source': 'declarai-ai-chat-panel',
+            'feedback_id': 'feedback-1',
+            'user_id': 'analyst-123',
+            'submitted_at': '2026-06-05T01:02:03Z',
+            'target_trace_id': 'trace-abc',
+            'target_span_id': 'span-def',
+            'target_session_id': 'declarai-file-42',
+        }
+
+    def test_feedback_derives_session_id_from_file_id(self, monkeypatch):
+        from ai_assistant import feedback as feedback_mod
+
+        captured = {}
+        monkeypatch.setattr(feedback_mod, 'record_user_feedback',
+                            lambda **kw: captured.update(kw) or True)
+        monkeypatch.setattr(feedback_mod, 'prometa_flush', lambda: None)
+
+        resp = feedback_mod.AIFeedbackView().post(self._FakeRequest({
+            'liked': False,
+            'file_id': 77,
+            'target_span_id': 'span-77',
+        }))
+
+        assert resp.status_code == 200
+        assert captured['target_session_id'] == 'declarai-file-77'
+        assert captured['target_span_id'] == 'span-77'
+
+    def test_feedback_redacts_pii_comment_and_drops_unsafe_user_id(self, monkeypatch):
+        from ai_assistant import feedback as feedback_mod
+
+        captured = {}
+        monkeypatch.setattr(feedback_mod, 'record_user_feedback',
+                            lambda **kw: captured.update(kw) or True)
+        monkeypatch.setattr(feedback_mod, 'prometa_flush', lambda: None)
+
+        resp = feedback_mod.AIFeedbackView().post(self._FakeRequest({
+            'comment': 'Contact me at person@example.com or 415-555-1212.',
+            'user_id': 'person@example.com',
+            'target_span_id': 'span-safe',
+        }))
+
+        assert resp.status_code == 200
+        assert resp.data['comment_redacted'] is True
+        assert resp.data['user_id_included'] is False
+        assert captured['user_id'] is None
+        assert 'person@example.com' not in captured['comment']
+        assert '415-555-1212' not in captured['comment']
+        assert '[redacted-email]' in captured['comment']
+        assert '[redacted-phone]' in captured['comment']
+
+    def test_feedback_allows_raw_comment_and_user_id_when_explicit(self, monkeypatch):
+        from ai_assistant import feedback as feedback_mod
+
+        captured = {}
+        monkeypatch.setattr(feedback_mod, 'record_user_feedback',
+                            lambda **kw: captured.update(kw) or True)
+        monkeypatch.setattr(feedback_mod, 'prometa_flush', lambda: None)
+
+        resp = feedback_mod.AIFeedbackView().post(self._FakeRequest({
+            'liked': True,
+            'comment': 'Email person@example.com about this answer.',
+            'user_id': 'person@example.com',
+            'allow_pii': True,
+        }))
+
+        assert resp.status_code == 200
+        assert captured['comment'] == 'Email person@example.com about this answer.'
+        assert captured['user_id'] == 'person@example.com'
+
+    def test_chat_workflow_returns_feedback_target_ids(self, monkeypatch):
+        out = _run_chat_workflow(
+            monkeypatch,
+            provider='openai',
+            file_id=42,
+            span_id='span-abc',
+            trace_id='trace-def',
+            call_llm=lambda idx, messages, tools: _text_response('done'),
+        )
+
+        assert out['result']['chat_span_id'] == 'span-abc'
+        assert out['result']['chat_trace_id'] == 'trace-def'
+        assert out['result']['chat_session_id'] == 'declarai-file-42'
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.css
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.css
@@ -738,3 +738,125 @@
   background: #e8f5e9;
   border-radius: 4px;
 }
+
+/* Assistant answer feedback */
+.message-feedback {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.feedback-icon-btn,
+.feedback-star-btn,
+.feedback-comment-btn {
+  width: 26px;
+  height: 26px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  background: #fff;
+  color: #777;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  line-height: 1;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.feedback-icon-btn:hover:not(:disabled),
+.feedback-star-btn:hover:not(:disabled),
+.feedback-comment-btn:hover:not(:disabled) {
+  border-color: #bdbdbd;
+  background: #fafafa;
+  color: #333;
+}
+
+.feedback-icon-btn.active,
+.feedback-comment-btn.active {
+  border-color: #740505;
+  background: #fff5f5;
+  color: #740505;
+}
+
+.feedback-stars {
+  display: inline-flex;
+  gap: 1px;
+  margin-left: 2px;
+}
+
+.feedback-star-btn {
+  border-color: transparent;
+  background: transparent;
+  color: #c7c7c7;
+}
+
+.feedback-star-btn.active {
+  color: #b7791f;
+}
+
+.feedback-submit-btn {
+  min-width: 62px;
+  height: 26px;
+  padding: 0 9px;
+  border: 1px solid #740505;
+  border-radius: 4px;
+  background: #740505;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.12s, background 0.12s;
+}
+
+.feedback-submit-btn:hover:not(:disabled) {
+  background: #920707;
+}
+
+.feedback-submit-btn:disabled,
+.feedback-icon-btn:disabled,
+.feedback-star-btn:disabled,
+.feedback-comment-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.message-feedback.submitted .feedback-submit-btn {
+  border-color: #2e7d32;
+  background: #2e7d32;
+}
+
+.feedback-comment-row {
+  flex-basis: 100%;
+  margin-top: 3px;
+}
+
+.feedback-comment-input {
+  width: 100%;
+  min-height: 48px;
+  max-height: 110px;
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 7px 8px;
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+  resize: vertical;
+  color: #333;
+}
+
+.feedback-comment-input:focus {
+  outline: none;
+  border-color: #740505;
+  box-shadow: 0 0 0 2px rgba(116, 5, 5, 0.1);
+}
+
+.feedback-error {
+  flex-basis: 100%;
+  color: #c62828;
+  font-size: 11px;
+  margin-top: 2px;
+}

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.html
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.html
@@ -194,6 +194,68 @@
           <div *ngIf="actionError" class="action-error">{{ actionError }}</div>
           <div *ngIf="actionSuccess" class="action-success">{{ actionSuccess }}</div>
         </div>
+        <div
+          class="message-feedback"
+          *ngIf="msg.role === 'assistant' && !msg.loading && !msg.autoCorrection"
+          [class.submitted]="msg.feedback?.submitted"
+        >
+          <button
+            type="button"
+            class="feedback-icon-btn"
+            [class.active]="msg.feedback?.liked === true"
+            [disabled]="msg.feedback?.submitted || msg.feedback?.submitting"
+            (click)="setFeedbackLiked(mi, true)"
+            title="Thumbs up"
+          >&#128077;</button>
+          <button
+            type="button"
+            class="feedback-icon-btn"
+            [class.active]="msg.feedback?.liked === false"
+            [disabled]="msg.feedback?.submitted || msg.feedback?.submitting"
+            (click)="setFeedbackLiked(mi, false)"
+            title="Thumbs down"
+          >&#128078;</button>
+          <div class="feedback-stars" aria-label="Optional star rating">
+            <button
+              type="button"
+              *ngFor="let star of feedbackStars"
+              class="feedback-star-btn"
+              [class.active]="(msg.feedback?.rating || 0) >= star"
+              [disabled]="msg.feedback?.submitted || msg.feedback?.submitting"
+              (click)="setFeedbackRating(mi, star)"
+              [title]="star + ' star rating'"
+            >&#9733;</button>
+          </div>
+          <button
+            type="button"
+            class="feedback-comment-btn"
+            [class.active]="msg.feedback?.commentOpen"
+            [disabled]="msg.feedback?.submitted || msg.feedback?.submitting"
+            (click)="toggleFeedbackComment(mi)"
+            title="Add comment"
+          >&#9998;</button>
+          <button
+            type="button"
+            class="feedback-submit-btn"
+            [disabled]="msg.feedback?.submitted || msg.feedback?.submitting || !canSubmitFeedback(msg)"
+            (click)="submitFeedback(mi)"
+            title="Submit feedback"
+          >
+            <span *ngIf="!msg.feedback?.submitting && !msg.feedback?.submitted">Submit</span>
+            <span *ngIf="msg.feedback?.submitting">Sending...</span>
+            <span *ngIf="msg.feedback?.submitted">&#10003; Sent</span>
+          </button>
+          <div class="feedback-comment-row" *ngIf="msg.feedback?.commentOpen && !msg.feedback?.submitted">
+            <textarea
+              class="feedback-comment-input"
+              [value]="msg.feedback?.comment || ''"
+              (input)="onFeedbackCommentChange(mi, $any($event.target).value)"
+              placeholder="Optional comment"
+              rows="2"
+            ></textarea>
+          </div>
+          <div class="feedback-error" *ngIf="msg.feedback?.error">{{ msg.feedback?.error }}</div>
+        </div>
         <div class="chat-message-section" *ngIf="msg.section">
           {{ getSectionLabel(msg.section) }}
         </div>

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.spec.ts
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.spec.ts
@@ -1008,6 +1008,8 @@ describe('AiChatPanelComponent', () => {
         message: 'I prepared an action.',
         actions: [{ type: 'update_notes', payload: { description: 'note' } }],
         chat_span_id: 'chat-span-abc123',
+        chat_trace_id: 'trace-abc123',
+        chat_session_id: 'declarai-file-1',
       }));
       spyOn(dataService, 'getAiModels').and.returnValue(of({ models: [], default: 'gpt-5.5' }));
 
@@ -1018,6 +1020,8 @@ describe('AiChatPanelComponent', () => {
 
       const last = aiService.getMessages().slice(-1)[0];
       expect(last.chatSpanId).toBe('chat-span-abc123');
+      expect(last.chatTraceId).toBe('trace-abc123');
+      expect(last.chatSessionId).toBe('declarai-file-1');
     });
 
     it('should leave chatSpanId undefined when /chat/ response omits the field', () => {
@@ -1100,6 +1104,63 @@ describe('AiChatPanelComponent', () => {
         { description: 'note' },
         undefined,                    // ← key assertion: no link forwarded
       );
+    });
+  });
+
+  describe('assistant answer feedback', () => {
+    beforeEach(() => {
+      sharedService.setCurrentFileId(42);
+    });
+
+    it('submitFeedback should send thumbs/rating/comment with Prometa target ids', () => {
+      aiService.addMessage({
+        role: 'assistant',
+        content: 'Useful answer',
+        timestamp: new Date(),
+        chatSpanId: 'span-1',
+        chatTraceId: 'trace-1',
+        chatSessionId: 'declarai-file-42',
+        feedback: {
+          liked: true,
+          rating: 4,
+          comment: 'This clarified the PSI threshold.',
+          feedbackId: 'feedback-1',
+        },
+      });
+      const submitSpy = spyOn(dataService, 'submitAiFeedback').and.returnValue(
+        of({ status: 'success', feedback_id: 'feedback-1' })
+      );
+
+      component.submitFeedback(0);
+
+      expect(submitSpy).toHaveBeenCalled();
+      const payload = submitSpy.calls.mostRecent().args[0];
+      expect(payload.liked).toBeTrue();
+      expect(payload.rating).toBe(4);
+      expect(payload.comment).toBe('This clarified the PSI threshold.');
+      expect(payload.source).toBe('declarai-ai-chat-panel');
+      expect(payload.feedback_id).toBe('feedback-1');
+      expect(payload.target_trace_id).toBe('trace-1');
+      expect(payload.target_span_id).toBe('span-1');
+      expect(payload.target_session_id).toBe('declarai-file-42');
+      expect(payload.conversation_id).toBe('declarai-file-42');
+      expect(payload.file_id).toBe(42);
+      expect(payload.submitted_at).toBeTruthy();
+      expect(aiService.getMessages()[0].feedback?.submitted).toBeTrue();
+    });
+
+    it('submitFeedback should require a thumb, rating, or comment before POSTing', () => {
+      aiService.addMessage({
+        role: 'assistant',
+        content: 'Answer',
+        timestamp: new Date(),
+      });
+      const submitSpy = spyOn(dataService, 'submitAiFeedback');
+
+      component.submitFeedback(0);
+
+      expect(submitSpy).not.toHaveBeenCalled();
+      expect(aiService.getMessages()[0].feedback?.error).toContain('Choose a thumb');
     });
   });
 

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy, ViewChild, ElementRef, AfterViewChecked } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { AiAssistantService, AiAction, AiIntentLabel, ChatMessage } from '../services/ai-assistant.service';
+import { AiAssistantService, AiAction, AiFeedbackState, AiIntentLabel, ChatMessage } from '../services/ai-assistant.service';
 import { DataService } from '../services/data.service';
 import { SharedService } from '../services/shared.service';
 
@@ -19,6 +19,8 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
   private currentSection: string = '';
   private subscriptions = new Subscription();
   private shouldScrollToBottom = false;
+  feedbackStars = [1, 2, 3, 4, 5];
+  private feedbackSequence = 0;
 
   // Model selector
   availableModels: Array<{key: string; display_name: string; provider: string; ram_gb?: number; tool_calling_mode?: string}> = [];
@@ -161,6 +163,8 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
           resp.message || fallbackMsg,
           actions,
           resp.chat_span_id,
+          resp.chat_trace_id,
+          resp.chat_session_id,
         );
         this.isLoading = false;
       },
@@ -792,6 +796,8 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
           resp.message || correctionFallback,
           actions,
           resp.chat_span_id,
+          resp.chat_trace_id,
+          resp.chat_session_id,
         );
         this.isLoading = false;
         // Clear the error since the AI has provided a correction
@@ -1081,6 +1087,110 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
       general: 'General',
     };
     return labels[section] || section;
+  }
+
+  setFeedbackLiked(messageIndex: number, liked: boolean): void {
+    const msg = this.aiService.getMessages()[messageIndex];
+    if (!msg || msg.feedback?.submitted || msg.feedback?.submitting) return;
+    this.aiService.updateMessageFeedback(messageIndex, { liked, error: undefined });
+  }
+
+  setFeedbackRating(messageIndex: number, rating: number): void {
+    const msg = this.aiService.getMessages()[messageIndex];
+    if (!msg || msg.feedback?.submitted || msg.feedback?.submitting) return;
+    const nextRating = msg.feedback?.rating === rating ? undefined : rating;
+    this.aiService.updateMessageFeedback(messageIndex, { rating: nextRating, error: undefined });
+  }
+
+  toggleFeedbackComment(messageIndex: number): void {
+    const msg = this.aiService.getMessages()[messageIndex];
+    if (!msg || msg.feedback?.submitted || msg.feedback?.submitting) return;
+    this.aiService.updateMessageFeedback(messageIndex, {
+      commentOpen: !msg.feedback?.commentOpen,
+      error: undefined,
+    });
+  }
+
+  onFeedbackCommentChange(messageIndex: number, value: string): void {
+    const msg = this.aiService.getMessages()[messageIndex];
+    if (!msg || msg.feedback?.submitted || msg.feedback?.submitting) return;
+    this.aiService.updateMessageFeedback(messageIndex, { comment: value, error: undefined });
+  }
+
+  canSubmitFeedback(msg: ChatMessage): boolean {
+    const feedback = msg.feedback || {};
+    return !!(
+      feedback.liked !== undefined ||
+      feedback.rating ||
+      (feedback.comment || '').trim()
+    );
+  }
+
+  submitFeedback(messageIndex: number): void {
+    const msg = this.aiService.getMessages()[messageIndex];
+    if (!msg || msg.role !== 'assistant' || msg.feedback?.submitted || msg.feedback?.submitting) return;
+
+    const feedback: AiFeedbackState = msg.feedback || {};
+    const comment = (feedback.comment || '').trim();
+    if (!this.canSubmitFeedback(msg)) {
+      this.aiService.updateMessageFeedback(messageIndex, {
+        error: 'Choose a thumb, star rating, or add a comment.',
+      });
+      return;
+    }
+
+    const feedbackId = feedback.feedbackId || this.newFeedbackId(messageIndex);
+    const payload: any = {
+      source: 'declarai-ai-chat-panel',
+      feedback_id: feedbackId,
+      submitted_at: new Date().toISOString(),
+    };
+    if (feedback.liked !== undefined) payload.liked = feedback.liked;
+    if (feedback.rating) payload.rating = feedback.rating;
+    if (comment) payload.comment = comment;
+    if (msg.chatTraceId) payload.target_trace_id = msg.chatTraceId;
+    if (msg.chatSpanId) payload.target_span_id = msg.chatSpanId;
+    if (msg.chatSessionId) {
+      payload.target_session_id = msg.chatSessionId;
+      payload.conversation_id = msg.chatSessionId;
+    }
+    const fileId = this.sharedService.getCurrentFileId();
+    if (fileId != null) payload.file_id = fileId;
+
+    this.aiService.updateMessageFeedback(messageIndex, {
+      submitting: true,
+      error: undefined,
+      feedbackId,
+    });
+    this.dataService.submitAiFeedback(payload).subscribe({
+      next: (resp: any) => {
+        this.aiService.updateMessageFeedback(messageIndex, {
+          submitting: false,
+          submitted: true,
+          commentOpen: false,
+          feedbackId: resp?.feedback_id || feedbackId,
+          error: undefined,
+        });
+      },
+      error: (err: any) => {
+        const msgText = err?.error?.errors
+          ? Object.values(err.error.errors).join(' ')
+          : (err?.error?.error || err?.message || 'Feedback could not be submitted.');
+        this.aiService.updateMessageFeedback(messageIndex, {
+          submitting: false,
+          error: msgText,
+        });
+      },
+    });
+  }
+
+  private newFeedbackId(messageIndex: number): string {
+    const cryptoObj = globalThis.crypto;
+    if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+      return cryptoObj.randomUUID();
+    }
+    this.feedbackSequence += 1;
+    return `declarai-feedback-${Date.now()}-${messageIndex}-${this.feedbackSequence}`;
   }
 
   private scrollToBottom(): void {

--- a/frontend/src/app/services/ai-assistant.service.spec.ts
+++ b/frontend/src/app/services/ai-assistant.service.spec.ts
@@ -149,6 +149,37 @@ describe('AiAssistantService', () => {
       // missing) must be treated identically to omitted — never stamped.
       expect(msgs[msgs.length - 1].chatSpanId).toBeUndefined();
     });
+
+    it('should persist trace and session ids when provided for feedback targeting', () => {
+      service.addMessage({ role: 'assistant', content: '...', timestamp: new Date(), loading: true });
+      service.updateLastMessage('Done', [], 'span-1', 'trace-1', 'declarai-file-42');
+      const msg = service.getMessages().slice(-1)[0];
+      expect(msg.chatSpanId).toBe('span-1');
+      expect(msg.chatTraceId).toBe('trace-1');
+      expect(msg.chatSessionId).toBe('declarai-file-42');
+    });
+  });
+
+  // ── feedback state ─────────────────────────────────────────────────
+  describe('feedback state', () => {
+    it('should patch feedback state on assistant messages', () => {
+      service.addMessage({ role: 'assistant', content: 'A1', timestamp: new Date() });
+
+      service.updateMessageFeedback(0, { liked: true });
+      service.updateMessageFeedback(0, { rating: 5 });
+
+      const feedback = service.getMessages()[0].feedback!;
+      expect(feedback.liked).toBeTrue();
+      expect(feedback.rating).toBe(5);
+    });
+
+    it('should ignore feedback patches for user messages', () => {
+      service.addMessage({ role: 'user', content: 'Q1', timestamp: new Date() });
+
+      service.updateMessageFeedback(0, { liked: true });
+
+      expect(service.getMessages()[0].feedback).toBeUndefined();
+    });
   });
 
   // ── markActionApplied ──────────────────────────────────────────────

--- a/frontend/src/app/services/ai-assistant.service.ts
+++ b/frontend/src/app/services/ai-assistant.service.ts
@@ -11,6 +11,17 @@ export interface AiAction {
 
 export type AiIntentLabel = 'A' | 'B' | 'C' | 'D' | 'E' | 'R';
 
+export interface AiFeedbackState {
+  liked?: boolean;
+  rating?: number;
+  comment?: string;
+  commentOpen?: boolean;
+  submitting?: boolean;
+  submitted?: boolean;
+  error?: string;
+  feedbackId?: string;
+}
+
 export interface PendingAiContext {
   context: any;
   section: string;
@@ -52,6 +63,9 @@ export interface ChatMessage {
    * link" and the apply call simply omits the `parent_span_id` field.
    */
   chatSpanId?: string;
+  chatTraceId?: string;
+  chatSessionId?: string;
+  feedback?: AiFeedbackState;
 }
 
 @Injectable({
@@ -92,7 +106,8 @@ export class AiAssistantService {
     this.messagesSubject.next(messages);
   }
 
-  updateLastMessage(content: string, actions?: AiAction[], chatSpanId?: string): void {
+  updateLastMessage(content: string, actions?: AiAction[], chatSpanId?: string,
+                    chatTraceId?: string, chatSessionId?: string): void {
     const messages = [...this.messagesSubject.getValue()];
     if (messages.length > 0) {
       messages[messages.length - 1] = {
@@ -106,9 +121,25 @@ export class AiAssistantService {
         // are unaffected and an absent id keeps the message clean
         // rather than writing `chatSpanId: undefined`.
         ...(chatSpanId ? { chatSpanId } : {}),
+        ...(chatTraceId ? { chatTraceId } : {}),
+        ...(chatSessionId ? { chatSessionId } : {}),
       };
       this.messagesSubject.next(messages);
     }
+  }
+
+  updateMessageFeedback(messageIndex: number, patch: Partial<AiFeedbackState>): void {
+    const messages = [...this.messagesSubject.getValue()];
+    const msg = messages[messageIndex];
+    if (!msg || msg.role !== 'assistant') return;
+    messages[messageIndex] = {
+      ...msg,
+      feedback: {
+        ...(msg.feedback || {}),
+        ...patch,
+      },
+    };
+    this.messagesSubject.next(messages);
   }
 
   /** Mark an action on a specific message as applied */

--- a/frontend/src/app/services/data.service.spec.ts
+++ b/frontend/src/app/services/data.service.spec.ts
@@ -401,6 +401,31 @@ describe('DataService', () => {
       req.flush({ message: 'Response' });
     });
 
+    it('submitAiFeedback should POST feedback payload with target ids', () => {
+      service.submitAiFeedback({
+        liked: true,
+        rating: 5,
+        comment: 'Helpful answer',
+        source: 'declarai-ai-chat-panel',
+        feedback_id: 'feedback-1',
+        target_trace_id: 'trace-1',
+        target_span_id: 'span-1',
+        target_session_id: 'declarai-file-42',
+        submitted_at: '2026-06-05T01:02:03.000Z',
+      }).subscribe(res => {
+        expect(res.status).toBe('success');
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}ai-assistant/feedback/`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body.liked).toBeTrue();
+      expect(req.request.body.rating).toBe(5);
+      expect(req.request.body.target_trace_id).toBe('trace-1');
+      expect(req.request.body.target_span_id).toBe('span-1');
+      expect(req.request.body.target_session_id).toBe('declarai-file-42');
+      req.flush({ status: 'success', feedback_id: 'feedback-1' });
+    });
+
     it('sendAiChat should include preclassified intent labels when provided', () => {
       service.sendAiChat(
         'Analyze the current summary',

--- a/frontend/src/app/services/data.service.ts
+++ b/frontend/src/app/services/data.service.ts
@@ -505,6 +505,27 @@ export class DataService {
     );
   }
 
+  submitAiFeedback(payload: {
+    liked?: boolean;
+    rating?: number;
+    comment?: string;
+    source?: string;
+    feedback_id?: string;
+    target_trace_id?: string;
+    target_span_id?: string;
+    target_session_id?: string;
+    conversation_id?: string;
+    submitted_at?: string;
+    file_id?: number;
+  }): Observable<any> {
+    return this.http.post(`${this.apiUrl}ai-assistant/feedback/`, payload).pipe(
+      catchError((err: any) => {
+        console.error('Error submitting AI feedback:', err);
+        return throwError(() => err);
+      })
+    );
+  }
+
   getAiModels(): Observable<any> {
     return this.http.get(`${this.apiUrl}ai-assistant/models/`).pipe(
       catchError((err: any) => {


### PR DESCRIPTION
## Summary
- Add an AI assistant feedback endpoint that validates thumbs/rating/comment payloads and records Prometa `feedback.record` events through `prometa-sdk==0.9.0`.
- Return chat span/trace/session ids from assistant responses and propagate them from the Angular feedback UI.
- Redact obvious PII from comments and drop unsafe user ids unless explicitly allowed.

## Tests
- Pre-commit gate: backend unit/regression/functional/integration/UAT passed, frontend production build passed, frontend Karma passed.
- Pre-push gate: backend 912 tests passed across 5 categories, frontend build passed, 417 Karma specs passed.