### PR TITLE
feat: harden DeclarAI MCP Prometa contract

### DIFF
--- a/backend/ai_assistant/mcp_server/actions.py
+++ b/backend/ai_assistant/mcp_server/actions.py
@@ -8,9 +8,15 @@ import json
 from typing import Any
 
 from ai_assistant.mcp_server import auth
+from ai_assistant.mcp_server.observability import (
+    stamp_mcp_context,
+    span_timer,
+    workflow,
+)
 from ai_assistant.mcp_server.registry import get_action_spec
 
 
+@workflow(name="declarai-mcp-prepare-action")
 def prepare_action(
     file_id: int,
     action_type: str,
@@ -19,28 +25,53 @@ def prepare_action(
     parent_span_id: str | None = None,
 ) -> dict[str, Any]:
     """Return a reviewable action payload without mutating platform state."""
-    auth.require_scope(auth.SCOPE_ACTION_PREPARE)
     spec = get_action_spec(action_type)
-    if spec is None:
-        raise ValueError(f"Unknown DeclarAI action type: {action_type}")
-    payload = _coerce_payload(payload)
-    action_block = _format_action_block(action_type, payload)
-    out: dict[str, Any] = {
-        "status": "prepared",
-        "file_id": file_id,
-        "action_type": action_type,
-        "payload": payload,
-        "risk": spec.risk,
-        "requires_approval": True,
-        "side_effects": False,
-        "direct_tool": spec.direct_name,
-        "action_block": action_block,
-    }
-    if parent_span_id:
-        out["parent_span_id"] = parent_span_id
-    return out
+    with span_timer("declarai.mcp"):
+        stamp_mcp_context(
+            operation="prepare_action",
+            tool_name=spec.prepare_name if spec else f"declarai.prepare.{action_type}",
+            file_id=file_id,
+            action_type=action_type,
+            required_scopes=[auth.SCOPE_ACTION_PREPARE],
+            risk="low",
+            side_effects=False,
+            destructive=False,
+        )
+        try:
+            auth.require_scope(auth.SCOPE_ACTION_PREPARE)
+            if spec is None:
+                raise ValueError(f"Unknown DeclarAI action type: {action_type}")
+            payload = _coerce_payload(payload)
+            action_block = _format_action_block(action_type, payload)
+            out: dict[str, Any] = {
+                "status": "prepared",
+                "file_id": file_id,
+                "action_type": action_type,
+                "payload": payload,
+                "risk": spec.risk,
+                "requires_approval": True,
+                "side_effects": False,
+                "direct_tool": spec.direct_name,
+                "action_block": action_block,
+            }
+            if parent_span_id:
+                out["parent_span_id"] = parent_span_id
+            stamp_mcp_context(
+                operation="prepare_action",
+                ok=True,
+                result_chars=len(action_block),
+            )
+            return out
+        except Exception as exc:
+            stamp_mcp_context(
+                operation="prepare_action",
+                ok=False,
+                error=str(exc),
+            )
+            raise
 
 
+@workflow(name="declarai-mcp-direct-action")
 def execute_direct_action(
     file_id: int,
     action_type: str,
@@ -50,23 +81,49 @@ def execute_direct_action(
     parent_span_id: str | None = None,
 ) -> dict[str, Any]:
     """Execute a side-effecting DeclarAI action through the existing dispatcher."""
-    auth.require_direct_actions_enabled()
     spec = get_action_spec(action_type)
-    if spec is None:
-        raise ValueError(f"Unknown DeclarAI action type: {action_type}")
-    auth.require_scope(spec.scope)
-    auth.require_approval(action_type, approval_id)
-    payload = _coerce_payload(payload)
-    result = _dispatch_action(file_id, action_type, payload, parent_span_id)
-    return {
-        "status": "executed",
-        "file_id": file_id,
-        "action_type": action_type,
-        "approval_id": approval_id,
-        "risk": spec.risk,
-        "side_effects": True,
-        "result": result,
-    }
+    with span_timer("declarai.mcp"):
+        stamp_mcp_context(
+            operation="direct_action",
+            tool_name=spec.direct_name if spec else f"declarai.action.{action_type}",
+            file_id=file_id,
+            action_type=action_type,
+            required_scopes=[spec.scope] if spec else [],
+            risk=spec.risk if spec else "unknown",
+            side_effects=True,
+            destructive=spec.destructive if spec else None,
+            approval_id=approval_id,
+        )
+        try:
+            auth.require_direct_actions_enabled()
+            if spec is None:
+                raise ValueError(f"Unknown DeclarAI action type: {action_type}")
+            auth.require_scope(spec.scope)
+            auth.require_approval(action_type, approval_id)
+            payload = _coerce_payload(payload)
+            result = _dispatch_action(file_id, action_type, payload, parent_span_id)
+            out = {
+                "status": "executed",
+                "file_id": file_id,
+                "action_type": action_type,
+                "approval_id": approval_id,
+                "risk": spec.risk,
+                "side_effects": True,
+                "result": result,
+            }
+            stamp_mcp_context(
+                operation="direct_action",
+                ok=True,
+                result_chars=len(str(result)),
+            )
+            return out
+        except Exception as exc:
+            stamp_mcp_context(
+                operation="direct_action",
+                ok=False,
+                error=str(exc),
+            )
+            raise
 
 
 def _dispatch_action(

--- a/backend/ai_assistant/mcp_server/observability.py
+++ b/backend/ai_assistant/mcp_server/observability.py
@@ -1,0 +1,70 @@
+"""
+Prometa span helpers for the DeclarAI MCP facade.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+
+from ai_assistant.prometa_config import (
+    set_customer_id,
+    set_session_id,
+    set_span_attr,
+    span_timer,
+    workflow,
+)
+
+
+def stamp_mcp_context(
+    *,
+    operation: str,
+    tool_name: str | None = None,
+    file_id: int | None = None,
+    action_type: str | None = None,
+    required_scopes: Iterable[str] | None = None,
+    risk: str | None = None,
+    side_effects: bool | None = None,
+    destructive: bool | None = None,
+    approval_id: str | None = None,
+    ok: bool | None = None,
+    error: str | None = None,
+    result_chars: int | None = None,
+) -> None:
+    """Stamp DeclarAI MCP attributes on the active Prometa span."""
+    set_span_attr("declarai.mcp.operation", operation)
+    if tool_name:
+        set_span_attr("declarai.mcp.tool_name", tool_name)
+    if file_id is not None:
+        set_span_attr("declarai.mcp.file_id", file_id)
+        set_session_id(f"declarai-file-{file_id}")
+        set_customer_id(str(file_id))
+    if action_type:
+        set_span_attr("declarai.mcp.action_type", action_type)
+    scopes = list(required_scopes or [])
+    if scopes:
+        set_span_attr("declarai.mcp.required_scopes", ",".join(scopes))
+    if risk:
+        set_span_attr("declarai.mcp.risk", risk)
+    if side_effects is not None:
+        set_span_attr("declarai.mcp.side_effects", side_effects)
+    if destructive is not None:
+        set_span_attr("declarai.mcp.destructive", destructive)
+    if approval_id:
+        set_span_attr("declarai.mcp.approval_id", approval_id)
+    if ok is not None:
+        set_span_attr("declarai.mcp.ok", ok)
+    if error:
+        set_span_attr("declarai.mcp.error", error[:200])
+    if result_chars is not None:
+        set_span_attr("declarai.mcp.result_chars", result_chars)
+
+    client_id = os.environ.get("DECLARAI_MCP_CLIENT_ID")
+    if client_id:
+        set_span_attr("declarai.mcp.client_id", client_id)
+    session_id = os.environ.get("DECLARAI_MCP_SESSION_ID")
+    if session_id:
+        set_span_attr("declarai.mcp.session_id", session_id)
+    transport = os.environ.get("DECLARAI_MCP_TRANSPORT")
+    if transport:
+        set_span_attr("declarai.mcp.transport", transport)

--- a/backend/ai_assistant/mcp_server/registry.py
+++ b/backend/ai_assistant/mcp_server/registry.py
@@ -20,6 +20,8 @@ from ai_assistant.tool_definitions import PIPELINE_TOOLS
 READ_TOOL_PREFIX = "declarai."
 PREPARE_ACTION_PREFIX = "declarai.prepare."
 DIRECT_ACTION_PREFIX = "declarai.action."
+CATALOG_TOOL_NAME = "declarai.get_mcp_tool_catalog"
+TOOL_METADATA_VERSION = "declarai-mcp-tools-v1"
 
 
 @dataclass(frozen=True)
@@ -31,6 +33,9 @@ class ReadToolSpec:
     title: str
     description: str
     input_schema: dict[str, Any]
+    scope: str = auth.SCOPE_PIPELINE_READ
+    risk: str = "low"
+    destructive: bool = False
 
 
 @dataclass(frozen=True)
@@ -180,6 +185,123 @@ def get_action_spec(action_type: str) -> ActionSpec | None:
     return None
 
 
+def build_tool_meta(
+    *,
+    category: str,
+    required_scopes: list[str],
+    risk: str,
+    side_effects: bool,
+    destructive: bool,
+    idempotent: bool,
+    approval_required: bool,
+    action_type: str | None = None,
+    target_action_risk: str | None = None,
+    guardrails_required: list[str] | None = None,
+) -> dict[str, Any]:
+    """Return namespaced metadata for MCP hosts that consume Tool._meta."""
+    meta: dict[str, Any] = {
+        "declarai.tool_metadata_version": TOOL_METADATA_VERSION,
+        "declarai.category": category,
+        "declarai.required_scopes": required_scopes,
+        "declarai.risk": risk,
+        "declarai.side_effects": side_effects,
+        "declarai.destructive": destructive,
+        "declarai.idempotent": idempotent,
+        "declarai.approval_required": approval_required,
+        "declarai.guardrails_required": guardrails_required or _guardrails_for(
+            risk=risk,
+            side_effects=side_effects,
+            destructive=destructive,
+        ),
+    }
+    if action_type:
+        meta["declarai.action_type"] = action_type
+    if target_action_risk:
+        meta["declarai.target_action_risk"] = target_action_risk
+    return meta
+
+
+def build_tool_catalog(*, include_direct_actions: bool = False) -> dict[str, Any]:
+    """Return Prometa-friendly tool governance metadata.
+
+    MCP ``tools/list`` exposes annotations and optional ``_meta``. Some hosts
+    still ignore custom metadata, so DeclarAI also exposes this explicit catalog
+    for scope binding and deployment review.
+    """
+    tools: list[dict[str, Any]] = []
+    tools.append(
+        _catalog_entry(
+            name=CATALOG_TOOL_NAME,
+            title="Get MCP tool catalog",
+            category="catalog",
+            required_scopes=[auth.SCOPE_PIPELINE_READ],
+            risk="low",
+            read_only=True,
+            side_effects=False,
+            destructive=False,
+            idempotent=True,
+            approval_required=False,
+        )
+    )
+    for spec in get_read_tool_specs():
+        tools.append(
+            _catalog_entry(
+                name=spec.mcp_name,
+                title=spec.title,
+                category="read",
+                required_scopes=[spec.scope],
+                risk=spec.risk,
+                read_only=True,
+                side_effects=False,
+                destructive=spec.destructive,
+                idempotent=True,
+                approval_required=False,
+            )
+        )
+    for spec in get_action_specs():
+        tools.append(
+            _catalog_entry(
+                name=spec.prepare_name,
+                title=spec.title,
+                category="prepare_action",
+                required_scopes=[auth.SCOPE_ACTION_PREPARE],
+                risk="low",
+                read_only=True,
+                side_effects=False,
+                destructive=False,
+                idempotent=True,
+                approval_required=False,
+                action_type=spec.action_type,
+                target_action_risk=spec.risk,
+                guardrails_required=["review_action_block"],
+            )
+        )
+        if include_direct_actions:
+            tools.append(
+                _catalog_entry(
+                    name=spec.direct_name,
+                    title=spec.title.replace("Prepare", "Execute", 1),
+                    category="direct_action",
+                    required_scopes=[spec.scope],
+                    risk=spec.risk,
+                    read_only=False,
+                    side_effects=True,
+                    destructive=spec.destructive,
+                    idempotent=False,
+                    approval_required=auth.approval_required(),
+                    action_type=spec.action_type,
+                )
+            )
+    return {
+        "server": "DeclarAI Auto-ML",
+        "catalog_version": TOOL_METADATA_VERSION,
+        "default_scopes": sorted(auth.DEFAULT_SCOPES),
+        "direct_actions_registered": include_direct_actions,
+        "scope_env": "DECLARAI_MCP_SCOPES",
+        "tools": tools,
+    }
+
+
 def _schema_with_file_id(parameters: dict[str, Any]) -> dict[str, Any]:
     """Copy an OpenAI parameters schema and make ``file_id`` explicit."""
     schema = copy.deepcopy(parameters) if isinstance(parameters, dict) else {}
@@ -200,3 +322,53 @@ def _schema_with_file_id(parameters: dict[str, Any]) -> dict[str, Any]:
     schema["required"] = required
     schema.setdefault("additionalProperties", False)
     return schema
+
+
+def _catalog_entry(
+    *,
+    name: str,
+    title: str,
+    category: str,
+    required_scopes: list[str],
+    risk: str,
+    read_only: bool,
+    side_effects: bool,
+    destructive: bool,
+    idempotent: bool,
+    approval_required: bool,
+    action_type: str | None = None,
+    target_action_risk: str | None = None,
+    guardrails_required: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "title": title,
+        "category": category,
+        "required_scopes": required_scopes,
+        "risk": risk,
+        "read_only": read_only,
+        "side_effects": side_effects,
+        "destructive": destructive,
+        "idempotent": idempotent,
+        "approval_required": approval_required,
+        "action_type": action_type,
+        "target_action_risk": target_action_risk,
+        "guardrails_required": guardrails_required
+        if guardrails_required is not None
+        else _guardrails_for(
+            risk=risk,
+            side_effects=side_effects,
+            destructive=destructive,
+        ),
+    }
+
+
+def _guardrails_for(*, risk: str, side_effects: bool, destructive: bool) -> list[str]:
+    guardrails: list[str] = []
+    if side_effects:
+        guardrails.append("human_approval")
+    if risk in {"high", "critical"}:
+        guardrails.append("risk_gate")
+    if destructive:
+        guardrails.append("dataset_backup")
+    return guardrails

--- a/backend/ai_assistant/mcp_server/server.py
+++ b/backend/ai_assistant/mcp_server/server.py
@@ -12,8 +12,17 @@ from typing import Any, Literal
 
 from ai_assistant.mcp_server import auth
 from ai_assistant.mcp_server.actions import execute_direct_action, prepare_action
+from ai_assistant.mcp_server.observability import (
+    stamp_mcp_context,
+    span_timer,
+    workflow,
+)
 from ai_assistant.mcp_server.registry import (
     ActionSpec,
+    CATALOG_TOOL_NAME,
+    ReadToolSpec,
+    build_tool_catalog,
+    build_tool_meta,
     get_action_specs,
     get_read_tool_specs,
 )
@@ -59,6 +68,7 @@ def create_mcp_server(
             "Install backend requirements or run: pip install 'mcp>=1.27,<2'."
         ) from exc
 
+    include_direct_actions = _resolve_include_direct_actions(include_direct_actions)
     mcp = FastMCP(
         "DeclarAI Auto-ML",
         instructions=SERVER_INSTRUCTIONS,
@@ -66,22 +76,57 @@ def create_mcp_server(
         port=port,
         json_response=json_response,
     )
+    _register_catalog_tool(mcp, include_direct_actions=include_direct_actions)
     _register_read_tools(mcp)
     _register_prepare_action_tools(mcp)
-    if include_direct_actions is None:
-        include_direct_actions = auth.direct_actions_enabled()
-    elif include_direct_actions and not auth.direct_actions_enabled():
-        include_direct_actions = False
     if include_direct_actions:
         _register_direct_action_tools(mcp)
     return mcp
 
 
-def _run_read_tool(file_id: int, internal_name: str, arguments: dict[str, Any]) -> str:
-    auth.require_scope(auth.SCOPE_PIPELINE_READ)
-    from ai_assistant.tool_executor import execute_tool_call
+def _resolve_include_direct_actions(include_direct_actions: bool | None) -> bool:
+    if include_direct_actions is None:
+        return auth.direct_actions_enabled()
+    if include_direct_actions and not auth.direct_actions_enabled():
+        return False
+    return include_direct_actions
 
-    return execute_tool_call(file_id, internal_name, arguments)
+
+@workflow(name="declarai-mcp-read-tool")
+def _run_read_tool(
+    file_id: int,
+    mcp_name: str,
+    internal_name: str,
+    arguments: dict[str, Any],
+) -> str:
+    with span_timer("declarai.mcp"):
+        stamp_mcp_context(
+            operation="read_tool",
+            tool_name=mcp_name,
+            file_id=file_id,
+            required_scopes=[auth.SCOPE_PIPELINE_READ],
+            risk="low",
+            side_effects=False,
+            destructive=False,
+        )
+        try:
+            auth.require_scope(auth.SCOPE_PIPELINE_READ)
+            from ai_assistant.tool_executor import execute_tool_call
+
+            result = execute_tool_call(file_id, internal_name, arguments)
+            stamp_mcp_context(
+                operation="read_tool",
+                ok=True,
+                result_chars=len(result),
+            )
+            return result
+        except Exception as exc:
+            stamp_mcp_context(
+                operation="read_tool",
+                ok=False,
+                error=str(exc),
+            )
+            raise
 
 
 def _clean_args(**kwargs: Any) -> dict[str, Any]:
@@ -101,167 +146,326 @@ def _tool_annotations(*, read_only: bool, destructive: bool, idempotent: bool):
     )
 
 
+def _register_catalog_tool(mcp, *, include_direct_actions: bool) -> None:
+    annotations = _tool_annotations(
+        read_only=True,
+        destructive=False,
+        idempotent=True,
+    )
+    meta = build_tool_meta(
+        category="catalog",
+        required_scopes=[auth.SCOPE_PIPELINE_READ],
+        risk="low",
+        side_effects=False,
+        destructive=False,
+        idempotent=True,
+        approval_required=False,
+    )
+
+    @mcp.tool(
+        name=CATALOG_TOOL_NAME,
+        title="Get MCP tool catalog",
+        description=(
+            "Return DeclarAI MCP tool scopes, risk, side-effect, approval, "
+            "and guardrail metadata for Prometa binding."
+        ),
+        annotations=annotations,
+        meta=meta,
+        structured_output=True,
+    )
+    @workflow(name="declarai-mcp-catalog")
+    def get_mcp_tool_catalog() -> dict[str, Any]:
+        with span_timer("declarai.mcp"):
+            stamp_mcp_context(
+                operation="catalog",
+                tool_name=CATALOG_TOOL_NAME,
+                required_scopes=[auth.SCOPE_PIPELINE_READ],
+                risk="low",
+                side_effects=False,
+                destructive=False,
+            )
+            try:
+                auth.require_scope(auth.SCOPE_PIPELINE_READ)
+                result = build_tool_catalog(
+                    include_direct_actions=include_direct_actions,
+                )
+                stamp_mcp_context(
+                    operation="catalog",
+                    ok=True,
+                    result_chars=len(str(result)),
+                )
+                return result
+            except Exception as exc:
+                stamp_mcp_context(
+                    operation="catalog",
+                    ok=False,
+                    error=str(exc),
+                )
+                raise
+
+
 def _register_read_tools(mcp) -> None:
     read_annotations = _tool_annotations(
         read_only=True,
         destructive=False,
         idempotent=True,
     )
-    descriptions = {spec.internal_name: spec.description for spec in get_read_tool_specs()}
+    read_specs = {spec.internal_name: spec for spec in get_read_tool_specs()}
+    descriptions = {
+        spec.internal_name: spec.description for spec in read_specs.values()
+    }
 
     @mcp.tool(
         name="declarai.get_split_validation",
         title="Get split validation",
         description=descriptions["get_split_validation"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_split_validation"]),
         structured_output=False,
     )
     def get_split_validation(file_id: int) -> str:
-        return _run_read_tool(file_id, "get_split_validation", {})
+        return _run_read_tool(
+            file_id,
+            "declarai.get_split_validation",
+            "get_split_validation",
+            {},
+        )
 
     @mcp.tool(
         name="declarai.get_dq_summary",
         title="Get data-quality summary",
         description=descriptions["get_dq_summary"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_dq_summary"]),
         structured_output=False,
     )
     def get_dq_summary(file_id: int, feature: str | None = None) -> str:
-        return _run_read_tool(file_id, "get_dq_summary", _clean_args(feature=feature))
+        return _run_read_tool(
+            file_id,
+            "declarai.get_dq_summary",
+            "get_dq_summary",
+            _clean_args(feature=feature),
+        )
 
     @mcp.tool(
         name="declarai.get_feature_stats",
         title="Get feature stats",
         description=descriptions["get_feature_stats"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_feature_stats"]),
         structured_output=False,
     )
     def get_feature_stats(file_id: int, feature: str) -> str:
-        return _run_read_tool(file_id, "get_feature_stats", {"feature": feature})
+        return _run_read_tool(
+            file_id,
+            "declarai.get_feature_stats",
+            "get_feature_stats",
+            {"feature": feature},
+        )
 
     @mcp.tool(
         name="declarai.get_vif_decomposition",
         title="Get VIF decomposition",
         description=descriptions["get_vif_decomposition"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_vif_decomposition"]),
         structured_output=False,
     )
     def get_vif_decomposition(file_id: int, feature: str) -> str:
-        return _run_read_tool(file_id, "get_vif_decomposition", {"feature": feature})
+        return _run_read_tool(
+            file_id,
+            "declarai.get_vif_decomposition",
+            "get_vif_decomposition",
+            {"feature": feature},
+        )
 
     @mcp.tool(
         name="declarai.get_encoding_plan",
         title="Get encoding plan",
         description=descriptions["get_encoding_plan"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_encoding_plan"]),
         structured_output=False,
     )
     def get_encoding_plan(file_id: int) -> str:
-        return _run_read_tool(file_id, "get_encoding_plan", {})
+        return _run_read_tool(
+            file_id,
+            "declarai.get_encoding_plan",
+            "get_encoding_plan",
+            {},
+        )
 
     @mcp.tool(
         name="declarai.get_selected_features",
         title="Get selected features",
         description=descriptions["get_selected_features"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_selected_features"]),
         structured_output=False,
     )
     def get_selected_features(file_id: int, top_n: int | None = None) -> str:
-        return _run_read_tool(file_id, "get_selected_features", _clean_args(top_n=top_n))
+        return _run_read_tool(
+            file_id,
+            "declarai.get_selected_features",
+            "get_selected_features",
+            _clean_args(top_n=top_n),
+        )
 
     @mcp.tool(
         name="declarai.get_shap_details",
         title="Get SHAP details",
         description=descriptions["get_shap_details"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_shap_details"]),
         structured_output=False,
     )
     def get_shap_details(file_id: int, top_n: int | None = None) -> str:
-        return _run_read_tool(file_id, "get_shap_details", _clean_args(top_n=top_n))
+        return _run_read_tool(
+            file_id,
+            "declarai.get_shap_details",
+            "get_shap_details",
+            _clean_args(top_n=top_n),
+        )
 
     @mcp.tool(
         name="declarai.get_sfs_results",
         title="Get SFS results",
         description=descriptions["get_sfs_results"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_sfs_results"]),
         structured_output=False,
     )
     def get_sfs_results(file_id: int, direction: SFS_DIRECTION | None = None) -> str:
-        return _run_read_tool(file_id, "get_sfs_results", _clean_args(direction=direction))
+        return _run_read_tool(
+            file_id,
+            "declarai.get_sfs_results",
+            "get_sfs_results",
+            _clean_args(direction=direction),
+        )
 
     @mcp.tool(
         name="declarai.get_cv_results",
         title="Get CV results",
         description=descriptions["get_cv_results"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_cv_results"]),
         structured_output=False,
     )
     def get_cv_results(file_id: int) -> str:
-        return _run_read_tool(file_id, "get_cv_results", {})
+        return _run_read_tool(
+            file_id,
+            "declarai.get_cv_results",
+            "get_cv_results",
+            {},
+        )
 
     @mcp.tool(
         name="declarai.get_pipeline_notes",
         title="Get pipeline notes",
         description=descriptions["get_pipeline_notes"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_pipeline_notes"]),
         structured_output=False,
     )
     def get_pipeline_notes(file_id: int) -> str:
-        return _run_read_tool(file_id, "get_pipeline_notes", {})
+        return _run_read_tool(
+            file_id,
+            "declarai.get_pipeline_notes",
+            "get_pipeline_notes",
+            {},
+        )
 
     @mcp.tool(
         name="declarai.get_pipeline_config",
         title="Get pipeline config",
         description=descriptions["get_pipeline_config"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_pipeline_config"]),
         structured_output=False,
     )
     def get_pipeline_config(file_id: int) -> str:
-        return _run_read_tool(file_id, "get_pipeline_config", {})
+        return _run_read_tool(
+            file_id,
+            "declarai.get_pipeline_config",
+            "get_pipeline_config",
+            {},
+        )
 
     @mcp.tool(
         name="declarai.get_purifier_options",
         title="Get purifier options",
         description=descriptions["get_purifier_options"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_purifier_options"]),
         structured_output=False,
     )
     def get_purifier_options(file_id: int, kind: PURIFIER_KIND | None = None) -> str:
-        return _run_read_tool(file_id, "get_purifier_options", _clean_args(kind=kind))
+        return _run_read_tool(
+            file_id,
+            "declarai.get_purifier_options",
+            "get_purifier_options",
+            _clean_args(kind=kind),
+        )
 
     @mcp.tool(
         name="declarai.get_data_dictionary",
         title="Get data dictionary",
         description=descriptions["get_data_dictionary"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_data_dictionary"]),
         structured_output=False,
     )
     def get_data_dictionary(file_id: int, feature: str | None = None) -> str:
-        return _run_read_tool(file_id, "get_data_dictionary", _clean_args(feature=feature))
+        return _run_read_tool(
+            file_id,
+            "declarai.get_data_dictionary",
+            "get_data_dictionary",
+            _clean_args(feature=feature),
+        )
 
     @mcp.tool(
         name="declarai.invoke_skill",
         title="Invoke bundled skill",
         description=descriptions["invoke_skill"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["invoke_skill"]),
         structured_output=False,
     )
     def invoke_skill(file_id: int, skill_name: str) -> str:
-        return _run_read_tool(file_id, "invoke_skill", {"skill_name": skill_name})
+        return _run_read_tool(
+            file_id,
+            "declarai.invoke_skill",
+            "invoke_skill",
+            {"skill_name": skill_name},
+        )
 
     @mcp.tool(
         name="declarai.get_skill_file",
         title="Get skill file",
         description=descriptions["get_skill_file"],
         annotations=read_annotations,
+        meta=_read_tool_meta(read_specs["get_skill_file"]),
         structured_output=False,
     )
     def get_skill_file(file_id: int, skill_name: str, path: str) -> str:
         return _run_read_tool(
             file_id,
+            "declarai.get_skill_file",
             "get_skill_file",
             {"skill_name": skill_name, "path": path},
         )
+
+
+def _read_tool_meta(spec: ReadToolSpec) -> dict[str, Any]:
+    return build_tool_meta(
+        category="read",
+        required_scopes=[spec.scope],
+        risk=spec.risk,
+        side_effects=False,
+        destructive=spec.destructive,
+        idempotent=True,
+        approval_required=False,
+    )
 
 
 def _register_prepare_action_tools(mcp) -> None:
@@ -280,16 +484,23 @@ def _register_prepare_action_tools(mcp) -> None:
                 "action block and does not execute it."
             ),
             annotations=annotations,
+            meta=build_tool_meta(
+                category="prepare_action",
+                required_scopes=[auth.SCOPE_ACTION_PREPARE],
+                risk="low",
+                side_effects=False,
+                destructive=False,
+                idempotent=True,
+                approval_required=False,
+                action_type=spec.action_type,
+                target_action_risk=spec.risk,
+                guardrails_required=["review_action_block"],
+            ),
             structured_output=True,
         )
 
 
 def _register_direct_action_tools(mcp) -> None:
-    annotations = _tool_annotations(
-        read_only=False,
-        destructive=True,
-        idempotent=False,
-    )
     for spec in get_action_specs():
         mcp.add_tool(
             _make_direct_action_tool(spec),
@@ -299,7 +510,21 @@ def _register_direct_action_tools(mcp) -> None:
                 f"Execute {spec.action_type} through the DeclarAI action dispatcher. "
                 f"Requires scope {spec.scope} and approval_id."
             ),
-            annotations=annotations,
+            annotations=_tool_annotations(
+                read_only=False,
+                destructive=spec.destructive,
+                idempotent=False,
+            ),
+            meta=build_tool_meta(
+                category="direct_action",
+                required_scopes=[spec.scope],
+                risk=spec.risk,
+                side_effects=True,
+                destructive=spec.destructive,
+                idempotent=False,
+                approval_required=auth.approval_required(),
+                action_type=spec.action_type,
+            ),
             structured_output=True,
         )
 

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -31,6 +31,34 @@ class TestMcpRegistry:
         spec_names = [spec.action_type for spec in get_action_specs()]
         assert spec_names == list(HANDLERS.keys())
 
+    def test_catalog_documents_prometa_scope_and_guardrail_binding(self):
+        from ai_assistant.mcp_server.registry import build_tool_catalog
+
+        catalog = build_tool_catalog(include_direct_actions=True)
+        by_name = {tool["name"]: tool for tool in catalog["tools"]}
+
+        assert catalog["catalog_version"] == "declarai-mcp-tools-v1"
+        assert by_name["declarai.get_mcp_tool_catalog"]["required_scopes"] == [
+            "declarai.pipeline.read"
+        ]
+        assert by_name["declarai.get_data_dictionary"]["required_scopes"] == [
+            "declarai.pipeline.read"
+        ]
+        assert by_name["declarai.prepare.execute_code"]["required_scopes"] == [
+            "declarai.action.prepare"
+        ]
+        assert by_name["declarai.prepare.execute_code"]["guardrails_required"] == [
+            "review_action_block"
+        ]
+        direct_execute = by_name["declarai.action.execute_code"]
+        assert direct_execute["required_scopes"] == ["declarai.dataset.write"]
+        assert direct_execute["destructive"] is True
+        assert direct_execute["guardrails_required"] == [
+            "human_approval",
+            "risk_gate",
+            "dataset_backup",
+        ]
+
 
 @pytest.mark.unit
 class TestMcpActionHelpers:
@@ -113,6 +141,29 @@ class TestMcpActionHelpers:
         assert result["result"]["status"] == "success"
         assert calls == [(42, "update_notes", {"action": "add"}, "span-1")]
 
+    def test_prepare_action_stamps_mcp_span_attributes(self, monkeypatch):
+        monkeypatch.delenv("DECLARAI_MCP_SCOPES", raising=False)
+        from ai_assistant.mcp_server import actions
+
+        stamped = []
+        monkeypatch.setattr(
+            actions,
+            "stamp_mcp_context",
+            lambda **kwargs: stamped.append(kwargs),
+        )
+
+        actions.prepare_action(
+            42,
+            "update_notes",
+            {"action": "add", "content": "Review note"},
+        )
+
+        assert stamped[0]["operation"] == "prepare_action"
+        assert stamped[0]["tool_name"] == "declarai.prepare.update_notes"
+        assert stamped[0]["file_id"] == 42
+        assert stamped[0]["required_scopes"] == ["declarai.action.prepare"]
+        assert stamped[-1]["ok"] is True
+
 
 @pytest.mark.unit
 class TestMcpServer:
@@ -124,9 +175,18 @@ class TestMcpServer:
         tools = asyncio.run(mcp.list_tools())
         names = {tool.name for tool in tools}
 
+        assert "declarai.get_mcp_tool_catalog" in names
         assert "declarai.get_data_dictionary" in names
         assert "declarai.prepare.start_sfs" in names
         assert "declarai.action.start_sfs" not in names
+
+        by_name = {tool.name: tool for tool in tools}
+        assert by_name["declarai.get_data_dictionary"].meta[
+            "declarai.required_scopes"
+        ] == ["declarai.pipeline.read"]
+        assert by_name["declarai.prepare.start_sfs"].meta[
+            "declarai.guardrails_required"
+        ] == ["review_action_block"]
 
     def test_prepare_tool_can_be_invoked_through_fastmcp(self, monkeypatch):
         pytest.importorskip("mcp")
@@ -148,6 +208,21 @@ class TestMcpServer:
         assert structured["action_type"] == "update_notes"
         assert structured["side_effects"] is False
 
+    def test_catalog_tool_can_be_invoked_through_fastmcp(self, monkeypatch):
+        pytest.importorskip("mcp")
+        monkeypatch.delenv("DECLARAI_MCP_SCOPES", raising=False)
+        from ai_assistant.mcp_server.server import create_mcp_server
+
+        mcp = create_mcp_server(include_direct_actions=False)
+        _, structured = asyncio.run(
+            mcp.call_tool("declarai.get_mcp_tool_catalog", {})
+        )
+        by_name = {tool["name"]: tool for tool in structured["tools"]}
+
+        assert structured["direct_actions_registered"] is False
+        assert "declarai.action.update_notes" not in by_name
+        assert by_name["declarai.prepare.update_notes"]["target_action_risk"] == "low"
+
     def test_create_server_can_register_direct_actions(self, monkeypatch):
         pytest.importorskip("mcp")
         monkeypatch.setenv("DECLARAI_MCP_ENABLE_DIRECT_ACTIONS", "true")
@@ -158,6 +233,18 @@ class TestMcpServer:
         names = {tool.name for tool in tools}
 
         assert "declarai.action.update_notes" in names
+
+        by_name = {tool.name: tool for tool in tools}
+        update_notes = by_name["declarai.action.update_notes"]
+        execute_code = by_name["declarai.action.execute_code"]
+        assert update_notes.annotations.destructiveHint is False
+        assert update_notes.meta["declarai.required_scopes"] == ["declarai.notes.write"]
+        assert execute_code.annotations.destructiveHint is True
+        assert execute_code.meta["declarai.guardrails_required"] == [
+            "human_approval",
+            "risk_gate",
+            "dataset_backup",
+        ]
 
     def test_direct_actions_flag_still_requires_env_gate(self, monkeypatch):
         pytest.importorskip("mcp")

--- a/docs/ai-assistant-tools-and-mcp-integration.md
+++ b/docs/ai-assistant-tools-and-mcp-integration.md
@@ -697,3 +697,123 @@ Direct action calls require `approval_id` by default. For trusted local-only aut
 ```bash
 export DECLARAI_MCP_REQUIRE_APPROVAL=false
 ```
+
+### Prometa Binding Contract
+
+Current recommended shape for the POC is Prometa on-prem or same-network
+Prometa connected to an internal DeclarAI Streamable HTTP endpoint:
+
+```bash
+python manage.py run_mcp_server --transport streamable-http --host 0.0.0.0 --port 8000
+```
+
+For Prometa SaaS, put this endpoint behind public HTTPS with MCP-aware OAuth or
+an equivalent resource-server gateway before registering it in Prometa. The
+Django management command is the MCP application surface; production internet
+exposure should add TLS termination, Origin validation, token audience checks,
+and per-agent scopes at the ingress layer.
+
+The server publishes governance metadata in two ways:
+
+- every MCP `Tool` has `_meta` keys such as `declarai.required_scopes`,
+  `declarai.risk`, `declarai.side_effects`, `declarai.destructive`,
+  `declarai.approval_required`, and `declarai.guardrails_required`;
+- `declarai.get_mcp_tool_catalog` returns the same metadata as a structured
+  catalog for hosts that do not consume custom `Tool._meta`.
+
+Read-only tools:
+
+```text
+declarai.get_mcp_tool_catalog
+declarai.get_split_validation
+declarai.get_dq_summary
+declarai.get_feature_stats
+declarai.get_vif_decomposition
+declarai.get_encoding_plan
+declarai.get_selected_features
+declarai.get_shap_details
+declarai.get_sfs_results
+declarai.get_cv_results
+declarai.get_pipeline_notes
+declarai.get_pipeline_config
+declarai.get_purifier_options
+declarai.get_data_dictionary
+declarai.invoke_skill
+declarai.get_skill_file
+```
+
+Required scope for all read-only tools:
+
+```text
+declarai.pipeline.read
+```
+
+Prepare-action tools are review-only. They return DeclarAI action blocks but do
+not mutate data, metadata, config, notes, or pipeline state. They are annotated
+as read-only, non-destructive, and idempotent. Required scope for every
+`declarai.prepare.*` tool:
+
+```text
+declarai.action.prepare
+```
+
+Direct action tools are only registered when both are true:
+
+```bash
+export DECLARAI_MCP_ENABLE_DIRECT_ACTIONS=true
+python manage.py run_mcp_server --direct-actions
+```
+
+Direct action scope map:
+
+| MCP tool | Scope | Risk | Destructive | Mandatory guardrails |
+| --- | --- | --- | --- | --- |
+| `declarai.action.execute_code` | `declarai.dataset.write` | high | yes | human approval, risk gate, dataset backup |
+| `declarai.action.update_metadata` | `declarai.metadata.write` | medium | no | human approval |
+| `declarai.action.update_config` | `declarai.config.write` | medium | no | human approval |
+| `declarai.action.set_ordinal_ranking` | `declarai.metadata.write` | medium | no | human approval |
+| `declarai.action.start_sfs` | `declarai.pipeline.run` | high | no | human approval, risk gate |
+| `declarai.action.start_data_purifier` | `declarai.pipeline.run` | high | no | human approval, risk gate |
+| `declarai.action.update_purifier_selection` | `declarai.config.write` | medium | no | human approval |
+| `declarai.action.apply_encoding` | `declarai.pipeline.run` | high | no | human approval, risk gate |
+| `declarai.action.start_modeling` | `declarai.pipeline.run` | high | no | human approval, risk gate |
+| `declarai.action.start_hyperparameter` | `declarai.pipeline.run` | high | no | human approval, risk gate |
+| `declarai.action.update_notes` | `declarai.notes.write` | low | no | human approval |
+
+Annotation contract:
+
+- read tools: `readOnlyHint=true`, `destructiveHint=false`,
+  `idempotentHint=true`;
+- prepare tools: `readOnlyHint=true`, `destructiveHint=false`,
+  `idempotentHint=true`;
+- direct action tools: `readOnlyHint=false`, `idempotentHint=false`, and
+  `destructiveHint=true` only for `declarai.action.execute_code`.
+
+MCP observability spans:
+
+- `declarai-mcp-catalog` for governance catalog calls;
+- `declarai-mcp-read-tool` for read tool calls;
+- `declarai-mcp-prepare-action` for review-only action preparation;
+- `declarai-mcp-direct-action` for side-effecting action execution;
+
+The emitted attributes include `declarai.mcp.operation`,
+`declarai.mcp.tool_name`, `declarai.mcp.file_id`, `declarai.mcp.action_type`,
+`declarai.mcp.required_scopes`, `declarai.mcp.risk`,
+`declarai.mcp.side_effects`, `declarai.mcp.destructive`,
+`declarai.mcp.approval_id`, `declarai.mcp.ok`,
+`declarai.mcp.result_chars`, and elapsed timing attributes.
+
+Optional deployment labels can be supplied with:
+
+```bash
+export DECLARAI_MCP_CLIENT_ID=prometa-builder
+export DECLARAI_MCP_SESSION_ID=prometa-sync-session
+export DECLARAI_MCP_TRANSPORT=streamable-http
+```
+
+Runtime boundary as of this implementation: DeclarAI hosts the MCP tool
+surface and can execute direct action tools when explicitly enabled. Prometa can
+discover, govern, and bundle agents from that surface. The production
+`tools/call` executor loop should be chosen per deployment: either Prometa hosts
+the agent executor and calls DeclarAI MCP tools, or DeclarAI runs the signed
+Prometa bundle next to the MCP host.


### PR DESCRIPTION
## Summary
- add Prometa-friendly MCP tool metadata and a structured tool catalog for scope/risk/guardrail binding
- correct direct-action annotations so only destructive actions set destructiveHint=true
- emit declarai.mcp.* Prometa spans around catalog, read, prepare, and direct MCP calls
- document the Prometa deployment shape, scope map, annotations, observability attributes, and executor boundary

## Validation
- pytest tests/test_mcp_server.py -q
- python -m compileall ai_assistant/mcp_server ai_assistant/management/commands/run_mcp_server.py
- pre-commit hook: 914 backend tests passed
- pre-push hook: 914 backend tests passed, frontend build passed, 415 Karma specs passed