### PR TITLE
feat: add Prometa on-prem bundle runner

### DIFF
--- a/backend/ai_assistant/management/commands/run_prometa_bundle.py
+++ b/backend/ai_assistant/management/commands/run_prometa_bundle.py
@@ -1,0 +1,97 @@
+"""Verify and run a signed Prometa deployment bundle locally."""
+
+from __future__ import annotations
+
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ai_assistant.prometa_runner.runner import PrometaOnPremBundleRunner
+
+
+class Command(BaseCommand):
+    help = "Verify/preflight a signed Prometa bundle and optionally call a bundled MCP tool."
+
+    def add_arguments(self, parser):
+        source = parser.add_mutually_exclusive_group(required=True)
+        source.add_argument(
+            "--bundle-file",
+            help="Path to a Prometa bundle JSON file.",
+        )
+        source.add_argument(
+            "--manifest-id",
+            help="Prometa agent manifest id to fetch from /api/agent-manifests/{id}/bundle.",
+        )
+        parser.add_argument(
+            "--prometa-url",
+            help="Prometa base URL when using --manifest-id.",
+        )
+        parser.add_argument(
+            "--token",
+            help="Bearer token for Prometa bundle fetch.",
+        )
+        parser.add_argument(
+            "--timeout",
+            type=float,
+            default=30.0,
+            help="Prometa fetch timeout in seconds.",
+        )
+        parser.add_argument(
+            "--allow-unsigned",
+            action="store_true",
+            help="Allow unsigned bundles. For local development only.",
+        )
+        parser.add_argument(
+            "--tool",
+            help="Bundled MCP operation to call, for example declarai.prepare.update_notes.",
+        )
+        parser.add_argument(
+            "--arguments",
+            default="{}",
+            help="JSON object arguments for --tool.",
+        )
+        parser.add_argument(
+            "--approval-id",
+            help="Human approval record id for approval-required tool calls.",
+        )
+
+    def handle(self, *args, **options):
+        require_signature = not options["allow_unsigned"]
+        try:
+            if options["bundle_file"]:
+                runner = PrometaOnPremBundleRunner.from_file(
+                    options["bundle_file"],
+                    require_signature=require_signature,
+                )
+            else:
+                if not options["prometa_url"]:
+                    raise CommandError("--prometa-url is required with --manifest-id.")
+                runner = PrometaOnPremBundleRunner.from_prometa(
+                    base_url=options["prometa_url"],
+                    manifest_id=options["manifest_id"],
+                    token=options["token"],
+                    timeout=options["timeout"],
+                    require_signature=require_signature,
+                )
+
+            if not options["tool"]:
+                self.stdout.write(json.dumps(runner.summary(), indent=2, sort_keys=True))
+                return
+
+            try:
+                arguments = json.loads(options["arguments"])
+            except json.JSONDecodeError as exc:
+                raise CommandError("--arguments must be a JSON object.") from exc
+            if not isinstance(arguments, dict):
+                raise CommandError("--arguments must be a JSON object.")
+
+            result = runner.call_tool(
+                options["tool"],
+                arguments,
+                approval_id=options["approval_id"],
+            )
+            self.stdout.write(json.dumps(result, indent=2, sort_keys=True))
+        except CommandError:
+            raise
+        except Exception as exc:
+            raise CommandError(str(exc)) from exc

--- a/backend/ai_assistant/mcp_server/observability.py
+++ b/backend/ai_assistant/mcp_server/observability.py
@@ -14,6 +14,8 @@ from ai_assistant.prometa_config import (
     span_timer,
     workflow,
 )
+from ai_assistant.prometa_runner.context import get_current_bundle_identity
+from ai_assistant.prometa_runner.telemetry import stamp_bundle_identity
 
 
 def stamp_mcp_context(
@@ -58,6 +60,10 @@ def stamp_mcp_context(
         set_span_attr("declarai.mcp.error", error[:200])
     if result_chars is not None:
         set_span_attr("declarai.mcp.result_chars", result_chars)
+
+    bundle_identity = get_current_bundle_identity()
+    if bundle_identity is not None:
+        stamp_bundle_identity(*bundle_identity)
 
     client_id = os.environ.get("DECLARAI_MCP_CLIENT_ID")
     if client_id:

--- a/backend/ai_assistant/prometa_runner/__init__.py
+++ b/backend/ai_assistant/prometa_runner/__init__.py
@@ -1,0 +1,17 @@
+"""
+DeclarAI-owned runner support for signed Prometa deployment bundles.
+"""
+
+from .canonicalization import (
+    CANONICALIZATION_ALGORITHM,
+    canonicalize_bundle_content,
+)
+from .runner import PrometaOnPremBundleRunner
+from .signature import verify_bundle_signature
+
+__all__ = [
+    "CANONICALIZATION_ALGORITHM",
+    "PrometaOnPremBundleRunner",
+    "canonicalize_bundle_content",
+    "verify_bundle_signature",
+]

--- a/backend/ai_assistant/prometa_runner/canonicalization.py
+++ b/backend/ai_assistant/prometa_runner/canonicalization.py
@@ -1,0 +1,63 @@
+"""
+Canonical byte representation for Prometa deployment bundle signatures.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+
+CANONICALIZATION_ALGORITHM = "json-stable-sort-keys-utf8-no-ascii-escape-v1"
+LEGACY_CANONICALIZATION_ALGORITHMS = frozenset({None, ""})
+SUPPORTED_CANONICALIZATION_ALGORITHMS = frozenset(
+    {CANONICALIZATION_ALGORITHM, *LEGACY_CANONICALIZATION_ALGORITHMS}
+)
+
+
+class CanonicalizationError(ValueError):
+    """Raised when a bundle declares an unsupported canonicalization."""
+
+
+def canonicalization_from_envelope(envelope: Mapping[str, Any]) -> str | None:
+    value = envelope.get("canonicalization")
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise CanonicalizationError("Bundle canonicalization must be a string.")
+    return value
+
+
+def require_supported_canonicalization(envelope: Mapping[str, Any]) -> str:
+    declared = canonicalization_from_envelope(envelope)
+    if declared not in SUPPORTED_CANONICALIZATION_ALGORITHMS:
+        raise CanonicalizationError(
+            f"Unsupported Prometa bundle canonicalization: {declared!r}."
+        )
+    return declared or CANONICALIZATION_ALGORITHM
+
+
+def canonicalize_bundle_content(content: Mapping[str, Any]) -> bytes:
+    """Return the exact bytes Prometa signs for ``content``.
+
+    Mirrors Prometa's TypeScript helper:
+
+    ``JSON.stringify(stable(content))``
+
+    where ``stable`` recursively sorts object keys, preserves array order, and
+    leaves primitive values unchanged. Python details that matter:
+
+    - ``sort_keys=True`` recurses through dictionaries;
+    - compact separators match ``JSON.stringify`` spacing;
+    - ``ensure_ascii=False`` keeps non-ASCII text as UTF-8 bytes;
+    - ``allow_nan=False`` rejects NaN/Infinity instead of emitting invalid
+      JavaScript-compatible values.
+    """
+    return json.dumps(
+        content,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")

--- a/backend/ai_assistant/prometa_runner/client.py
+++ b/backend/ai_assistant/prometa_runner/client.py
@@ -1,0 +1,50 @@
+"""
+Small in-plane HTTP client for fetching Prometa deployment bundles.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urljoin
+from urllib.request import Request, urlopen
+
+
+class PrometaBundleFetchError(RuntimeError):
+    """Raised when the runner cannot fetch a bundle from Prometa."""
+
+
+def fetch_bundle(
+    *,
+    base_url: str,
+    manifest_id: str,
+    token: str | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Fetch ``GET /api/agent-manifests/{id}/bundle`` from Prometa."""
+    root = base_url.rstrip("/") + "/"
+    path = f"api/agent-manifests/{quote(manifest_id, safe='')}/bundle"
+    url = urljoin(root, path)
+    headers = {"Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(url, headers=headers, method="GET")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise PrometaBundleFetchError(
+            f"Prometa bundle fetch failed with HTTP {exc.code}: {body[:300]}"
+        ) from exc
+    except URLError as exc:
+        raise PrometaBundleFetchError(f"Prometa bundle fetch failed: {exc}") from exc
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise PrometaBundleFetchError("Prometa bundle response was not JSON.") from exc
+    if not isinstance(parsed, dict):
+        raise PrometaBundleFetchError("Prometa bundle response must be a JSON object.")
+    return parsed

--- a/backend/ai_assistant/prometa_runner/context.py
+++ b/backend/ai_assistant/prometa_runner/context.py
@@ -1,0 +1,25 @@
+"""
+Request-local Prometa bundle identity for MCP calls.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+
+_bundle_identity: ContextVar[tuple[str, str | None] | None] = ContextVar(
+    "declarai_prometa_bundle_identity",
+    default=None,
+)
+
+
+def set_current_bundle_identity(agent_id: str, solution_id: str | None = None):
+    return _bundle_identity.set((agent_id, solution_id))
+
+
+def reset_current_bundle_identity(token) -> None:
+    _bundle_identity.reset(token)
+
+
+def get_current_bundle_identity() -> tuple[str, str | None] | None:
+    return _bundle_identity.get()

--- a/backend/ai_assistant/prometa_runner/policy.py
+++ b/backend/ai_assistant/prometa_runner/policy.py
@@ -1,0 +1,209 @@
+"""
+Governance checks for Prometa deployment bundle execution.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+RISK_ORDER = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+READ_ONLY_SIDE_EFFECTS = frozenset({"", "none", "read", "read-only", "read_only"})
+
+
+class BundlePolicyError(PermissionError):
+    """Raised when a bundle or tool call violates Prometa governance."""
+
+
+def manifest(content: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = content.get("manifest")
+    if not isinstance(value, Mapping):
+        raise BundlePolicyError("Prometa bundle content is missing manifest.")
+    return value
+
+
+def require_deployable(content: Mapping[str, Any]) -> None:
+    if manifest(content).get("deployable") is not True:
+        raise BundlePolicyError("Prometa bundle is not deployable.")
+
+
+def require_agent_identity(content: Mapping[str, Any]) -> tuple[str, str | None]:
+    m = manifest(content)
+    agent_id = m.get("agentId")
+    solution_id = m.get("solutionId")
+    if not isinstance(agent_id, str) or not agent_id.strip():
+        raise BundlePolicyError("Prometa bundle manifest is missing agentId.")
+    if solution_id is not None and not isinstance(solution_id, str):
+        raise BundlePolicyError("Prometa bundle manifest solutionId must be a string.")
+    return agent_id, solution_id
+
+
+def preflight_bundle(content: Mapping[str, Any]) -> None:
+    require_deployable(content)
+    require_agent_identity(content)
+    for tool in bundle_tools(content):
+        require_tool_scopes(content, tool)
+
+
+def bundle_tools(content: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    tools = content.get("tools")
+    if not isinstance(tools, Sequence) or isinstance(tools, (str, bytes)):
+        return []
+    return [tool for tool in tools if isinstance(tool, Mapping)]
+
+
+def find_tool(content: Mapping[str, Any], operation: str) -> Mapping[str, Any]:
+    matches = [
+        tool for tool in bundle_tools(content) if tool.get("operation") == operation
+    ]
+    if not matches:
+        raise BundlePolicyError(f"Tool operation is not in Prometa bundle: {operation}")
+    if len(matches) > 1:
+        raise BundlePolicyError(
+            f"Tool operation is ambiguous in Prometa bundle: {operation}"
+        )
+    return matches[0]
+
+
+def require_tool_call_allowed(
+    content: Mapping[str, Any],
+    tool: Mapping[str, Any],
+    *,
+    approval_id: str | None = None,
+) -> None:
+    require_deployable(content)
+    require_agent_identity(content)
+    require_tool_scopes(content, tool)
+    required_guardrails = guardrails_required_for_tool(tool)
+    missing = [
+        guardrail
+        for guardrail in required_guardrails
+        if not bundle_has_guardrail(content, guardrail)
+    ]
+    if missing:
+        operation = str(tool.get("operation") or "")
+        raise BundlePolicyError(
+            f"Tool {operation} is missing required guardrails: {', '.join(missing)}"
+        )
+    if approval_required_for_tool(tool) and not (approval_id or "").strip():
+        operation = str(tool.get("operation") or "")
+        raise BundlePolicyError(f"Tool {operation} requires approval_id.")
+
+
+def require_tool_scopes(
+    content: Mapping[str, Any],
+    tool: Mapping[str, Any],
+) -> None:
+    required = set(_str_list(tool.get("scopes")))
+    if not required:
+        return
+    identity_scopes = set(_identity_granted_scopes(content))
+    bundle_granted = set(_str_list(content.get("grantedScopes")))
+    granted = identity_scopes | bundle_granted
+    missing = sorted(required - granted)
+    if missing:
+        operation = str(tool.get("operation") or "")
+        raise BundlePolicyError(
+            f"Tool {operation} requires scopes not granted by bundle identity: "
+            f"{', '.join(missing)}"
+        )
+
+
+def approval_required_for_tool(tool: Mapping[str, Any]) -> bool:
+    explicit = _optional_bool(tool.get("approvalRequired"))
+    if explicit is None:
+        explicit = _optional_bool(tool.get("approval_required"))
+    if explicit is not None:
+        return explicit
+    operation = str(tool.get("operation") or "")
+    if operation.startswith("declarai.action."):
+        return True
+    side_effects = _normalize(str(tool.get("sideEffects") or ""))
+    return side_effects not in {_normalize(v) for v in READ_ONLY_SIDE_EFFECTS}
+
+
+def guardrails_required_for_tool(tool: Mapping[str, Any]) -> list[str]:
+    explicit = _str_list(tool.get("requiredGuardrails"))
+    if not explicit:
+        explicit = _str_list(tool.get("required_guardrails"))
+    if explicit:
+        return [_normalize_guardrail(value) for value in explicit]
+
+    required: list[str] = []
+    if approval_required_for_tool(tool):
+        required.append("human_approval")
+    if _risk_rank(tool) >= RISK_ORDER["high"]:
+        required.append("risk_gate")
+    operation = str(tool.get("operation") or "")
+    if operation == "declarai.action.execute_code":
+        required.append("dataset_backup")
+    return required
+
+
+def bundle_has_guardrail(content: Mapping[str, Any], guardrail: str) -> bool:
+    wanted = _normalize_guardrail(guardrail)
+    guardrails = content.get("guardrails")
+    if not isinstance(guardrails, Sequence) or isinstance(guardrails, (str, bytes)):
+        return False
+    for entry in guardrails:
+        if not isinstance(entry, Mapping):
+            continue
+        tokens = {
+            _normalize_guardrail(str(entry.get("name") or "")),
+            _normalize_guardrail(str(entry.get("guardrailType") or "")),
+            _normalize_guardrail(str(entry.get("approvalFor") or "")),
+        }
+        if wanted in tokens:
+            return True
+        if wanted == "risk_gate" and "mcpriskgate" in tokens:
+            return True
+        if wanted == "human_approval" and any(
+            token in tokens
+            for token in {"humanapproval", "approval", "approvalgate"}
+        ):
+            return True
+    return False
+
+
+def _identity_granted_scopes(content: Mapping[str, Any]) -> list[str]:
+    identity = content.get("identity")
+    if not isinstance(identity, Mapping):
+        return []
+    return _str_list(identity.get("grantedScopes"))
+
+
+def _risk_rank(tool: Mapping[str, Any]) -> int:
+    risk = str(tool.get("riskLevel") or tool.get("risk") or "low").lower()
+    return RISK_ORDER.get(risk, 0)
+
+
+def _str_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
+
+
+def _optional_bool(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _normalize(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _normalize_guardrail(value: str) -> str:
+    normalized = _normalize(value)
+    aliases = {
+        "humanapproval": "human_approval",
+        "humanapprovalguardrail": "human_approval",
+        "approval": "human_approval",
+        "approvalgate": "human_approval",
+        "mcpriskgate": "risk_gate",
+        "riskgate": "risk_gate",
+        "datasetbackup": "dataset_backup",
+        "backup": "dataset_backup",
+        "reviewactionblock": "review_action_block",
+    }
+    return aliases.get(normalized, normalized)

--- a/backend/ai_assistant/prometa_runner/runner.py
+++ b/backend/ai_assistant/prometa_runner/runner.py
@@ -1,0 +1,203 @@
+"""
+DeclarAI execution-plane runner for Prometa signed deployment bundles.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ai_assistant.prometa_config import set_span_attr, span_timer
+from ai_assistant.prometa_runner.client import fetch_bundle
+from ai_assistant.prometa_runner.context import (
+    reset_current_bundle_identity,
+    set_current_bundle_identity,
+)
+from ai_assistant.prometa_runner.policy import (
+    BundlePolicyError,
+    find_tool,
+    guardrails_required_for_tool,
+    preflight_bundle,
+    require_tool_call_allowed,
+)
+from ai_assistant.prometa_runner.signature import verify_bundle_signature
+from ai_assistant.prometa_runner.telemetry import stamp_bundle_identity
+
+
+class PrometaOnPremBundleRunner:
+    """Verify, preflight, and execute a Prometa bundle against local MCP tools."""
+
+    def __init__(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        require_signature: bool = True,
+        mcp_server=None,
+    ) -> None:
+        self.envelope = dict(envelope)
+        verify_bundle_signature(self.envelope, require_signature=require_signature)
+        content = self.envelope.get("content")
+        if not isinstance(content, Mapping):
+            raise BundlePolicyError("Prometa bundle content must be an object.")
+        self.content: Mapping[str, Any] = content
+        preflight_bundle(self.content)
+        self.agent_id = str(self.content["manifest"]["agentId"])
+        solution_id = self.content["manifest"].get("solutionId")
+        self.solution_id = solution_id if isinstance(solution_id, str) else None
+        self._mcp_server = mcp_server
+        self._owns_mcp_server = mcp_server is None
+        self._direct_actions_registered = False
+
+    @classmethod
+    def from_file(
+        cls,
+        path: str | Path,
+        *,
+        require_signature: bool = True,
+        mcp_server=None,
+    ) -> "PrometaOnPremBundleRunner":
+        with Path(path).open("r", encoding="utf-8") as handle:
+            envelope = json.load(handle)
+        if not isinstance(envelope, Mapping):
+            raise BundlePolicyError("Prometa bundle file must contain a JSON object.")
+        return cls(
+            envelope,
+            require_signature=require_signature,
+            mcp_server=mcp_server,
+        )
+
+    @classmethod
+    def from_prometa(
+        cls,
+        *,
+        base_url: str,
+        manifest_id: str,
+        token: str | None = None,
+        timeout: float = 30.0,
+        require_signature: bool = True,
+        mcp_server=None,
+    ) -> "PrometaOnPremBundleRunner":
+        return cls(
+            fetch_bundle(
+                base_url=base_url,
+                manifest_id=manifest_id,
+                token=token,
+                timeout=timeout,
+            ),
+            require_signature=require_signature,
+            mcp_server=mcp_server,
+        )
+
+    def summary(self) -> dict[str, Any]:
+        tools = [
+            {
+                "name": tool.get("name"),
+                "operation": tool.get("operation"),
+                "riskLevel": tool.get("riskLevel"),
+                "scopes": tool.get("scopes") or [],
+                "requiredGuardrails": guardrails_required_for_tool(tool),
+            }
+            for tool in self._bundle_tools()
+        ]
+        return {
+            "agentId": self.agent_id,
+            "solutionId": self.solution_id,
+            "manifest": self.content.get("manifest"),
+            "signed": bool(self.envelope.get("signed")),
+            "algorithm": self.envelope.get("algorithm"),
+            "canonicalization": self.envelope.get("canonicalization")
+            or "json-stable-sort-keys-utf8-no-ascii-escape-v1",
+            "tools": tools,
+        }
+
+    async def call_tool_async(
+        self,
+        operation: str,
+        arguments: Mapping[str, Any],
+        *,
+        approval_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Execute one bundled MCP operation through the local MCP server."""
+        if not isinstance(arguments, Mapping):
+            raise BundlePolicyError("MCP tool arguments must be an object.")
+        tool = find_tool(self.content, operation)
+        require_tool_call_allowed(
+            self.content,
+            tool,
+            approval_id=approval_id,
+        )
+        call_args = dict(arguments)
+        if approval_id and operation.startswith("declarai.action."):
+            call_args.setdefault("approval_id", approval_id)
+        return await self._call_local_mcp_tool(operation, call_args)
+
+    def call_tool(
+        self,
+        operation: str,
+        arguments: Mapping[str, Any],
+        *,
+        approval_id: str | None = None,
+    ) -> dict[str, Any]:
+        return asyncio.run(
+            self.call_tool_async(
+                operation,
+                arguments,
+                approval_id=approval_id,
+            )
+        )
+
+    async def _call_local_mcp_tool(
+        self,
+        operation: str,
+        call_args: dict[str, Any],
+    ) -> dict[str, Any]:
+        with span_timer("declarai.prometa.bundle"):
+            stamp_bundle_identity(self.agent_id, self.solution_id)
+            set_span_attr("declarai.prometa.bundle.operation", operation)
+            token = set_current_bundle_identity(self.agent_id, self.solution_id)
+            try:
+                mcp_server = self._get_mcp_server(operation)
+                content_items, structured = await mcp_server.call_tool(
+                    operation,
+                    call_args,
+                )
+                stamp_bundle_identity(self.agent_id, self.solution_id)
+                set_span_attr("declarai.prometa.bundle.ok", True)
+                return {
+                    "operation": operation,
+                    "structured": structured,
+                    "content": [
+                        getattr(item, "text", str(item))
+                        for item in (content_items or [])
+                    ],
+                }
+            except Exception as exc:
+                set_span_attr("declarai.prometa.bundle.ok", False)
+                set_span_attr("declarai.prometa.bundle.error", str(exc)[:200])
+                raise
+            finally:
+                reset_current_bundle_identity(token)
+
+    def _get_mcp_server(self, operation: str):
+        needs_direct_actions = operation.startswith("declarai.action.")
+        if self._mcp_server is None or (
+            self._owns_mcp_server
+            and needs_direct_actions
+            and not self._direct_actions_registered
+        ):
+            from ai_assistant.mcp_server.server import create_mcp_server
+
+            self._mcp_server = create_mcp_server(
+                include_direct_actions=needs_direct_actions,
+            )
+            self._direct_actions_registered = needs_direct_actions
+        return self._mcp_server
+
+    def _bundle_tools(self) -> list[Mapping[str, Any]]:
+        tools = self.content.get("tools")
+        if not isinstance(tools, list):
+            return []
+        return [tool for tool in tools if isinstance(tool, Mapping)]

--- a/backend/ai_assistant/prometa_runner/signature.py
+++ b/backend/ai_assistant/prometa_runner/signature.py
@@ -1,0 +1,92 @@
+"""
+Ed25519 signature verification for Prometa deployment bundles.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Mapping
+from typing import Any
+
+from ai_assistant.prometa_runner.canonicalization import (
+    canonicalize_bundle_content,
+    require_supported_canonicalization,
+)
+
+
+class BundleVerificationError(ValueError):
+    """Raised when a Prometa bundle cannot be trusted."""
+
+
+def verify_bundle_signature(
+    envelope: Mapping[str, Any],
+    *,
+    require_signature: bool = True,
+) -> bool:
+    """Verify a Prometa bundle envelope.
+
+    The envelope is the response from:
+    ``GET /api/agent-manifests/{id}/bundle``.
+
+    Prometa signs the canonical ``content`` bytes with Ed25519. ``publicKey`` is
+    a base64 SPKI public key, and ``signature`` is a detached base64 signature.
+    """
+    content = envelope.get("content")
+    if not isinstance(content, Mapping):
+        raise BundleVerificationError("Prometa bundle is missing object content.")
+
+    try:
+        require_supported_canonicalization(envelope)
+    except Exception as exc:
+        raise BundleVerificationError(str(exc)) from exc
+
+    signed = bool(envelope.get("signed"))
+    algorithm = envelope.get("algorithm")
+    public_key = envelope.get("publicKey")
+    signature = envelope.get("signature")
+    if not signed:
+        if require_signature:
+            raise BundleVerificationError("Prometa bundle is unsigned.")
+        return False
+    if algorithm != "ed25519":
+        raise BundleVerificationError(
+            f"Unsupported Prometa bundle signature algorithm: {algorithm!r}."
+        )
+    if not isinstance(public_key, str) or not public_key.strip():
+        raise BundleVerificationError("Prometa bundle is missing publicKey.")
+    if not isinstance(signature, str) or not signature.strip():
+        raise BundleVerificationError("Prometa bundle is missing signature.")
+
+    try:
+        key = _load_ed25519_public_key(public_key)
+        sig_bytes = base64.b64decode(signature, validate=True)
+        key.verify(sig_bytes, canonicalize_bundle_content(content))
+        return True
+    except BundleVerificationError:
+        raise
+    except Exception as exc:
+        raise BundleVerificationError(
+            "Prometa bundle signature verification failed."
+        ) from exc
+
+
+def _load_ed25519_public_key(public_key_b64: str):
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PublicKey,
+        )
+        from cryptography.hazmat.primitives.serialization import load_pem_public_key
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise BundleVerificationError(
+            "cryptography is required to verify Prometa Ed25519 bundles."
+        ) from exc
+
+    pem = (
+        "-----BEGIN PUBLIC KEY-----\n"
+        f"{public_key_b64.strip()}\n"
+        "-----END PUBLIC KEY-----"
+    ).encode("ascii")
+    key = load_pem_public_key(pem)
+    if not isinstance(key, Ed25519PublicKey):
+        raise BundleVerificationError("Prometa bundle publicKey is not Ed25519.")
+    return key

--- a/backend/ai_assistant/prometa_runner/telemetry.py
+++ b/backend/ai_assistant/prometa_runner/telemetry.py
@@ -1,0 +1,25 @@
+"""
+Telemetry correlation helpers for Prometa-bundled DeclarAI runs.
+"""
+
+from __future__ import annotations
+
+from ai_assistant.prometa_config import set_span_attr
+
+
+def stamp_bundle_identity(agent_id: str, solution_id: str | None = None) -> None:
+    """Stamp Prometa bundle identity on the active span.
+
+    ``gen_ai.agent.id`` is the canonical GenAI-semconv-style attribute the
+    Prometa SDK/platform already consumes. The ``prometa.*`` and
+    ``declarai.prometa.bundle.*`` attributes make the same join key obvious in
+    trace detail views and future platform queries.
+    """
+    set_span_attr("gen_ai.agent.id", agent_id)
+    set_span_attr("prometa.agent.id", agent_id)
+    set_span_attr("prometa.agent_id", agent_id)
+    set_span_attr("declarai.prometa.bundle.agent_id", agent_id)
+    if solution_id:
+        set_span_attr("prometa.solution.id", solution_id)
+        set_span_attr("prometa.solution_id", solution_id)
+        set_span_attr("declarai.prometa.bundle.solution_id", solution_id)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,6 +21,7 @@ openai>=1.0
 prometa-sdk==0.9.0
 redis>=5.0
 mcp>=1.27,<2
+cryptography>=42
 
 # Testing dependencies
 pytest>=8.0

--- a/backend/tests/test_prometa_bundle_runner.py
+++ b/backend/tests/test_prometa_bundle_runner.py
@@ -1,0 +1,285 @@
+"""
+Unit tests for the DeclarAI-owned Prometa on-prem bundle runner.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from ai_assistant.prometa_runner.canonicalization import canonicalize_bundle_content
+
+
+def _content(
+    *,
+    deployable=True,
+    tools=None,
+    guardrails=None,
+    granted_scopes=None,
+    agent_id="agt-prometa-1",
+):
+    granted_scopes = granted_scopes or [
+        "declarai.pipeline.read",
+        "declarai.action.prepare",
+        "declarai.notes.write",
+    ]
+    return {
+        "schemaVersion": 1,
+        "manifest": {
+            "id": "man-1",
+            "name": "Auto-ML Copilot",
+            "description": "Drives the pipeline.",
+            "version": 3,
+            "status": "published",
+            "agentId": agent_id,
+            "solutionId": "sol-1",
+            "deployable": deployable,
+        },
+        "systemPrompt": "# Auto-ML Copilot",
+        "models": [],
+        "primaryModel": None,
+        "topology": None,
+        "tools": tools
+        if tools is not None
+        else [
+            {
+                "name": "Prepare note",
+                "source": "mcp",
+                "mcpServer": "DeclarAI Auto-ML",
+                "operation": "declarai.prepare.update_notes",
+                "sideEffects": "read-only",
+                "riskLevel": "low",
+                "authBinding": "service-account",
+                "scopes": ["declarai.action.prepare"],
+            }
+        ],
+        "skills": [],
+        "knowledge": [],
+        "memory": [],
+        "subAgents": [],
+        "workflows": [],
+        "guardrails": guardrails if guardrails is not None else [],
+        "identity": {
+            "name": "DeclarAI runner",
+            "identityType": "service-account",
+            "grantedScopes": granted_scopes,
+            "secretBinding": "local",
+        },
+        "triggers": [],
+        "evaluation": [],
+        "mcpServers": ["DeclarAI Auto-ML"],
+        "requiredScopes": [],
+        "grantedScopes": granted_scopes,
+        "readiness": {"quality": 80, "security": 80, "maturity": 80, "productivity": 80},
+    }
+
+
+def _signed_envelope(content):
+    private_key = Ed25519PrivateKey.generate()
+    public_key_b64 = base64.b64encode(
+        private_key.public_key().public_bytes(
+            Encoding.DER,
+            PublicFormat.SubjectPublicKeyInfo,
+        )
+    ).decode("ascii")
+    signature = base64.b64encode(
+        private_key.sign(canonicalize_bundle_content(content))
+    ).decode("ascii")
+    return {
+        "content": content,
+        "algorithm": "ed25519",
+        "publicKey": public_key_b64,
+        "signature": signature,
+        "signed": True,
+        "canonicalization": "json-stable-sort-keys-utf8-no-ascii-escape-v1",
+    }
+
+
+@pytest.mark.unit
+class TestPrometaBundleSignature:
+    def test_canonicalization_matches_prometa_stable_json_contract(self):
+        content = {"z": 1, "a": {"z": 2, "a": ["x"]}, "text": "Merhaba " + "\u011f"}
+
+        canonical = canonicalize_bundle_content(content)
+
+        assert canonical.startswith(b'{"a":')
+        assert b"\\u011f" not in canonical
+        assert b"\xc4\x9f" in canonical
+
+    def test_verifies_ed25519_signature(self):
+        from ai_assistant.prometa_runner.signature import verify_bundle_signature
+
+        envelope = _signed_envelope(_content())
+
+        assert verify_bundle_signature(envelope) is True
+
+    def test_rejects_tampered_content(self):
+        from ai_assistant.prometa_runner.signature import (
+            BundleVerificationError,
+            verify_bundle_signature,
+        )
+
+        envelope = _signed_envelope(_content())
+        envelope["content"] = {**envelope["content"], "systemPrompt": "tampered"}
+
+        with pytest.raises(BundleVerificationError, match="verification failed"):
+            verify_bundle_signature(envelope)
+
+    def test_rejects_unsupported_canonicalization(self):
+        from ai_assistant.prometa_runner.signature import (
+            BundleVerificationError,
+            verify_bundle_signature,
+        )
+
+        envelope = _signed_envelope(_content())
+        envelope["canonicalization"] = "not-supported"
+
+        with pytest.raises(BundleVerificationError, match="canonicalization"):
+            verify_bundle_signature(envelope)
+
+
+@pytest.mark.unit
+class TestPrometaBundlePolicy:
+    def test_runner_rejects_non_deployable_bundle(self):
+        from ai_assistant.prometa_runner.policy import BundlePolicyError
+        from ai_assistant.prometa_runner.runner import PrometaOnPremBundleRunner
+
+        with pytest.raises(BundlePolicyError, match="not deployable"):
+            PrometaOnPremBundleRunner(_signed_envelope(_content(deployable=False)))
+
+    def test_runner_rejects_missing_agent_id(self):
+        from ai_assistant.prometa_runner.policy import BundlePolicyError
+        from ai_assistant.prometa_runner.runner import PrometaOnPremBundleRunner
+
+        with pytest.raises(BundlePolicyError, match="agentId"):
+            PrometaOnPremBundleRunner(_signed_envelope(_content(agent_id=None)))
+
+    def test_policy_rejects_ungranted_tool_scope(self):
+        from ai_assistant.prometa_runner.policy import BundlePolicyError
+        from ai_assistant.prometa_runner.runner import PrometaOnPremBundleRunner
+
+        tool = {
+            "name": "Run modeling",
+            "source": "mcp",
+            "operation": "declarai.action.start_modeling",
+            "sideEffects": "write",
+            "riskLevel": "high",
+            "authBinding": "service-account",
+            "scopes": ["declarai.pipeline.run"],
+        }
+
+        with pytest.raises(BundlePolicyError, match="requires scopes"):
+            PrometaOnPremBundleRunner(_signed_envelope(_content(tools=[tool])))
+
+    def test_policy_requires_approval_and_guardrails_for_direct_action(self):
+        from ai_assistant.prometa_runner.policy import (
+            BundlePolicyError,
+            find_tool,
+            require_tool_call_allowed,
+        )
+
+        tool = {
+            "name": "Update notes",
+            "source": "mcp",
+            "operation": "declarai.action.update_notes",
+            "sideEffects": "write",
+            "riskLevel": "low",
+            "authBinding": "service-account",
+            "scopes": ["declarai.notes.write"],
+        }
+        content = _content(
+            tools=[tool],
+            guardrails=[{"name": "Human approval", "guardrailType": "human-approval"}],
+        )
+
+        with pytest.raises(BundlePolicyError, match="approval_id"):
+            require_tool_call_allowed(content, find_tool(content, "declarai.action.update_notes"))
+
+        require_tool_call_allowed(
+            content,
+            find_tool(content, "declarai.action.update_notes"),
+            approval_id="approval-1",
+        )
+
+    def test_policy_prefers_explicit_required_guardrails_when_present(self):
+        from ai_assistant.prometa_runner.policy import guardrails_required_for_tool
+
+        tool = {
+            "operation": "declarai.action.execute_code",
+            "riskLevel": "high",
+            "requiredGuardrails": ["human_approval"],
+        }
+
+        assert guardrails_required_for_tool(tool) == ["human_approval"]
+
+
+@pytest.mark.unit
+class TestPrometaBundleRunner:
+    def test_runner_calls_local_mcp_with_bundle_identity_context(self, monkeypatch):
+        from ai_assistant.prometa_runner.context import get_current_bundle_identity
+        from ai_assistant.prometa_runner.runner import PrometaOnPremBundleRunner
+
+        captured = {}
+
+        class FakeMcp:
+            async def call_tool(self, operation, arguments):
+                captured["operation"] = operation
+                captured["arguments"] = arguments
+                captured["identity"] = get_current_bundle_identity()
+                return [], {"status": "prepared"}
+
+        runner = PrometaOnPremBundleRunner(
+            _signed_envelope(_content()),
+            mcp_server=FakeMcp(),
+        )
+
+        result = runner.call_tool(
+            "declarai.prepare.update_notes",
+            {"file_id": 42, "payload": {"action": "add"}},
+        )
+
+        assert result["structured"] == {"status": "prepared"}
+        assert captured["operation"] == "declarai.prepare.update_notes"
+        assert captured["identity"] == ("agt-prometa-1", "sol-1")
+
+    def test_runner_injects_approval_id_for_direct_action(self):
+        from ai_assistant.prometa_runner.runner import PrometaOnPremBundleRunner
+
+        captured = {}
+
+        class FakeMcp:
+            async def call_tool(self, operation, arguments):
+                captured["arguments"] = arguments
+                return [], {"status": "executed"}
+
+        tool = {
+            "name": "Update notes",
+            "source": "mcp",
+            "operation": "declarai.action.update_notes",
+            "sideEffects": "write",
+            "riskLevel": "low",
+            "authBinding": "service-account",
+            "scopes": ["declarai.notes.write"],
+        }
+        runner = PrometaOnPremBundleRunner(
+            _signed_envelope(
+                _content(
+                    tools=[tool],
+                    guardrails=[
+                        {"name": "Human approval", "guardrailType": "human-approval"}
+                    ],
+                )
+            ),
+            mcp_server=FakeMcp(),
+        )
+
+        runner.call_tool(
+            "declarai.action.update_notes",
+            {"file_id": 42, "payload": {"action": "add"}},
+            approval_id="approval-1",
+        )
+
+        assert captured["arguments"]["approval_id"] == "approval-1"

--- a/docs/ai-assistant-tools-and-mcp-integration.md
+++ b/docs/ai-assistant-tools-and-mcp-integration.md
@@ -811,9 +811,9 @@ export DECLARAI_MCP_SESSION_ID=prometa-sync-session
 export DECLARAI_MCP_TRANSPORT=streamable-http
 ```
 
-Runtime boundary as of this implementation: DeclarAI hosts the MCP tool
-surface and can execute direct action tools when explicitly enabled. Prometa can
-discover, govern, and bundle agents from that surface. The production
-`tools/call` executor loop should be chosen per deployment: either Prometa hosts
-the agent executor and calls DeclarAI MCP tools, or DeclarAI runs the signed
-Prometa bundle next to the MCP host.
+Settled runtime boundary: Prometa discovers, governs, signs, and observes;
+DeclarAI runs. Prometa does not call DeclarAI `tools/call`. DeclarAI executes
+approved MCP operations from the signed Prometa bundle next to the MCP host.
+The DeclarAI-owned on-prem runner foundation lives in
+`backend/ai_assistant/prometa_runner/` and is documented in
+[`docs/prometa-onprem-bundle-runner.md`](prometa-onprem-bundle-runner.md).

--- a/docs/prometa-onprem-bundle-runner.md
+++ b/docs/prometa-onprem-bundle-runner.md
@@ -1,0 +1,142 @@
+# DeclarAI Prometa On-Prem Bundle Runner
+
+Prometa builds, governs, signs, and observes. DeclarAI runs.
+
+This repository now includes the DeclarAI-side runner foundation for signed
+Prometa deployment bundles:
+
+```text
+backend/ai_assistant/prometa_runner/
+```
+
+It consumes the bundle from Prometa's:
+
+```text
+GET /api/agent-manifests/{id}/bundle
+```
+
+or from a local JSON file, then verifies and preflights the bundle before any
+local MCP tool execution.
+
+## Signature Verification
+
+The runner expects the bundle envelope:
+
+```json
+{
+  "content": {},
+  "algorithm": "ed25519",
+  "publicKey": "<base64 SPKI public key>",
+  "signature": "<base64 detached signature>",
+  "signed": true
+}
+```
+
+Canonicalization is:
+
+```text
+json-stable-sort-keys-utf8-no-ascii-escape-v1
+```
+
+Python verification mirrors Prometa's TypeScript implementation:
+
+- recursively sort object keys;
+- preserve array order;
+- serialize compact JSON with no spaces;
+- encode as UTF-8;
+- do not ASCII-escape non-ASCII text;
+- reject NaN/Infinity.
+
+The runner accepts Prometa's current envelope without a `canonicalization`
+field as this algorithm, and also accepts the explicit field when Prometa adds
+it. Unknown canonicalization values are rejected.
+
+## Preflight Policy
+
+Before a bundle can run, DeclarAI rejects:
+
+- unsigned or unverifiable bundles, unless `--allow-unsigned` is used for local
+  development;
+- `content.manifest.deployable !== true`;
+- missing `content.manifest.agentId`;
+- tool scopes not granted by the bundle identity or bundle-level
+  `grantedScopes`.
+
+For tool calls, the runner enforces:
+
+- `approvalRequired` / `approval_required` when Prometa carries it;
+- `requiredGuardrails` / `required_guardrails` when Prometa carries it;
+- fallback inference for current bundle shapes:
+  - `declarai.action.*` requires `human_approval`;
+  - high/critical risk tools require `risk_gate`;
+  - `declarai.action.execute_code` also requires `dataset_backup`.
+
+## Commands
+
+Verify and summarize a local bundle:
+
+```bash
+cd backend
+python manage.py run_prometa_bundle --bundle-file /path/to/bundle.json
+```
+
+Fetch, verify, and summarize from Prometa:
+
+```bash
+python manage.py run_prometa_bundle \
+  --prometa-url https://prometa.internal \
+  --manifest-id <manifest-id> \
+  --token "$PROMETA_TOKEN"
+```
+
+Execute one bundled MCP operation locally:
+
+```bash
+python manage.py run_prometa_bundle \
+  --bundle-file /path/to/bundle.json \
+  --tool declarai.prepare.update_notes \
+  --arguments '{"file_id":42,"payload":{"action":"add","content":"Review note"}}'
+```
+
+For direct actions:
+
+```bash
+export DECLARAI_MCP_ENABLE_DIRECT_ACTIONS=true
+export DECLARAI_MCP_SCOPES=declarai.notes.write
+
+python manage.py run_prometa_bundle \
+  --bundle-file /path/to/bundle.json \
+  --tool declarai.action.update_notes \
+  --arguments '{"file_id":42,"payload":{"action":"add","content":"Review note"}}' \
+  --approval-id approval-123
+```
+
+## Telemetry Correlation
+
+The runner stamps Prometa bundle identity into the active MCP spans:
+
+```text
+gen_ai.agent.id
+prometa.agent.id
+prometa.agent_id
+prometa.solution.id
+prometa.solution_id
+declarai.prometa.bundle.agent_id
+declarai.prometa.bundle.solution_id
+```
+
+The existing MCP spans keep emitting:
+
+```text
+declarai.mcp.*
+```
+
+This lets Prometa join DeclarAI-run tool calls back to the Agent Registry row
+that produced the signed bundle, then score those runs through AQL, AML,
+policies, and audit.
+
+## Boundary
+
+Prometa never calls DeclarAI `tools/call`. This runner is the DeclarAI-owned
+execution-plane primitive. A full autonomous loop can sit above it, but all MCP
+tool execution should pass through this verifier and policy gate.


### PR DESCRIPTION
## Summary
- add DeclarAI-owned runner foundation for signed Prometa deployment bundles
- verify Ed25519 signatures over Prometa's stable sorted-key JSON canonicalization
- preflight deployability, agent identity, scopes, approval, and guardrail requirements before local MCP calls
- stamp Prometa bundle agent/solution identity into DeclarAI MCP spans for AQL/AML/policy/audit correlation
- add a run_prometa_bundle management command and operator docs

## Validation
- pytest tests/test_prometa_bundle_runner.py tests/test_mcp_server.py -q
- python -m compileall ai_assistant/prometa_runner ai_assistant/mcp_server ai_assistant/management/commands/run_prometa_bundle.py
- python manage.py help run_prometa_bundle
- pre-commit hook: 914 backend tests passed
- pre-push hook: 914 backend tests passed, frontend build passed, 415 Karma specs passed