### PR TITLE
Align Prometa bundle canonicalization

### DIFF
--- a/backend/ai_assistant/prometa_runner/canonicalization.py
+++ b/backend/ai_assistant/prometa_runner/canonicalization.py
@@ -9,8 +9,10 @@ from collections.abc import Mapping
 from typing import Any
 
 
-CANONICALIZATION_ALGORITHM = "json-stable-sort-keys-utf8-no-ascii-escape-v1"
-LEGACY_CANONICALIZATION_ALGORITHMS = frozenset({None, ""})
+CANONICALIZATION_ALGORITHM = "json-sorted-keys-utf8"
+LEGACY_CANONICALIZATION_ALGORITHMS = frozenset(
+    {None, "", "json-stable-sort-keys-utf8-no-ascii-escape-v1"}
+)
 SUPPORTED_CANONICALIZATION_ALGORITHMS = frozenset(
     {CANONICALIZATION_ALGORITHM, *LEGACY_CANONICALIZATION_ALGORITHMS}
 )

--- a/backend/ai_assistant/prometa_runner/policy.py
+++ b/backend/ai_assistant/prometa_runner/policy.py
@@ -125,11 +125,16 @@ def approval_required_for_tool(tool: Mapping[str, Any]) -> bool:
 
 
 def guardrails_required_for_tool(tool: Mapping[str, Any]) -> list[str]:
-    explicit = _str_list(tool.get("requiredGuardrails"))
-    if not explicit:
-        explicit = _str_list(tool.get("required_guardrails"))
-    if explicit:
-        return [_normalize_guardrail(value) for value in explicit]
+    if "requiredGuardrails" in tool:
+        return [
+            _normalize_guardrail(value)
+            for value in _str_list(tool.get("requiredGuardrails"))
+        ]
+    if "required_guardrails" in tool:
+        return [
+            _normalize_guardrail(value)
+            for value in _str_list(tool.get("required_guardrails"))
+        ]
 
     required: list[str] = []
     if approval_required_for_tool(tool):

--- a/backend/ai_assistant/prometa_runner/runner.py
+++ b/backend/ai_assistant/prometa_runner/runner.py
@@ -109,7 +109,7 @@ class PrometaOnPremBundleRunner:
             "signed": bool(self.envelope.get("signed")),
             "algorithm": self.envelope.get("algorithm"),
             "canonicalization": self.envelope.get("canonicalization")
-            or "json-stable-sort-keys-utf8-no-ascii-escape-v1",
+            or "json-sorted-keys-utf8",
             "tools": tools,
         }
 

--- a/backend/tests/test_prometa_bundle_runner.py
+++ b/backend/tests/test_prometa_bundle_runner.py
@@ -77,7 +77,7 @@ def _content(
     }
 
 
-def _signed_envelope(content):
+def _signed_envelope(content, *, canonicalization="json-sorted-keys-utf8"):
     private_key = Ed25519PrivateKey.generate()
     public_key_b64 = base64.b64encode(
         private_key.public_key().public_bytes(
@@ -94,7 +94,7 @@ def _signed_envelope(content):
         "publicKey": public_key_b64,
         "signature": signature,
         "signed": True,
-        "canonicalization": "json-stable-sort-keys-utf8-no-ascii-escape-v1",
+        "canonicalization": canonicalization,
     }
 
 
@@ -113,6 +113,16 @@ class TestPrometaBundleSignature:
         from ai_assistant.prometa_runner.signature import verify_bundle_signature
 
         envelope = _signed_envelope(_content())
+
+        assert verify_bundle_signature(envelope) is True
+
+    def test_accepts_previous_canonicalization_label_for_existing_bundles(self):
+        from ai_assistant.prometa_runner.signature import verify_bundle_signature
+
+        envelope = _signed_envelope(
+            _content(),
+            canonicalization="json-stable-sort-keys-utf8-no-ascii-escape-v1",
+        )
 
         assert verify_bundle_signature(envelope) is True
 
@@ -214,6 +224,17 @@ class TestPrometaBundlePolicy:
         }
 
         assert guardrails_required_for_tool(tool) == ["human_approval"]
+
+    def test_policy_treats_explicit_empty_required_guardrails_as_authoritative(self):
+        from ai_assistant.prometa_runner.policy import guardrails_required_for_tool
+
+        tool = {
+            "operation": "declarai.action.execute_code",
+            "riskLevel": "high",
+            "requiredGuardrails": [],
+        }
+
+        assert guardrails_required_for_tool(tool) == []
 
 
 @pytest.mark.unit

--- a/docs/prometa-onprem-bundle-runner.md
+++ b/docs/prometa-onprem-bundle-runner.md
@@ -35,7 +35,7 @@ The runner expects the bundle envelope:
 Canonicalization is:
 
 ```text
-json-stable-sort-keys-utf8-no-ascii-escape-v1
+json-sorted-keys-utf8
 ```
 
 Python verification mirrors Prometa's TypeScript implementation:
@@ -47,9 +47,10 @@ Python verification mirrors Prometa's TypeScript implementation:
 - do not ASCII-escape non-ASCII text;
 - reject NaN/Infinity.
 
-The runner accepts Prometa's current envelope without a `canonicalization`
-field as this algorithm, and also accepts the explicit field when Prometa adds
-it. Unknown canonicalization values are rejected.
+The runner accepts Prometa's explicit `canonicalization` field with this value.
+For compatibility with earlier local test bundles, it also accepts a missing
+field or the provisional `json-stable-sort-keys-utf8-no-ascii-escape-v1` label
+as the same byte contract. Unknown canonicalization values are rejected.
 
 ## Preflight Policy
 
@@ -66,7 +67,8 @@ For tool calls, the runner enforces:
 
 - `approvalRequired` / `approval_required` when Prometa carries it;
 - `requiredGuardrails` / `required_guardrails` when Prometa carries it;
-- fallback inference for current bundle shapes:
+- fallback inference only for older bundle shapes that do not carry
+  `requiredGuardrails`:
   - `declarai.action.*` requires `human_approval`;
   - high/critical risk tools require `risk_gate`;
   - `declarai.action.execute_code` also requires `dataset_backup`.


### PR DESCRIPTION
## Summary
- accept Prometa's shipped `canonicalization: "json-sorted-keys-utf8"` bundle envelope value
- keep the previous provisional canonicalization label as a compatibility alias for existing local bundles
- treat explicit per-tool `requiredGuardrails: []` as authoritative now that Prometa emits the field directly
- update runner docs and coverage for the shipped bundle contract

## Validation
- `pytest tests/test_prometa_bundle_runner.py tests/test_mcp_server.py -q`
- `python -m compileall ai_assistant/prometa_runner ai_assistant/mcp_server ai_assistant/management/commands/run_prometa_bundle.py`
- `git diff --check`
- pre-commit hook: 914 backend tests
- pre-push hook: 914 backend tests, frontend build, 415 Karma specs