### PR TITLE
[codex] Show hyperparameter tuning in pipeline flow

### DIFF
--- a/backend/modeling/views.py
+++ b/backend/modeling/views.py
@@ -2251,6 +2251,7 @@ class PipelineRunListView(APIView):
             'modeling_started': '3b_modeling',
             'modeling_completed': '3b_modeling',
             'sfs_backward_completed': '3ci_sfs_backward',
+            'hyperparam_completed': '3d_hyperparameter_tuning',
         }
         if current_step == 'declaration':
             return '1b_data_declaration' if file_id else '1a_pipeline_declaration'
@@ -2264,6 +2265,8 @@ class PipelineRunListView(APIView):
                     return _SUB_MAP[modeling_sub]
                 if modeling_sub.startswith('sfs_'):
                     return '3c_sfs'
+                if modeling_sub.startswith('hyperparam_'):
+                    return '3d_hyperparameter_tuning'
             return '3a_encoding' if current_step == 'modeling' else '3c_sfs'
         return '1a_pipeline_declaration'
 

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -621,6 +621,7 @@ class TestInferDetailedStep:
         'modeling_started': '3b_modeling',
         'modeling_completed': '3b_modeling',
         'sfs_backward_completed': '3ci_sfs_backward',
+        'hyperparam_completed': '3d_hyperparameter_tuning',
     }
 
     def _infer(self, current_step, modeling_sub, file_id):
@@ -636,6 +637,8 @@ class TestInferDetailedStep:
                     return self._SUB_MAP[modeling_sub]
                 if modeling_sub.startswith('sfs_'):
                     return '3c_sfs'
+                if modeling_sub.startswith('hyperparam_'):
+                    return '3d_hyperparameter_tuning'
             return '3a_encoding' if current_step == 'modeling' else '3c_sfs'
         return '1a_pipeline_declaration'
 
@@ -665,6 +668,9 @@ class TestInferDetailedStep:
 
     def test_sfs_generic_substep(self):
         assert self._infer('modeling', 'sfs_forward_completed', 1) == '3c_sfs'
+
+    def test_hyperparam_substep(self):
+        assert self._infer('sfs', 'hyperparam_completed', 1) == '3d_hyperparameter_tuning'
 
     def test_sfs_step_no_substep(self):
         assert self._infer('sfs', '', None) == '3c_sfs'

--- a/frontend/src/app/model-development/model-development.component.spec.ts
+++ b/frontend/src/app/model-development/model-development.component.spec.ts
@@ -67,6 +67,31 @@ describe('ModelDevelopmentComponent', () => {
     expect(component.showSteps['modeling']).toBeFalse();
   });
 
+  it('should include hyperparameter tuning as the post-SFS pipeline flow sub-step', () => {
+    const modelingStep = component.navMainSteps.find((step) => step.id === 'modeling');
+    expect(modelingStep?.subSteps.map((sub) => sub.label)).toContain('Hyperparameter Tuning');
+  });
+
+  it('should mark hyperparameter tuning in progress after SFS and completed after results', () => {
+    const sharedService = TestBed.inject(SharedService);
+
+    sharedService.setModelingCheckpoint({
+      substep: 'sfs_completed',
+      modelingStatus: { model: {} },
+      sfsBackwardResults: [{ step: 1 }],
+    });
+    expect(component.getSubStepStatus('2c')).toBe('completed');
+    expect(component.getSubStepStatus('2d')).toBe('in_progress');
+
+    sharedService.setModelingCheckpoint({
+      substep: 'hyperparam_completed',
+      modelingStatus: { model: {} },
+      sfsBackwardResults: [{ step: 1 }],
+      hpResults: { best_params: {} },
+    });
+    expect(component.getSubStepStatus('2d')).toBe('completed');
+  });
+
   // ── dataPurifierStartRequests$ subscription (v2.26.0+) ──────────────
   // AI's `start_data_purifier` action broadcasts here; this component
   // patches selectedOptions + split form fields and calls

--- a/frontend/src/app/model-development/model-development.component.ts
+++ b/frontend/src/app/model-development/model-development.component.ts
@@ -162,6 +162,7 @@ export class ModelDevelopmentComponent implements OnInit, AfterViewChecked {
         { id: '2a', label: 'Categorical Encoding' },
         { id: '2b', label: 'Model Training & CV' },
         { id: '2c', label: 'Feature Selection (SFS)' },
+        { id: '2d', label: 'Hyperparameter Tuning' },
       ]
     },
     {
@@ -1324,7 +1325,7 @@ export class ModelDevelopmentComponent implements OnInit, AfterViewChecked {
           // Map declaration substeps to detailed taxonomy
           if (substep === 'decl_data_imported') this.detailedStep = '1b_data_declaration';
           else if (substep === 'decl_dictionary_generated') this.detailedStep = '1c_dictionary_declaration';
-        } else if (substep.startsWith('sfs_')) {
+        } else if (substep.startsWith('sfs_') || substep.startsWith('hyperparam_')) {
           step = 'sfs';
           this.detailedStep = this.mapModelingSubstepToDetailed(substep);
         } else {
@@ -1353,7 +1354,7 @@ export class ModelDevelopmentComponent implements OnInit, AfterViewChecked {
         if (substep !== this._lastModelingSubstep) {
           console.log(`[Pipeline] modelingCheckpoint$ auto-save: ${this._lastModelingSubstep} -> ${substep}`);
           this._lastModelingSubstep = substep;
-          const step = substep.startsWith('sfs_') ? 'sfs' : 'modeling';
+          const step = (substep.startsWith('sfs_') || substep.startsWith('hyperparam_')) ? 'sfs' : 'modeling';
           this.detailedStep = this.mapModelingSubstepToDetailed(substep);
           this.saveCheckpoint(step);
         }
@@ -1803,7 +1804,7 @@ export class ModelDevelopmentComponent implements OnInit, AfterViewChecked {
   private static readonly DETAILED_STEPS: string[] = [
     '1a_pipeline_declaration', '1b_data_declaration', '1c_dictionary_declaration',
     '2a_purifier_declaration', '2b_data_quality_summary',
-    '3a_encoding', '3b_modeling', '3c_sfs', '3ci_sfs_backward'
+    '3a_encoding', '3b_modeling', '3c_sfs', '3ci_sfs_backward', '3d_hyperparameter_tuning'
   ];
 
   private static readonly DETAILED_LABELS: {[k: string]: string} = {
@@ -1815,7 +1816,8 @@ export class ModelDevelopmentComponent implements OnInit, AfterViewChecked {
     '3a_encoding': 'Categorical Feature Encoding',
     '3b_modeling': 'Modeling',
     '3c_sfs': 'SFS',
-    '3ci_sfs_backward': 'SFS Backward'
+    '3ci_sfs_backward': 'SFS Backward',
+    '3d_hyperparameter_tuning': 'Hyperparameter Tuning'
   };
 
   /** Map a modeling child-component substep to the detailed taxonomy */
@@ -1824,6 +1826,7 @@ export class ModelDevelopmentComponent implements OnInit, AfterViewChecked {
     if (substep === 'modeling_started' || substep === 'modeling_completed') return '3b_modeling';
     if (substep === 'sfs_backward_completed') return '3ci_sfs_backward';
     if (substep.startsWith('sfs_')) return '3c_sfs';
+    if (substep.startsWith('hyperparam_')) return '3d_hyperparameter_tuning';
     return this.detailedStep; // keep current if unknown
   }
 
@@ -2749,6 +2752,7 @@ export class ModelDevelopmentComponent implements OnInit, AfterViewChecked {
         '2a': 'encoding-anchor',
         '2b': 'modeling-anchor',
         '2c': 'sfs-anchor',
+        '2d': 'hyperparam-anchor',
       };
       const anchorId = anchorMap[subStepId];
       if (anchorId) {
@@ -2805,17 +2809,23 @@ export class ModelDevelopmentComponent implements OnInit, AfterViewChecked {
       case '2a': // Categorical Encoding
         if (mc && mc.substep && ['encoding_completed', 'modeling_started', 'modeling_completed',
             'sfs_running', 'sfs_stopped', 'sfs_backward_completed', 'sfs_forward_completed',
-            'sfs_completed', 'sfs_forward_from_backward_completed'].includes(mc.substep)) return 'completed';
+            'sfs_completed', 'sfs_forward_from_backward_completed', 'hyperparam_running',
+            'hyperparam_stopped', 'hyperparam_completed'].includes(mc.substep)) return 'completed';
         if (mc && mc.substep === 'algorithm_selected') return 'in_progress';
         if (this.modelingAvailable && !mc?.substep) return 'in_progress';
         return 'pending';
       case '2b': // Model Training & CV
-        if (mc && mc.modelingStatus?.model) return 'completed';
+        if (mc && (mc.modelingStatus?.model || mc.substep?.startsWith('hyperparam_'))) return 'completed';
         if (mc && (mc.substep === 'modeling_started' || mc.substep === 'encoding_completed')) return 'in_progress';
         return 'pending';
       case '2c': // SFS
-        if (mc && (mc.sfsBackwardResults?.length > 0 || mc.sfsForwardResults?.length > 0)) return 'completed';
+        if (mc && (mc.sfsBackwardResults?.length > 0 || mc.sfsForwardResults?.length > 0 || mc.sfsForwardFromBackwardResults?.length > 0 || mc.substep?.startsWith('hyperparam_'))) return 'completed';
         if (mc && mc.modelingStatus?.model && !(mc.sfsBackwardResults?.length > 0 || mc.sfsForwardResults?.length > 0)) return 'in_progress';
+        return 'pending';
+      case '2d': // Hyperparameter Tuning
+        if (mc && (mc.substep === 'hyperparam_completed' || mc.hpResults)) return 'completed';
+        if (mc && (mc.substep === 'hyperparam_running' || mc.substep === 'hyperparam_stopped')) return 'in_progress';
+        if (mc && (mc.sfsBackwardResults?.length > 0 || mc.sfsForwardResults?.length > 0 || mc.sfsForwardFromBackwardResults?.length > 0)) return 'in_progress';
         return 'pending';
 
       // Future steps

--- a/frontend/src/app/modeling/modeling.component.html
+++ b/frontend/src/app/modeling/modeling.component.html
@@ -10,6 +10,7 @@
       </mat-form-field>
     </div>
 
+    <div id="encoding-anchor"></div>
     <!-- Encoding Plan (auto-loaded after algorithm selection) -->
     <div *ngIf="selectedAlgorithm && (encodingPlan.length > 0 || encodingAnalyzing || encodingError)" style="margin-top: 16px; margin-bottom: 16px;">
       <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
@@ -437,6 +438,7 @@
         </div>
       </div>
 
+      <div id="sfs-anchor"></div>
       <!-- Sequential Feature Selection (SFS) Configuration Panel -->
       <div *ngIf="sfsReady && !sfsRunning && (sfsForwardResults.length === 0 && sfsBackwardResults.length === 0)" style="margin-top: 24px; padding: 20px; border: 2px solid #740505; border-radius: 8px; background: #fff9f9;">
         <h3 style="color: #740505; margin-top: 0;">Sequential Feature Selection (SFS)</h3>
@@ -1153,8 +1155,9 @@
         </div>
       </div>
 
+      <div id="hyperparam-anchor"></div>
       <!-- ===================================================================
-           Hyperparameter Tuning (random joint search + validation curves)
+             Hyperparameter Tuning (random joint search + validation curves)
            Appears after SFS produces a feature set.
            =================================================================== -->
       <div *ngIf="sfsForwardResults.length > 0 || sfsBackwardResults.length > 0 || sfsForwardFromBackwardResults.length > 0 || hpResults || hpRunning"

--- a/frontend/src/app/modeling/modeling.component.ts
+++ b/frontend/src/app/modeling/modeling.component.ts
@@ -1409,6 +1409,26 @@ export class ModelingComponent implements OnInit, AfterViewInit {
       sfsModelPaths: this.sfsModelPaths,
       sfsDurationSeconds: this.sfsDurationSeconds,
       sfsStopped: this.sfsStopped,
+      // Hyperparameter-tuning state
+      hpResults: this.hpResults,
+      hpRunning: this.hpRunning,
+      hpStopped: this.hpStopped,
+      hpProgress: this.hpProgress,
+      hpMessage: this.hpMessage,
+      hpDurationSeconds: this.hpDurationSeconds,
+      hpParamSpace: this.hpParamSpace,
+      hpNIter: this.hpNIter,
+      hpCvFolds: this.hpCvFolds,
+      hpNJobs: this.hpNJobs,
+      hpPrimaryMetric: this.hpPrimaryMetric,
+      hpValidationCurvePoints: this.hpValidationCurvePoints,
+      hpSearchMethod: this.hpSearchMethod,
+      hpBestPoints: this.hpBestPoints,
+      hpValidationCurves: this.hpValidationCurves,
+      hpEmphasized: this.hpEmphasized,
+      hpParamImportance: this.hpParamImportance,
+      hpGuidance: this.hpGuidance,
+      hpSpaceWarnings: this.hpSpaceWarnings,
     };
     this.sharedService.setModelingCheckpoint(state);
     this.sharedService.triggerCheckpoint(substep);
@@ -1449,6 +1469,30 @@ export class ModelingComponent implements OnInit, AfterViewInit {
     this.sfsModelPaths = state.sfsModelPaths || {};
     this.sfsDurationSeconds = state.sfsDurationSeconds ?? null;
     this.sfsStopped = state.sfsStopped || false;
+
+    // Hyperparameter-tuning state
+    this.hpResults = state.hpResults || null;
+    this.hpRunning = !!state.hpRunning;
+    this.hpStopped = !!state.hpStopped;
+    this.hpProgress = state.hpProgress ?? 0;
+    this.hpMessage = state.hpMessage || '';
+    this.hpDurationSeconds = state.hpDurationSeconds ?? null;
+    if (state.hpParamSpace) this.hpParamSpace = state.hpParamSpace;
+    if (state.hpNIter != null) this.hpNIter = state.hpNIter;
+    if (state.hpCvFolds != null) this.hpCvFolds = state.hpCvFolds;
+    if (state.hpNJobs != null) this.hpNJobs = state.hpNJobs;
+    if (state.hpPrimaryMetric) this.hpPrimaryMetric = state.hpPrimaryMetric;
+    if (state.hpValidationCurvePoints != null) this.hpValidationCurvePoints = state.hpValidationCurvePoints;
+    if (state.hpSearchMethod) this.hpSearchMethod = state.hpSearchMethod;
+    this.hpBestPoints = state.hpBestPoints || {};
+    this.hpValidationCurves = state.hpValidationCurves || [];
+    this.hpEmphasized = state.hpEmphasized || {};
+    this.hpParamImportance = state.hpParamImportance || {};
+    this.hpGuidance = state.hpGuidance || [];
+    this.hpSpaceWarnings = state.hpSpaceWarnings || [];
+    if (this.hpResults) {
+      setTimeout(() => this.drawHyperparamCurves(), 100);
+    }
 
     // Re-sort selected features if modeling status is present
     if (this.modelingStatus) {
@@ -1589,6 +1633,55 @@ export class ModelingComponent implements OnInit, AfterViewInit {
           console.warn('[Modeling] Resume: could not fetch SFS status:', err);
           this.sfsRunning = false;
           this.sfsMessage = '';
+          this.sharedService.setActiveProcess(null);
+        }
+      });
+    } else if (proc.type === 'hyperparam') {
+      this.hpRunning = true;
+      this.hpMessage = 'Checking hyperparameter tuning status...';
+      this.dataService.getHyperparamStatus(proc.file_id).subscribe({
+        next: (statusData: any) => {
+          const s = statusData.status;
+          this.hpProgress = statusData.progress || 0;
+          this.hpMessage = statusData.message || 'Tuning running...';
+          if (typeof statusData.completed_trials === 'number') this.hpCompletedTrials = statusData.completed_trials;
+          if (statusData.current_best) this.hpCurrentBest = statusData.current_best;
+          if (s === 'completed') {
+            this.hpRunning = false;
+            this.hpProgress = 1.0;
+            this.hpDurationSeconds = statusData.duration_seconds || null;
+            this.hpMessage = 'Hyperparameter tuning completed!';
+            this.sharedService.setActiveProcess(null);
+            setTimeout(() => this.fetchHyperparamResults(), 400);
+          } else if (s === 'running') {
+            this.startHyperparamStatusPolling();
+            this.pushModelingCheckpoint('hyperparam_running');
+          } else if (s === 'stopped' || s === 'interrupted') {
+            this.hpRunning = false;
+            this.hpStopped = true;
+            this.hpDurationSeconds = statusData.duration_seconds || null;
+            this.hpMessage = s === 'interrupted'
+              ? 'Tuning was interrupted (server restart).'
+              : 'Tuning stopped — partial results may be available';
+            this.sharedService.setActiveProcess(null);
+            setTimeout(() => this.fetchHyperparamResults(), 400);
+            this.pushModelingCheckpoint('hyperparam_stopped');
+          } else if (s === 'error') {
+            this.hpRunning = false;
+            this.hpDurationSeconds = statusData.duration_seconds || null;
+            this.hpMessage = 'Tuning failed: ' + (statusData.error || 'Unknown error');
+            this.sharedService.setActiveProcess(null);
+          } else {
+            this.hpRunning = false;
+            this.hpMessage = '';
+            this.sharedService.setActiveProcess(null);
+            this.fetchHyperparamResults();
+          }
+        },
+        error: (err: any) => {
+          console.warn('[Modeling] Resume: could not fetch hyperparameter status:', err);
+          this.hpRunning = false;
+          this.hpMessage = '';
           this.sharedService.setActiveProcess(null);
         }
       });
@@ -2860,6 +2953,7 @@ export class ModelingComponent implements OnInit, AfterViewInit {
         this.hpMessage = resp.message || 'Tuning running...';
         this.hpSpaceWarnings = resp.space_warnings || [];
         this.startHyperparamStatusPolling();
+        this.pushModelingCheckpoint('hyperparam_running');
       },
       error: (err: any) => {
         console.error('[Hyperparam] Failed to start:', err);
@@ -2932,6 +3026,7 @@ export class ModelingComponent implements OnInit, AfterViewInit {
               : 'Tuning stopped — partial results may be available';
             this.sharedService.setActiveProcess(null);
             setTimeout(() => this.fetchHyperparamResults(), 400);
+            this.pushModelingCheckpoint('hyperparam_stopped');
           } else if (status === 'error') {
             this.stopHyperparamStatusPolling();
             this.hpRunning = false; this.hpStopping = false;


### PR DESCRIPTION
## What changed
- Added Hyperparameter Tuning as the post-SFS Modeling sub-step in the pipeline-flow sidebar.
- Wired hyperparameter checkpoints into the parent pipeline status/detailed-step mapping so saved/resumed runs can display the correct sidebar state.
- Persisted hyperparameter tuning state through the modeling checkpoint payload and added anchors for sidebar navigation.

## Root cause
The hyperparameter UI was added inside the Modeling component after SFS, but the pipeline-flow sidebar is driven by a separate hardcoded parent step registry plus checkpoint status mapping. That registry stopped at SFS, and `hyperparam_*` substeps were not mapped into the detailed-step taxonomy.

## Validation
- `python -m py_compile backend/modeling/views.py backend/tests/test_unit.py`
- `pytest backend/tests/test_unit.py::TestInferDetailedStep -q`
- `npm run build`
- `npx ng test --watch=false --browsers=ChromeHeadless --include=src/app/model-development/model-development.component.spec.ts`
- Pre-commit gate: 914 backend tests, frontend build, 415 Karma specs
- Pre-push gate: 914 backend tests, frontend build, 415 Karma specs