### PR TITLE
[codex] Remove redundant purifier default selections

### DIFF
--- a/backend/preprocessing/purifier_catalog.py
+++ b/backend/preprocessing/purifier_catalog.py
@@ -177,7 +177,7 @@ PURIFIER_OPTIONS: list[dict] = [
 # Purifier Declaration screen.  Centralized here so /api/preprocessing/
 # options/ can expose them and the frontend can eventually drop its
 # duplicated `defaultOptionIds` array.
-DEFAULT_SELECTED_IDS: list[int] = [1, 2, 3, 4, 7, 11, 17, 23, 28, 32]
+DEFAULT_SELECTED_IDS: list[int] = [1, 2, 3, 4, 7, 23, 28, 32]
 
 
 # ── Internal lookup table ────────────────────────────────────────

--- a/backend/preprocessing/views.py
+++ b/backend/preprocessing/views.py
@@ -93,7 +93,7 @@ class PreprocessingOptionsView(APIView):
           },
           ...
         ],
-        "default_selected_ids": [1, 2, 3, 4, 7, 11, 17, 23, 28, 32]
+        "default_selected_ids": [1, 2, 3, 4, 7, 23, 28, 32]
       }
     """
 

--- a/backend/scripts/probe_topic_drift.py
+++ b/backend/scripts/probe_topic_drift.py
@@ -28,7 +28,7 @@ CONTEXT = {
     "pipeline_config": {
         "target_definition": "good/bad flag of credit applications within the 12 months period of its usage",
         "pipeline_type": "boosting",
-        "purifier_options": [1, 2, 3, 4, 7, 11, 17, 23, 28, 32],
+        "purifier_options": [1, 2, 3, 4, 7, 23, 28, 32],
     },
     "selected_features": [
         "FE_Debt_To_Income", "FE_Credit_Utilization", "FE_Income_Verification_Diff",

--- a/backend/tests/test_functional.py
+++ b/backend/tests/test_functional.py
@@ -318,6 +318,7 @@ class TestPreprocessingOptionsAPI:
     def test_options_endpoint_default_selected_ids_subset_of_catalog(self, api_client):
         response = api_client.get('/api/preprocessing/options/')
         assert response.status_code == 200
+        assert response.data['default_selected_ids'] == [1, 2, 3, 4, 7, 23, 28, 32]
         catalog_ids = {e['id'] for e in response.data['options']}
         for opt_id in response.data['default_selected_ids']:
             assert opt_id in catalog_ids, f"default id {opt_id} not in catalog"

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -8073,6 +8073,13 @@ class TestPurifierCatalog:
         for opt_id in DEFAULT_SELECTED_IDS:
             assert get_option(opt_id) is not None, f"default id {opt_id} not in catalog"
 
+    def test_default_selected_ids_use_combined_sparsity_missing_drop(self):
+        from preprocessing.purifier_catalog import DEFAULT_SELECTED_IDS
+        assert DEFAULT_SELECTED_IDS == [1, 2, 3, 4, 7, 23, 28, 32]
+        assert 11 not in DEFAULT_SELECTED_IDS
+        assert 17 not in DEFAULT_SELECTED_IDS
+        assert 23 in DEFAULT_SELECTED_IDS
+
 
 @pytest.mark.unit
 class TestPurifierApplyOptions:

--- a/frontend/e2e/preprocessing-options-api.spec.ts
+++ b/frontend/e2e/preprocessing-options-api.spec.ts
@@ -96,6 +96,7 @@ test.describe('GET /api/preprocessing/options/ — canonical purifier catalog', 
     }
     expect(response.status()).toBe(200);
     const body = await response.json();
+    expect(body.default_selected_ids).toEqual([1, 2, 3, 4, 7, 23, 28, 32]);
     const catalogIds = new Set<number>(body.options.map((o: { id: number }) => o.id));
     for (const optId of body.default_selected_ids) {
       expect(catalogIds.has(optId), `default id ${optId} not in catalog`).toBe(true);

--- a/frontend/src/app/model-development/model-development.component.spec.ts
+++ b/frontend/src/app/model-development/model-development.component.spec.ts
@@ -55,6 +55,13 @@ describe('ModelDevelopmentComponent', () => {
     expect(component.selectedPipeline).toBe('');
   });
 
+  it('should preselect combined sparsity/missing purifier option without separate duplicates', () => {
+    const ids = component.selectedOptions.map((o: any) => o.id).sort((a: number, b: number) => a - b);
+    expect(ids).toEqual([1, 2, 3, 4, 7, 23, 28, 32]);
+    expect(ids).not.toContain(11);
+    expect(ids).not.toContain(17);
+  });
+
   it('should have showSteps flags all false initially', () => {
     expect(component.showSteps['declaration']).toBeFalse();
     expect(component.showSteps['modeling']).toBeFalse();
@@ -235,7 +242,7 @@ describe('ModelDevelopmentComponent', () => {
 
     it('should REPLACE selectedOptions on wholesale-form broadcast', (done) => {
       spyOn(dataService, 'pushAiCache').and.returnValue(of({ status: 'success' }));
-      // Seed with the v2.27.x default set so we can verify it gets
+      // Seed with the redundant screenshot selection so we can verify it gets
       // wholesale-replaced.
       component.selectedOptions = component.purifierOptions
         .filter((o: any) => [1, 2, 3, 4, 7, 11, 17, 23, 28, 32].includes(o.id));

--- a/frontend/src/app/model-development/model-development.component.ts
+++ b/frontend/src/app/model-development/model-development.component.ts
@@ -793,7 +793,7 @@ export class ModelDevelopmentComponent implements OnInit, AfterViewChecked {
     { id: 34, name: 'Outlier Cleaning (Categorical Features) threshold = 0.05', group: 6 },
   ];
 
-  private defaultOptionIds: number[] = [1, 2, 3, 4, 7, 11, 17, 23, 28, 32];
+  private defaultOptionIds: number[] = [1, 2, 3, 4, 7, 23, 28, 32];
   selectedOptions: PurifierOption[] = this.purifierOptions.filter(o => this.defaultOptionIds.includes(o.id));
 
   constructor(private router: Router, private sharedService: SharedService, private dataService: DataService, private dialog: MatDialog, public aiAssistant: AiAssistantService) {}


### PR DESCRIPTION
## What changed
- Removed purifier option IDs 11 and 17 from the default/preselected data-purifier list.
- Kept option ID 23 selected as the combined sparsity/missing drop at the same threshold.
- Updated backend/API, frontend UI defaults, probe context, and contract tests to pin the new default list.

## Why
The preselected data-purification flow was selecting separate sparsity-drop and missing-drop rules while also selecting the combined sparsity/missing rule. Option 23 already covers the intended 0.95 threshold behavior, so the default UI state should not include 11 and 17.

## Validation
- Pre-commit gate: backend unit/regression/functional/integration/UAT passed; frontend build passed; 420 Karma specs passed.
- Pre-push gate: backend unit/regression/functional/integration/UAT passed; frontend build passed; 420 Karma specs passed.
- Focused frontend run: `npm test -- --watch=false --browsers=ChromeHeadless --include=src/app/model-development/model-development.component.spec.ts` passed 29/29 specs.
- Backend constant and syntax checks passed.