### PR TITLE
feat: add DeclarAI MCP server

### DIFF
--- a/backend/ai_assistant/management/__init__.py
+++ b/backend/ai_assistant/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for the AI assistant app."""

--- a/backend/ai_assistant/management/commands/__init__.py
+++ b/backend/ai_assistant/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""AI assistant management command package."""

--- a/backend/ai_assistant/management/commands/run_mcp_server.py
+++ b/backend/ai_assistant/management/commands/run_mcp_server.py
@@ -1,0 +1,64 @@
+"""Run the DeclarAI Auto-ML MCP server."""
+
+from __future__ import annotations
+
+import os
+
+from django.core.management.base import BaseCommand
+
+from ai_assistant.mcp_server.server import create_mcp_server
+
+
+class Command(BaseCommand):
+    help = "Run the DeclarAI Auto-ML MCP server over stdio or Streamable HTTP."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--transport",
+            choices=("stdio", "streamable-http"),
+            default=os.environ.get("DECLARAI_MCP_TRANSPORT", "stdio"),
+            help="MCP transport to use. Defaults to stdio.",
+        )
+        parser.add_argument(
+            "--host",
+            default=os.environ.get("DECLARAI_MCP_HOST", "127.0.0.1"),
+            help="Host for Streamable HTTP transport.",
+        )
+        parser.add_argument(
+            "--port",
+            type=int,
+            default=int(os.environ.get("DECLARAI_MCP_PORT", "8000")),
+            help="Port for Streamable HTTP transport.",
+        )
+        parser.add_argument(
+            "--direct-actions",
+            action="store_true",
+            help=(
+                "Register direct side-effecting action tools. Also requires "
+                "DECLARAI_MCP_ENABLE_DIRECT_ACTIONS=true and the relevant scopes."
+            ),
+        )
+        parser.add_argument(
+            "--json-response",
+            dest="json_response",
+            action="store_true",
+            default=True,
+            help="Use JSON responses for Streamable HTTP transport.",
+        )
+        parser.add_argument(
+            "--no-json-response",
+            dest="json_response",
+            action="store_false",
+            help="Allow SSE-style streaming responses for Streamable HTTP.",
+        )
+
+    def handle(self, *args, **options):
+        mcp = create_mcp_server(
+            host=options["host"],
+            port=options["port"],
+            json_response=options["json_response"],
+            include_direct_actions=options["direct_actions"] or None,
+        )
+        # Do not write to stdout before stdio transport starts; stdout is the
+        # protocol channel.  Errors still surface through Django/SDK logging.
+        mcp.run(transport=options["transport"])

--- a/backend/ai_assistant/mcp_server/__init__.py
+++ b/backend/ai_assistant/mcp_server/__init__.py
@@ -1,0 +1,7 @@
+"""
+MCP server integration for the DeclarAI Auto-ML assistant.
+
+The package intentionally keeps the MCP SDK import inside
+``server.create_mcp_server`` so helper modules remain importable in test
+environments before dependencies are installed.
+"""

--- a/backend/ai_assistant/mcp_server/__main__.py
+++ b/backend/ai_assistant/mcp_server/__main__.py
@@ -1,0 +1,48 @@
+"""Module entry point for running the DeclarAI MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the DeclarAI Auto-ML MCP server.")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "streamable-http"),
+        default=os.environ.get("DECLARAI_MCP_TRANSPORT", "stdio"),
+    )
+    parser.add_argument("--host", default=os.environ.get("DECLARAI_MCP_HOST", "127.0.0.1"))
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("DECLARAI_MCP_PORT", "8000")),
+    )
+    parser.add_argument(
+        "--direct-actions",
+        action="store_true",
+        help="Register side-effecting direct action tools when env gates also allow them.",
+    )
+    parser.add_argument("--json-response", dest="json_response", action="store_true", default=True)
+    parser.add_argument("--no-json-response", dest="json_response", action="store_false")
+    args = parser.parse_args()
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
+    import django
+
+    django.setup()
+
+    from ai_assistant.mcp_server.server import create_mcp_server
+
+    mcp = create_mcp_server(
+        host=args.host,
+        port=args.port,
+        json_response=args.json_response,
+        include_direct_actions=args.direct_actions or None,
+    )
+    mcp.run(transport=args.transport)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/ai_assistant/mcp_server/actions.py
+++ b/backend/ai_assistant/mcp_server/actions.py
@@ -1,0 +1,99 @@
+"""
+Action preparation and execution helpers for the DeclarAI MCP server.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ai_assistant.mcp_server import auth
+from ai_assistant.mcp_server.registry import get_action_spec
+
+
+def prepare_action(
+    file_id: int,
+    action_type: str,
+    payload: dict[str, Any] | None,
+    *,
+    parent_span_id: str | None = None,
+) -> dict[str, Any]:
+    """Return a reviewable action payload without mutating platform state."""
+    auth.require_scope(auth.SCOPE_ACTION_PREPARE)
+    spec = get_action_spec(action_type)
+    if spec is None:
+        raise ValueError(f"Unknown DeclarAI action type: {action_type}")
+    payload = _coerce_payload(payload)
+    action_block = _format_action_block(action_type, payload)
+    out: dict[str, Any] = {
+        "status": "prepared",
+        "file_id": file_id,
+        "action_type": action_type,
+        "payload": payload,
+        "risk": spec.risk,
+        "requires_approval": True,
+        "side_effects": False,
+        "direct_tool": spec.direct_name,
+        "action_block": action_block,
+    }
+    if parent_span_id:
+        out["parent_span_id"] = parent_span_id
+    return out
+
+
+def execute_direct_action(
+    file_id: int,
+    action_type: str,
+    payload: dict[str, Any] | None,
+    *,
+    approval_id: str | None,
+    parent_span_id: str | None = None,
+) -> dict[str, Any]:
+    """Execute a side-effecting DeclarAI action through the existing dispatcher."""
+    auth.require_direct_actions_enabled()
+    spec = get_action_spec(action_type)
+    if spec is None:
+        raise ValueError(f"Unknown DeclarAI action type: {action_type}")
+    auth.require_scope(spec.scope)
+    auth.require_approval(action_type, approval_id)
+    payload = _coerce_payload(payload)
+    result = _dispatch_action(file_id, action_type, payload, parent_span_id)
+    return {
+        "status": "executed",
+        "file_id": file_id,
+        "action_type": action_type,
+        "approval_id": approval_id,
+        "risk": spec.risk,
+        "side_effects": True,
+        "result": result,
+    }
+
+
+def _dispatch_action(
+    file_id: int,
+    action_type: str,
+    payload: dict[str, Any],
+    parent_span_id: str | None,
+) -> dict[str, Any]:
+    """Import lazily so helper tests do not need Django model imports up front."""
+    from ai_assistant.action_executor import dispatch_action
+
+    return dispatch_action(
+        file_id,
+        action_type,
+        payload,
+        parent_span_id=parent_span_id,
+    )
+
+
+def _coerce_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if payload is None:
+        return {}
+    if not isinstance(payload, dict):
+        raise ValueError("MCP action payload must be a JSON object.")
+    return payload
+
+
+def _format_action_block(action_type: str, payload: dict[str, Any]) -> str:
+    body = json.dumps(payload, ensure_ascii=True, sort_keys=True)
+    return f"<<<ACTION:{action_type}>>>\n{body}\n<<<END_ACTION>>>"

--- a/backend/ai_assistant/mcp_server/auth.py
+++ b/backend/ai_assistant/mcp_server/auth.py
@@ -1,0 +1,80 @@
+"""
+Minimal local authorization helpers for the DeclarAI MCP server.
+
+Production Streamable HTTP deployments should put a real MCP/OAuth resource
+server in front of these checks.  These helpers still give local and stdio
+deployments a deterministic scope gate, and keep direct action tools disabled
+unless an operator explicitly opts in.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+SCOPE_PIPELINE_READ = "declarai.pipeline.read"
+SCOPE_ACTION_PREPARE = "declarai.action.prepare"
+SCOPE_NOTES_WRITE = "declarai.notes.write"
+SCOPE_METADATA_WRITE = "declarai.metadata.write"
+SCOPE_CONFIG_WRITE = "declarai.config.write"
+SCOPE_DATASET_WRITE = "declarai.dataset.write"
+SCOPE_PIPELINE_RUN = "declarai.pipeline.run"
+
+DEFAULT_SCOPES = frozenset({SCOPE_PIPELINE_READ, SCOPE_ACTION_PREPARE})
+TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _truthy_env(name: str, *, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in TRUE_VALUES
+
+
+def configured_scopes() -> set[str]:
+    """Return scopes granted to the local MCP server process."""
+    raw = os.environ.get("DECLARAI_MCP_SCOPES")
+    if raw is None:
+        return set(DEFAULT_SCOPES)
+    return {scope.strip() for scope in raw.split(",") if scope.strip()}
+
+
+def require_scope(scope: str) -> None:
+    """Raise when the configured MCP process scopes do not include ``scope``."""
+    scopes = configured_scopes()
+    if scope not in scopes:
+        granted = ", ".join(sorted(scopes)) or "(none)"
+        raise PermissionError(
+            f"MCP scope '{scope}' is required; granted scopes: {granted}."
+        )
+
+
+def direct_actions_enabled() -> bool:
+    """Whether side-effecting direct action tools should be registered."""
+    return _truthy_env("DECLARAI_MCP_ENABLE_DIRECT_ACTIONS", default=False)
+
+
+def require_direct_actions_enabled() -> None:
+    """Raise unless direct action execution was explicitly enabled."""
+    if not direct_actions_enabled():
+        raise PermissionError(
+            "Direct MCP action execution is disabled. Set "
+            "DECLARAI_MCP_ENABLE_DIRECT_ACTIONS=true and grant the required "
+            "DECLARAI_MCP_SCOPES to expose side-effecting tools."
+        )
+
+
+def approval_required() -> bool:
+    """Whether direct action calls must carry an approval identifier."""
+    return _truthy_env("DECLARAI_MCP_REQUIRE_APPROVAL", default=True)
+
+
+def require_approval(action_type: str, approval_id: str | None) -> None:
+    """Require an explicit approval id before executing side-effecting actions."""
+    if approval_required() and not (approval_id or "").strip():
+        raise PermissionError(
+            f"Direct MCP action '{action_type}' requires approval_id. "
+            "The MCP host should collect human approval and pass its approval "
+            "record id here, or set DECLARAI_MCP_REQUIRE_APPROVAL=false for "
+            "trusted local-only automation."
+        )

--- a/backend/ai_assistant/mcp_server/registry.py
+++ b/backend/ai_assistant/mcp_server/registry.py
@@ -1,0 +1,202 @@
+"""
+Tool and action registry for the DeclarAI MCP facade.
+
+This module adapts the assistant's existing OpenAI-style tool schemas into
+MCP-facing names.  It deliberately does not reimplement any pipeline logic:
+runtime calls still go through ``tool_executor.execute_tool_call`` and
+``action_executor.dispatch_action``.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any
+
+from ai_assistant.mcp_server import auth
+from ai_assistant.tool_definitions import PIPELINE_TOOLS
+
+
+READ_TOOL_PREFIX = "declarai."
+PREPARE_ACTION_PREFIX = "declarai.prepare."
+DIRECT_ACTION_PREFIX = "declarai.action."
+
+
+@dataclass(frozen=True)
+class ReadToolSpec:
+    """MCP metadata for a read-only assistant tool."""
+
+    mcp_name: str
+    internal_name: str
+    title: str
+    description: str
+    input_schema: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ActionSpec:
+    """MCP metadata for an applyable assistant action."""
+
+    action_type: str
+    title: str
+    description: str
+    risk: str
+    scope: str
+    destructive: bool
+
+    @property
+    def prepare_name(self) -> str:
+        return f"{PREPARE_ACTION_PREFIX}{self.action_type}"
+
+    @property
+    def direct_name(self) -> str:
+        return f"{DIRECT_ACTION_PREFIX}{self.action_type}"
+
+
+ACTION_SPECS: tuple[ActionSpec, ...] = (
+    ActionSpec(
+        "execute_code",
+        "Prepare dataset code execution",
+        "Prepare a sandboxed pandas/numpy dataset mutation action.",
+        "high",
+        auth.SCOPE_DATASET_WRITE,
+        True,
+    ),
+    ActionSpec(
+        "update_metadata",
+        "Prepare metadata update",
+        "Prepare data-dictionary metadata updates.",
+        "medium",
+        auth.SCOPE_METADATA_WRITE,
+        False,
+    ),
+    ActionSpec(
+        "update_config",
+        "Prepare configuration update",
+        "Prepare pipeline or feature-usage configuration changes.",
+        "medium",
+        auth.SCOPE_CONFIG_WRITE,
+        False,
+    ),
+    ActionSpec(
+        "set_ordinal_ranking",
+        "Prepare ordinal ranking",
+        "Prepare ordinal category rankings and implied LoM updates.",
+        "medium",
+        auth.SCOPE_METADATA_WRITE,
+        False,
+    ),
+    ActionSpec(
+        "start_sfs",
+        "Prepare SFS run",
+        "Prepare a Sequential Feature Selection start action.",
+        "high",
+        auth.SCOPE_PIPELINE_RUN,
+        False,
+    ),
+    ActionSpec(
+        "start_data_purifier",
+        "Prepare data purifier run",
+        "Prepare a preprocessing/data-purifier run action.",
+        "high",
+        auth.SCOPE_PIPELINE_RUN,
+        False,
+    ),
+    ActionSpec(
+        "update_purifier_selection",
+        "Prepare purifier selection update",
+        "Prepare a no-run Data Purifier checkbox selection change.",
+        "medium",
+        auth.SCOPE_CONFIG_WRITE,
+        False,
+    ),
+    ActionSpec(
+        "apply_encoding",
+        "Prepare encoding run",
+        "Prepare an Apply Encoding pipeline action.",
+        "high",
+        auth.SCOPE_PIPELINE_RUN,
+        False,
+    ),
+    ActionSpec(
+        "start_modeling",
+        "Prepare modeling run",
+        "Prepare a model-training pipeline action.",
+        "high",
+        auth.SCOPE_PIPELINE_RUN,
+        False,
+    ),
+    ActionSpec(
+        "start_hyperparameter",
+        "Prepare hyperparameter tuning run",
+        "Prepare a post-SFS hyperparameter tuning action.",
+        "high",
+        auth.SCOPE_PIPELINE_RUN,
+        False,
+    ),
+    ActionSpec(
+        "update_notes",
+        "Prepare note update",
+        "Prepare an add, edit, or delete operation for pipeline notes.",
+        "low",
+        auth.SCOPE_NOTES_WRITE,
+        False,
+    ),
+)
+
+
+def get_read_tool_specs() -> list[ReadToolSpec]:
+    """Return deterministic MCP specs for every OpenAI-style pipeline tool."""
+    specs: list[ReadToolSpec] = []
+    for tool_definition in PIPELINE_TOOLS:
+        function = tool_definition.get("function", {})
+        internal_name = function.get("name")
+        if not internal_name:
+            continue
+        input_schema = _schema_with_file_id(function.get("parameters", {}))
+        title = internal_name.replace("_", " ").title()
+        specs.append(
+            ReadToolSpec(
+                mcp_name=f"{READ_TOOL_PREFIX}{internal_name}",
+                internal_name=internal_name,
+                title=title,
+                description=function.get("description", ""),
+                input_schema=input_schema,
+            )
+        )
+    return specs
+
+
+def get_action_specs() -> list[ActionSpec]:
+    """Return deterministic action specs in dispatcher order."""
+    return list(ACTION_SPECS)
+
+
+def get_action_spec(action_type: str) -> ActionSpec | None:
+    """Look up one action spec by internal action type."""
+    for spec in ACTION_SPECS:
+        if spec.action_type == action_type:
+            return spec
+    return None
+
+
+def _schema_with_file_id(parameters: dict[str, Any]) -> dict[str, Any]:
+    """Copy an OpenAI parameters schema and make ``file_id`` explicit."""
+    schema = copy.deepcopy(parameters) if isinstance(parameters, dict) else {}
+    schema.setdefault("type", "object")
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        properties = {}
+    schema["properties"] = {
+        "file_id": {
+            "type": "integer",
+            "description": "DeclarAI Declaration file id to inspect.",
+        },
+        **properties,
+    }
+    required = list(schema.get("required") or [])
+    if "file_id" not in required:
+        required.insert(0, "file_id")
+    schema["required"] = required
+    schema.setdefault("additionalProperties", False)
+    return schema

--- a/backend/ai_assistant/mcp_server/server.py
+++ b/backend/ai_assistant/mcp_server/server.py
@@ -1,0 +1,342 @@
+"""
+FastMCP server for the DeclarAI Auto-ML assistant.
+
+The server exposes the existing assistant tool/action surface over MCP.  It is a
+facade only: all platform logic remains in ``tool_executor`` and
+``action_executor``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from ai_assistant.mcp_server import auth
+from ai_assistant.mcp_server.actions import execute_direct_action, prepare_action
+from ai_assistant.mcp_server.registry import (
+    ActionSpec,
+    get_action_specs,
+    get_read_tool_specs,
+)
+
+
+PURIFIER_KIND = Literal[
+    "col_dedup",
+    "row_dedup",
+    "zero_var_drop",
+    "perfect_corr_drop",
+    "corr_drop",
+    "sparsity_drop",
+    "missing_drop",
+    "combined_drop",
+    "outlier_quantile_clip",
+    "cat_outlier_merge",
+]
+
+SFS_DIRECTION = Literal["forward", "backward", "forward_from_backward"]
+
+SERVER_INSTRUCTIONS = """
+DeclarAI Auto-ML MCP server. Read tools inspect one uploaded pipeline file by
+explicit file_id. Prepare-action tools return reviewable action blocks and do
+not mutate state. Direct action tools, when enabled by the operator, execute
+through the existing DeclarAI action dispatcher and require scopes plus an
+approval_id.
+""".strip()
+
+
+def create_mcp_server(
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    json_response: bool = True,
+    include_direct_actions: bool | None = None,
+):
+    """Create a configured FastMCP server instance."""
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:  # pragma: no cover - exercised before install only
+        raise RuntimeError(
+            "The DeclarAI MCP server requires the 'mcp' Python package. "
+            "Install backend requirements or run: pip install 'mcp>=1.27,<2'."
+        ) from exc
+
+    mcp = FastMCP(
+        "DeclarAI Auto-ML",
+        instructions=SERVER_INSTRUCTIONS,
+        host=host,
+        port=port,
+        json_response=json_response,
+    )
+    _register_read_tools(mcp)
+    _register_prepare_action_tools(mcp)
+    if include_direct_actions is None:
+        include_direct_actions = auth.direct_actions_enabled()
+    elif include_direct_actions and not auth.direct_actions_enabled():
+        include_direct_actions = False
+    if include_direct_actions:
+        _register_direct_action_tools(mcp)
+    return mcp
+
+
+def _run_read_tool(file_id: int, internal_name: str, arguments: dict[str, Any]) -> str:
+    auth.require_scope(auth.SCOPE_PIPELINE_READ)
+    from ai_assistant.tool_executor import execute_tool_call
+
+    return execute_tool_call(file_id, internal_name, arguments)
+
+
+def _clean_args(**kwargs: Any) -> dict[str, Any]:
+    return {key: value for key, value in kwargs.items() if value is not None}
+
+
+def _tool_annotations(*, read_only: bool, destructive: bool, idempotent: bool):
+    try:
+        from mcp.types import ToolAnnotations
+    except ImportError:  # pragma: no cover
+        return None
+    return ToolAnnotations(
+        readOnlyHint=read_only,
+        destructiveHint=destructive,
+        idempotentHint=idempotent,
+        openWorldHint=False,
+    )
+
+
+def _register_read_tools(mcp) -> None:
+    read_annotations = _tool_annotations(
+        read_only=True,
+        destructive=False,
+        idempotent=True,
+    )
+    descriptions = {spec.internal_name: spec.description for spec in get_read_tool_specs()}
+
+    @mcp.tool(
+        name="declarai.get_split_validation",
+        title="Get split validation",
+        description=descriptions["get_split_validation"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_split_validation(file_id: int) -> str:
+        return _run_read_tool(file_id, "get_split_validation", {})
+
+    @mcp.tool(
+        name="declarai.get_dq_summary",
+        title="Get data-quality summary",
+        description=descriptions["get_dq_summary"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_dq_summary(file_id: int, feature: str | None = None) -> str:
+        return _run_read_tool(file_id, "get_dq_summary", _clean_args(feature=feature))
+
+    @mcp.tool(
+        name="declarai.get_feature_stats",
+        title="Get feature stats",
+        description=descriptions["get_feature_stats"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_feature_stats(file_id: int, feature: str) -> str:
+        return _run_read_tool(file_id, "get_feature_stats", {"feature": feature})
+
+    @mcp.tool(
+        name="declarai.get_vif_decomposition",
+        title="Get VIF decomposition",
+        description=descriptions["get_vif_decomposition"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_vif_decomposition(file_id: int, feature: str) -> str:
+        return _run_read_tool(file_id, "get_vif_decomposition", {"feature": feature})
+
+    @mcp.tool(
+        name="declarai.get_encoding_plan",
+        title="Get encoding plan",
+        description=descriptions["get_encoding_plan"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_encoding_plan(file_id: int) -> str:
+        return _run_read_tool(file_id, "get_encoding_plan", {})
+
+    @mcp.tool(
+        name="declarai.get_selected_features",
+        title="Get selected features",
+        description=descriptions["get_selected_features"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_selected_features(file_id: int, top_n: int | None = None) -> str:
+        return _run_read_tool(file_id, "get_selected_features", _clean_args(top_n=top_n))
+
+    @mcp.tool(
+        name="declarai.get_shap_details",
+        title="Get SHAP details",
+        description=descriptions["get_shap_details"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_shap_details(file_id: int, top_n: int | None = None) -> str:
+        return _run_read_tool(file_id, "get_shap_details", _clean_args(top_n=top_n))
+
+    @mcp.tool(
+        name="declarai.get_sfs_results",
+        title="Get SFS results",
+        description=descriptions["get_sfs_results"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_sfs_results(file_id: int, direction: SFS_DIRECTION | None = None) -> str:
+        return _run_read_tool(file_id, "get_sfs_results", _clean_args(direction=direction))
+
+    @mcp.tool(
+        name="declarai.get_cv_results",
+        title="Get CV results",
+        description=descriptions["get_cv_results"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_cv_results(file_id: int) -> str:
+        return _run_read_tool(file_id, "get_cv_results", {})
+
+    @mcp.tool(
+        name="declarai.get_pipeline_notes",
+        title="Get pipeline notes",
+        description=descriptions["get_pipeline_notes"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_pipeline_notes(file_id: int) -> str:
+        return _run_read_tool(file_id, "get_pipeline_notes", {})
+
+    @mcp.tool(
+        name="declarai.get_pipeline_config",
+        title="Get pipeline config",
+        description=descriptions["get_pipeline_config"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_pipeline_config(file_id: int) -> str:
+        return _run_read_tool(file_id, "get_pipeline_config", {})
+
+    @mcp.tool(
+        name="declarai.get_purifier_options",
+        title="Get purifier options",
+        description=descriptions["get_purifier_options"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_purifier_options(file_id: int, kind: PURIFIER_KIND | None = None) -> str:
+        return _run_read_tool(file_id, "get_purifier_options", _clean_args(kind=kind))
+
+    @mcp.tool(
+        name="declarai.get_data_dictionary",
+        title="Get data dictionary",
+        description=descriptions["get_data_dictionary"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_data_dictionary(file_id: int, feature: str | None = None) -> str:
+        return _run_read_tool(file_id, "get_data_dictionary", _clean_args(feature=feature))
+
+    @mcp.tool(
+        name="declarai.invoke_skill",
+        title="Invoke bundled skill",
+        description=descriptions["invoke_skill"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def invoke_skill(file_id: int, skill_name: str) -> str:
+        return _run_read_tool(file_id, "invoke_skill", {"skill_name": skill_name})
+
+    @mcp.tool(
+        name="declarai.get_skill_file",
+        title="Get skill file",
+        description=descriptions["get_skill_file"],
+        annotations=read_annotations,
+        structured_output=False,
+    )
+    def get_skill_file(file_id: int, skill_name: str, path: str) -> str:
+        return _run_read_tool(
+            file_id,
+            "get_skill_file",
+            {"skill_name": skill_name, "path": path},
+        )
+
+
+def _register_prepare_action_tools(mcp) -> None:
+    annotations = _tool_annotations(
+        read_only=True,
+        destructive=False,
+        idempotent=True,
+    )
+    for spec in get_action_specs():
+        mcp.add_tool(
+            _make_prepare_action_tool(spec),
+            name=spec.prepare_name,
+            title=spec.title,
+            description=(
+                f"{spec.description} This tool is review-only: it returns an "
+                "action block and does not execute it."
+            ),
+            annotations=annotations,
+            structured_output=True,
+        )
+
+
+def _register_direct_action_tools(mcp) -> None:
+    annotations = _tool_annotations(
+        read_only=False,
+        destructive=True,
+        idempotent=False,
+    )
+    for spec in get_action_specs():
+        mcp.add_tool(
+            _make_direct_action_tool(spec),
+            name=spec.direct_name,
+            title=spec.title.replace("Prepare", "Execute", 1),
+            description=(
+                f"Execute {spec.action_type} through the DeclarAI action dispatcher. "
+                f"Requires scope {spec.scope} and approval_id."
+            ),
+            annotations=annotations,
+            structured_output=True,
+        )
+
+
+def _make_prepare_action_tool(spec: ActionSpec):
+    def prepare_tool(
+        file_id: int,
+        payload: dict[str, Any] | None = None,
+        parent_span_id: str | None = None,
+    ) -> dict[str, Any]:
+        return prepare_action(
+            file_id,
+            spec.action_type,
+            payload,
+            parent_span_id=parent_span_id,
+        )
+
+    prepare_tool.__name__ = f"prepare_{spec.action_type}"
+    prepare_tool.__doc__ = spec.description
+    return prepare_tool
+
+
+def _make_direct_action_tool(spec: ActionSpec):
+    def direct_tool(
+        file_id: int,
+        payload: dict[str, Any] | None = None,
+        approval_id: str | None = None,
+        parent_span_id: str | None = None,
+    ) -> dict[str, Any]:
+        return execute_direct_action(
+            file_id,
+            spec.action_type,
+            payload,
+            approval_id=approval_id,
+            parent_span_id=parent_span_id,
+        )
+
+    direct_tool.__name__ = f"execute_{spec.action_type}"
+    direct_tool.__doc__ = f"Execute {spec.action_type} through DeclarAI."
+    return direct_tool

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,6 +20,7 @@ statsmodels>=0.14
 openai>=1.0
 prometa-sdk==0.9.0
 redis>=5.0
+mcp>=1.27,<2
 
 # Testing dependencies
 pytest>=8.0

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -1,0 +1,171 @@
+"""
+Unit tests for the DeclarAI MCP server facade.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.unit
+class TestMcpRegistry:
+    def test_read_tool_specs_are_prefixed_and_require_file_id(self):
+        from ai_assistant.mcp_server.registry import get_read_tool_specs
+        from ai_assistant.tool_definitions import PIPELINE_TOOLS
+
+        specs = get_read_tool_specs()
+        assert len(specs) == len(PIPELINE_TOOLS)
+        assert specs[0].mcp_name.startswith("declarai.")
+        by_internal = {spec.internal_name: spec for spec in specs}
+        assert "get_data_dictionary" in by_internal
+        schema = by_internal["get_data_dictionary"].input_schema
+        assert schema["properties"]["file_id"]["type"] == "integer"
+        assert schema["required"][0] == "file_id"
+
+    def test_action_specs_track_existing_dispatcher(self):
+        from ai_assistant.action_executor import HANDLERS
+        from ai_assistant.mcp_server.registry import get_action_specs
+
+        spec_names = [spec.action_type for spec in get_action_specs()]
+        assert spec_names == list(HANDLERS.keys())
+
+
+@pytest.mark.unit
+class TestMcpActionHelpers:
+    def test_prepare_action_returns_reviewable_action_block(self, monkeypatch):
+        monkeypatch.delenv("DECLARAI_MCP_SCOPES", raising=False)
+        from ai_assistant.mcp_server.actions import prepare_action
+
+        result = prepare_action(
+            42,
+            "update_notes",
+            {"action": "add", "position": "after_sfs", "content": "Review note"},
+        )
+
+        assert result["status"] == "prepared"
+        assert result["file_id"] == 42
+        assert result["action_type"] == "update_notes"
+        assert result["requires_approval"] is True
+        assert result["side_effects"] is False
+        assert "<<<ACTION:update_notes>>>" in result["action_block"]
+        assert "<<<END_ACTION>>>" in result["action_block"]
+
+    def test_prepare_action_rejects_unknown_action(self, monkeypatch):
+        monkeypatch.delenv("DECLARAI_MCP_SCOPES", raising=False)
+        from ai_assistant.mcp_server.actions import prepare_action
+
+        with pytest.raises(ValueError, match="Unknown DeclarAI action type"):
+            prepare_action(42, "not_real", {})
+
+    def test_direct_action_is_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("DECLARAI_MCP_ENABLE_DIRECT_ACTIONS", raising=False)
+        from ai_assistant.mcp_server.actions import execute_direct_action
+
+        with pytest.raises(PermissionError, match="Direct MCP action execution is disabled"):
+            execute_direct_action(
+                42,
+                "update_notes",
+                {"action": "add"},
+                approval_id="approval-1",
+            )
+
+    def test_direct_action_requires_scope_and_approval(self, monkeypatch):
+        monkeypatch.setenv("DECLARAI_MCP_ENABLE_DIRECT_ACTIONS", "true")
+        monkeypatch.setenv("DECLARAI_MCP_SCOPES", "declarai.pipeline.read")
+        from ai_assistant.mcp_server.actions import execute_direct_action
+
+        with pytest.raises(PermissionError, match="declarai.notes.write"):
+            execute_direct_action(
+                42,
+                "update_notes",
+                {"action": "add"},
+                approval_id="approval-1",
+            )
+
+        monkeypatch.setenv("DECLARAI_MCP_SCOPES", "declarai.notes.write")
+        with pytest.raises(PermissionError, match="requires approval_id"):
+            execute_direct_action(42, "update_notes", {"action": "add"}, approval_id="")
+
+    def test_direct_action_dispatches_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("DECLARAI_MCP_ENABLE_DIRECT_ACTIONS", "true")
+        monkeypatch.setenv("DECLARAI_MCP_SCOPES", "declarai.notes.write")
+        calls = []
+
+        from ai_assistant.mcp_server import actions
+
+        def fake_dispatch(file_id, action_type, payload, parent_span_id):
+            calls.append((file_id, action_type, payload, parent_span_id))
+            return {"status": "success", "action_type": action_type}
+
+        monkeypatch.setattr(actions, "_dispatch_action", fake_dispatch)
+        result = actions.execute_direct_action(
+            42,
+            "update_notes",
+            {"action": "add"},
+            approval_id="approval-1",
+            parent_span_id="span-1",
+        )
+
+        assert result["status"] == "executed"
+        assert result["approval_id"] == "approval-1"
+        assert result["result"]["status"] == "success"
+        assert calls == [(42, "update_notes", {"action": "add"}, "span-1")]
+
+
+@pytest.mark.unit
+class TestMcpServer:
+    def test_create_server_registers_read_and_prepare_tools_by_default(self):
+        pytest.importorskip("mcp")
+        from ai_assistant.mcp_server.server import create_mcp_server
+
+        mcp = create_mcp_server(include_direct_actions=False)
+        tools = asyncio.run(mcp.list_tools())
+        names = {tool.name for tool in tools}
+
+        assert "declarai.get_data_dictionary" in names
+        assert "declarai.prepare.start_sfs" in names
+        assert "declarai.action.start_sfs" not in names
+
+    def test_prepare_tool_can_be_invoked_through_fastmcp(self, monkeypatch):
+        pytest.importorskip("mcp")
+        monkeypatch.delenv("DECLARAI_MCP_SCOPES", raising=False)
+        from ai_assistant.mcp_server.server import create_mcp_server
+
+        mcp = create_mcp_server(include_direct_actions=False)
+        _, structured = asyncio.run(
+            mcp.call_tool(
+                "declarai.prepare.update_notes",
+                {
+                    "file_id": 42,
+                    "payload": {"action": "add", "content": "Review note"},
+                },
+            )
+        )
+
+        assert structured["status"] == "prepared"
+        assert structured["action_type"] == "update_notes"
+        assert structured["side_effects"] is False
+
+    def test_create_server_can_register_direct_actions(self, monkeypatch):
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("DECLARAI_MCP_ENABLE_DIRECT_ACTIONS", "true")
+        from ai_assistant.mcp_server.server import create_mcp_server
+
+        mcp = create_mcp_server(include_direct_actions=True)
+        tools = asyncio.run(mcp.list_tools())
+        names = {tool.name for tool in tools}
+
+        assert "declarai.action.update_notes" in names
+
+    def test_direct_actions_flag_still_requires_env_gate(self, monkeypatch):
+        pytest.importorskip("mcp")
+        monkeypatch.delenv("DECLARAI_MCP_ENABLE_DIRECT_ACTIONS", raising=False)
+        from ai_assistant.mcp_server.server import create_mcp_server
+
+        mcp = create_mcp_server(include_direct_actions=True)
+        tools = asyncio.run(mcp.list_tools())
+        names = {tool.name for tool in tools}
+
+        assert "declarai.action.update_notes" not in names

--- a/docs/ai-assistant-tools-and-mcp-integration.md
+++ b/docs/ai-assistant-tools-and-mcp-integration.md
@@ -645,3 +645,55 @@ Ship the MCP integration in two phases:
 2. Governed action MCP server: start with "prepare action" tools, then selectively enable direct execution for low-risk actions (`update_notes`, maybe `update_purifier_selection`) before high-risk compute and dataset mutation actions.
 
 This preserves the platform's current safety model while making the same tool surface portable to any MCP-compatible agent host.
+
+## Implemented Server
+
+The repository includes a FastMCP-based server under:
+
+```text
+backend/ai_assistant/mcp_server/
+```
+
+Run it from the backend directory with stdio transport:
+
+```bash
+python manage.py run_mcp_server
+```
+
+Run it as a local Streamable HTTP server:
+
+```bash
+python manage.py run_mcp_server --transport streamable-http --host 127.0.0.1 --port 8000
+```
+
+MCP Inspector can connect to:
+
+```text
+http://127.0.0.1:8000/mcp
+```
+
+The server registers:
+
+- `declarai.get_*` read tools for the existing assistant inspection surface.
+- `declarai.prepare.*` action-preparation tools that return reviewable DeclarAI action blocks without mutating state.
+- `declarai.action.*` direct-execution tools only when explicitly enabled.
+
+Default scopes:
+
+```text
+declarai.pipeline.read,declarai.action.prepare
+```
+
+Enable direct side-effecting action tools only for a controlled deployment:
+
+```bash
+export DECLARAI_MCP_ENABLE_DIRECT_ACTIONS=true
+export DECLARAI_MCP_SCOPES=declarai.pipeline.read,declarai.action.prepare,declarai.notes.write,declarai.metadata.write,declarai.config.write,declarai.dataset.write,declarai.pipeline.run
+python manage.py run_mcp_server --transport streamable-http --direct-actions
+```
+
+Direct action calls require `approval_id` by default. For trusted local-only automation, this can be disabled with:
+
+```bash
+export DECLARAI_MCP_REQUIRE_APPROVAL=false
+```


### PR DESCRIPTION
## Summary
- add a FastMCP-based DeclarAI Auto-ML MCP server over stdio or Streamable HTTP
- expose existing assistant read tools, review-only action preparation tools, and opt-in scoped direct action tools
- add Django and module entrypoints plus focused MCP tests and integration docs

## Validation
- pytest tests/test_mcp_server.py -q
- python -m compileall ai_assistant/mcp_server ai_assistant/management/commands/run_mcp_server.py
- python manage.py help run_mcp_server
- pre-commit hook: 914 backend tests passed
- pre-push hook: 914 backend tests passed, frontend build passed, 415 Karma specs passed