### PR TITLE
Align Prometa SDK telemetry contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Model deployment interface (under development):
 
 The backend's AI Assistant emits structured agent telemetry through
 [`prometa-sdk`](https://github.com/prometa-ai/orchestra-python-sdk)
-(≥ 0.9.0) to the **Prometa Agentic Lifecycle Intelligence Platform**
+(≥ 0.10.1) to the **Prometa Agentic Lifecycle Intelligence Platform**
 for tracing, evaluation, and lifecycle governance.
 
 **Integration point**:
@@ -271,9 +271,10 @@ carrying token usage, cost, prompt/completion text, and model name.
 |---|---|---|
 | `PROMETA_ENDPOINT` | (off) | OTLP ingest URL, e.g. `https://prometa.example.com/api/v2/otlp/v1/traces` |
 | `PROMETA_API_KEY` | (off) | Prometa tenant API key |
-| `PROMETA_SOLUTION_ID` | `declarai` | Logical solution identifier in the platform's registry |
-| `PROMETA_AGENT_NAME` | `ai-assistant` | Logical agent name (auto-registered) |
-| `PROMETA_STAGE` | `development` | `development` / `staging` / `production` |
+| `PROMETA_SOLUTION_ID` | `declarai-assistant` | Logical solution identifier in the platform's registry |
+| `PROMETA_AGENT_NAME` | `declarai-agent` | Logical agent name (auto-registered) |
+| `PROMETA_AGENT_ID` | `declarai-agent-staging` | Stable agent id/slug; use the Prometa bundle `agentId` for runner executions |
+| `PROMETA_STAGE` | `staging` | `development` / `staging` / `production` |
 
 Leaving `PROMETA_ENDPOINT` unset disables telemetry entirely
 (no-op decorators, no network calls). The SDK and platform are
@@ -290,6 +291,10 @@ without Prometa wired up.
   `set_request_model`, `set_tool_name`) that light up the platform's
   canonical correlation chain — opt-in extras that bridge AI Assistant
   telemetry to the org's CRM / data warehouse identifiers.
+- Public span metadata setters (`set_attribute`, `set_attributes`) used by
+  DeclarAI's wrapper to preserve producer-owned fields such as
+  `declarai.mcp.*` while emitting tenant-neutral tool keys
+  `gen_ai.tool.name` and `prometa.tool_name`.
 - AML v0.4 instrumentation primitives (`guardrail`, `pii_filter`,
   `memory_read`, `record_retry_attempt`, …) for the platform's
   41-feature agent-maturity scoring.
@@ -408,7 +413,7 @@ auto-ml/
 | python-magic | ≥ 0.4 | MIME-type detection for uploaded files |
 | django-cors-headers | ≥ 4.3 | Cross-origin requests (frontend ↔ backend) |
 | openai | ≥ 1.0 | LLM client for AI Assistant action layer |
-| [prometa-sdk](https://github.com/prometa-ai/orchestra-python-sdk) | ≥ 0.9.0 | Agent telemetry — emits OTLP traces and assistant-answer feedback to the Prometa platform |
+| [prometa-sdk](https://github.com/prometa-ai/orchestra-python-sdk) | ≥ 0.10.1 | Agent telemetry — emits OTLP traces, generic tool keys, agent correlation, and assistant-answer feedback to the Prometa platform |
 | redis | ≥ 5.0 | Cache + session store for AI Assistant |
 
 ### Frontend

--- a/backend/ai_assistant/mcp_server/observability.py
+++ b/backend/ai_assistant/mcp_server/observability.py
@@ -11,6 +11,7 @@ from ai_assistant.prometa_config import (
     set_customer_id,
     set_session_id,
     set_span_attr,
+    set_span_attrs,
     span_timer,
     workflow,
 )
@@ -36,7 +37,14 @@ def stamp_mcp_context(
     """Stamp DeclarAI MCP attributes on the active Prometa span."""
     set_span_attr("declarai.mcp.operation", operation)
     if tool_name:
-        set_span_attr("declarai.mcp.tool_name", tool_name)
+        set_span_attrs(
+            {
+                "declarai.mcp.tool_name": tool_name,
+                "mcp.tool.name": tool_name,
+                "gen_ai.tool.name": tool_name,
+                "prometa.tool_name": tool_name,
+            }
+        )
     if file_id is not None:
         set_span_attr("declarai.mcp.file_id", file_id)
         set_session_id(f"declarai-file-{file_id}")

--- a/backend/ai_assistant/prometa_config.py
+++ b/backend/ai_assistant/prometa_config.py
@@ -282,8 +282,8 @@ def prompt_render(*, template_version: str = None,
     try:
         from prometa import prompt_render as _real_prompt_render
     except (ImportError, AttributeError):
-        # v0.6.x and earlier — symbol absent.  In production we hard-pin
-        # prometa-sdk==0.7.1 (see requirements.txt) so this branch only
+        # v0.6.x and earlier — symbol absent.  In production we require
+        # prometa-sdk>=0.10.1 (see requirements.txt) so this branch only
         # fires in legacy/test environments.
         yield _NoOpPromptRenderHandle()
         return
@@ -356,8 +356,8 @@ def child_only_tool(name: str = None, **kwargs):
     return decorator
 
 
-def set_span_attr(key: str, value) -> None:
-    """Set an attribute on the current Prometa span (no-op if SDK unavailable)."""
+def _set_span_attr_direct(key: str, value) -> None:
+    """Fallback for SDKs that predate the public set_attribute helper."""
     try:
         from prometa._context import current_span
         span = current_span()
@@ -365,6 +365,37 @@ def set_span_attr(key: str, value) -> None:
             span.attributes[key] = value
     except Exception:
         pass
+
+
+def set_span_attr(key: str, value) -> None:
+    """Set an attribute on the current Prometa span.
+
+    SDK 0.10.1 exposes the public ``set_attribute`` helper used for
+    producer-owned metadata such as ``declarai.mcp.*``.  Keep the direct span
+    fallback so older local/test SDKs still degrade safely.
+    """
+    try:
+        from prometa import set_attribute as _sdk_set_attribute
+        _sdk_set_attribute(key, value)
+    except (ImportError, AttributeError):
+        _set_span_attr_direct(key, value)
+    except Exception:
+        _set_span_attr_direct(key, value)
+
+
+def set_span_attrs(attributes: dict) -> None:
+    """Set several attributes on the current Prometa span."""
+    if not attributes:
+        return
+    try:
+        from prometa import set_attributes as _sdk_set_attributes
+        _sdk_set_attributes(dict(attributes))
+    except (ImportError, AttributeError):
+        for key, value in attributes.items():
+            set_span_attr(key, value)
+    except Exception:
+        for key, value in attributes.items():
+            _set_span_attr_direct(key, value)
 
 
 def stamp_elapsed(prefix: str, t0_ns: int) -> int:

--- a/backend/ai_assistant/prometa_runner/context.py
+++ b/backend/ai_assistant/prometa_runner/context.py
@@ -7,19 +7,27 @@ from __future__ import annotations
 from contextvars import ContextVar
 
 
-_bundle_identity: ContextVar[tuple[str, str | None] | None] = ContextVar(
+BundleIdentity = tuple[str, str | None, str | None, str | None]
+
+
+_bundle_identity: ContextVar[BundleIdentity | None] = ContextVar(
     "declarai_prometa_bundle_identity",
     default=None,
 )
 
 
-def set_current_bundle_identity(agent_id: str, solution_id: str | None = None):
-    return _bundle_identity.set((agent_id, solution_id))
+def set_current_bundle_identity(
+    agent_id: str,
+    solution_id: str | None = None,
+    solution_name: str | None = None,
+    agent_name: str | None = None,
+):
+    return _bundle_identity.set((agent_id, solution_id, solution_name, agent_name))
 
 
 def reset_current_bundle_identity(token) -> None:
     _bundle_identity.reset(token)
 
 
-def get_current_bundle_identity() -> tuple[str, str | None] | None:
+def get_current_bundle_identity() -> BundleIdentity | None:
     return _bundle_identity.get()

--- a/backend/ai_assistant/prometa_runner/runner.py
+++ b/backend/ai_assistant/prometa_runner/runner.py
@@ -44,9 +44,14 @@ class PrometaOnPremBundleRunner:
             raise BundlePolicyError("Prometa bundle content must be an object.")
         self.content: Mapping[str, Any] = content
         preflight_bundle(self.content)
-        self.agent_id = str(self.content["manifest"]["agentId"])
-        solution_id = self.content["manifest"].get("solutionId")
+        manifest = self.content["manifest"]
+        self.agent_id = str(manifest["agentId"])
+        agent_name = manifest.get("name")
+        solution_id = manifest.get("solutionId")
+        solution_name = manifest.get("solutionName")
+        self.agent_name = agent_name if isinstance(agent_name, str) else None
         self.solution_id = solution_id if isinstance(solution_id, str) else None
+        self.solution_name = solution_name if isinstance(solution_name, str) else None
         self._mcp_server = mcp_server
         self._owns_mcp_server = mcp_server is None
         self._direct_actions_registered = False
@@ -105,6 +110,8 @@ class PrometaOnPremBundleRunner:
         return {
             "agentId": self.agent_id,
             "solutionId": self.solution_id,
+            "solutionName": self.solution_name,
+            "agentName": self.agent_name,
             "manifest": self.content.get("manifest"),
             "signed": bool(self.envelope.get("signed")),
             "algorithm": self.envelope.get("algorithm"),
@@ -155,16 +162,31 @@ class PrometaOnPremBundleRunner:
         call_args: dict[str, Any],
     ) -> dict[str, Any]:
         with span_timer("declarai.prometa.bundle"):
-            stamp_bundle_identity(self.agent_id, self.solution_id)
+            stamp_bundle_identity(
+                self.agent_id,
+                self.solution_id,
+                self.solution_name,
+                self.agent_name,
+            )
             set_span_attr("declarai.prometa.bundle.operation", operation)
-            token = set_current_bundle_identity(self.agent_id, self.solution_id)
+            token = set_current_bundle_identity(
+                self.agent_id,
+                self.solution_id,
+                self.solution_name,
+                self.agent_name,
+            )
             try:
                 mcp_server = self._get_mcp_server(operation)
                 content_items, structured = await mcp_server.call_tool(
                     operation,
                     call_args,
                 )
-                stamp_bundle_identity(self.agent_id, self.solution_id)
+                stamp_bundle_identity(
+                    self.agent_id,
+                    self.solution_id,
+                    self.solution_name,
+                    self.agent_name,
+                )
                 set_span_attr("declarai.prometa.bundle.ok", True)
                 return {
                     "operation": operation,

--- a/backend/ai_assistant/prometa_runner/telemetry.py
+++ b/backend/ai_assistant/prometa_runner/telemetry.py
@@ -4,22 +4,38 @@ Telemetry correlation helpers for Prometa-bundled DeclarAI runs.
 
 from __future__ import annotations
 
-from ai_assistant.prometa_config import set_span_attr
+from ai_assistant.prometa_config import set_span_attrs
 
 
-def stamp_bundle_identity(agent_id: str, solution_id: str | None = None) -> None:
+def stamp_bundle_identity(
+    agent_id: str,
+    solution_id: str | None = None,
+    solution_name: str | None = None,
+    agent_name: str | None = None,
+) -> None:
     """Stamp Prometa bundle identity on the active span.
 
-    ``gen_ai.agent.id`` is the canonical GenAI-semconv-style attribute the
-    Prometa SDK/platform already consumes. The ``prometa.*`` and
-    ``declarai.prometa.bundle.*`` attributes make the same join key obvious in
-    trace detail views and future platform queries.
+    Prometa ingests ``prometa.agent_id`` as the primary id-based Agent
+    Registry join.  ``prometa.solution_id`` intentionally receives the
+    bundle's solution name when present because the platform's fallback
+    resolver uses solution-name + agent-name.
     """
-    set_span_attr("gen_ai.agent.id", agent_id)
-    set_span_attr("prometa.agent.id", agent_id)
-    set_span_attr("prometa.agent_id", agent_id)
-    set_span_attr("declarai.prometa.bundle.agent_id", agent_id)
+    attrs = {
+        "gen_ai.agent.id": agent_id,
+        "prometa.agent.id": agent_id,
+        "prometa.agent_id": agent_id,
+        "declarai.prometa.bundle.agent_id": agent_id,
+    }
+    if agent_name:
+        attrs["gen_ai.agent.name"] = agent_name
+        attrs["prometa.agent_name"] = agent_name
+        attrs["declarai.prometa.bundle.agent_name"] = agent_name
+    solution_key = solution_name or solution_id
+    if solution_key:
+        attrs["prometa.solution.id"] = solution_key
+        attrs["prometa.solution_id"] = solution_key
     if solution_id:
-        set_span_attr("prometa.solution.id", solution_id)
-        set_span_attr("prometa.solution_id", solution_id)
-        set_span_attr("declarai.prometa.bundle.solution_id", solution_id)
+        attrs["declarai.prometa.bundle.solution_id"] = solution_id
+    if solution_name:
+        attrs["declarai.prometa.bundle.solution_name"] = solution_name
+    set_span_attrs(attrs)

--- a/backend/ai_assistant/tool_executor.py
+++ b/backend/ai_assistant/tool_executor.py
@@ -984,7 +984,9 @@ def execute_tool_call(file_id: int, tool_name: str, arguments: dict) -> str:
     Emits a ``tool-call`` span (renamed from ``rag-tool-dispatch`` — we never
     did retrieval-augmented generation; this is straight function-calling
     against a Redis cache).  Span attributes:
-      - declarai.tool.name           which tool the LLM invoked
+      - declarai.tool.name           producer-owned tool name metadata
+      - gen_ai.tool.name             generic tool classifier key
+      - prometa.tool_name            Prometa tool registration/classifier key
       - declarai.tool.file_id        pipeline file id
       - declarai.tool.args_keys      comma-separated argument names
       - declarai.tool.ok             whether the handler ran to completion
@@ -1007,6 +1009,8 @@ def execute_tool_call(file_id: int, tool_name: str, arguments: dict) -> str:
     """
     with span_timer('declarai.tool'):
         set_span_attr('declarai.tool.name', tool_name)
+        set_span_attr('gen_ai.tool.name', tool_name)
+        set_span_attr('prometa.tool_name', tool_name)
         set_span_attr('declarai.tool.file_id', file_id)
         set_span_attr('declarai.tool.args_keys',
                       ','.join(sorted(arguments.keys())) if arguments else '')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,7 @@ statsmodels>=0.14
 
 # AI Assistant
 openai>=1.0
-prometa-sdk==0.9.0
+prometa-sdk>=0.10.1
 redis>=5.0
 mcp>=1.27,<2
 cryptography>=42

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -164,6 +164,31 @@ class TestMcpActionHelpers:
         assert stamped[0]["required_scopes"] == ["declarai.action.prepare"]
         assert stamped[-1]["ok"] is True
 
+    def test_mcp_context_stamps_generic_tool_classifier_keys(self, monkeypatch):
+        from ai_assistant.mcp_server import observability
+
+        captured = {}
+        monkeypatch.setattr(
+            observability,
+            "set_span_attrs",
+            lambda attrs: captured.update(attrs),
+        )
+        monkeypatch.setattr(
+            observability,
+            "set_span_attr",
+            lambda key, value: captured.__setitem__(key, value),
+        )
+
+        observability.stamp_mcp_context(
+            operation="read_tool",
+            tool_name="declarai.get_data_dictionary",
+        )
+
+        assert captured["declarai.mcp.tool_name"] == "declarai.get_data_dictionary"
+        assert captured["mcp.tool.name"] == "declarai.get_data_dictionary"
+        assert captured["gen_ai.tool.name"] == "declarai.get_data_dictionary"
+        assert captured["prometa.tool_name"] == "declarai.get_data_dictionary"
+
 
 @pytest.mark.unit
 class TestMcpServer:

--- a/backend/tests/test_prometa_bundle_runner.py
+++ b/backend/tests/test_prometa_bundle_runner.py
@@ -36,6 +36,7 @@ def _content(
             "status": "published",
             "agentId": agent_id,
             "solutionId": "sol-1",
+            "solutionName": "DeclarAI Solution",
             "deployable": deployable,
         },
         "systemPrompt": "# Auto-ML Copilot",
@@ -264,7 +265,39 @@ class TestPrometaBundleRunner:
 
         assert result["structured"] == {"status": "prepared"}
         assert captured["operation"] == "declarai.prepare.update_notes"
-        assert captured["identity"] == ("agt-prometa-1", "sol-1")
+        assert captured["identity"] == (
+            "agt-prometa-1",
+            "sol-1",
+            "DeclarAI Solution",
+            "Auto-ML Copilot",
+        )
+
+    def test_bundle_identity_stamps_prometa_agent_id_and_solution_name(self, monkeypatch):
+        from ai_assistant.prometa_runner import telemetry
+
+        captured = {}
+        monkeypatch.setattr(
+            telemetry,
+            "set_span_attrs",
+            lambda attrs: captured.update(attrs),
+        )
+
+        telemetry.stamp_bundle_identity(
+            "agt-prometa-1",
+            "sol-1",
+            "DeclarAI Solution",
+            "Auto-ML Copilot",
+        )
+
+        assert captured["prometa.agent_id"] == "agt-prometa-1"
+        assert captured["gen_ai.agent.id"] == "agt-prometa-1"
+        assert captured["prometa.solution_id"] == "DeclarAI Solution"
+        assert captured["gen_ai.agent.name"] == "Auto-ML Copilot"
+        assert captured["declarai.prometa.bundle.solution_id"] == "sol-1"
+        assert (
+            captured["declarai.prometa.bundle.solution_name"]
+            == "DeclarAI Solution"
+        )
 
     def test_runner_injects_approval_id_for_direct_action(self):
         from ai_assistant.prometa_runner.runner import PrometaOnPremBundleRunner

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -5866,6 +5866,8 @@ class TestToolCallSpanRename:
             out = execute_tool_call(60100, 'get_encoding_plan', {'top_n': 5})
             assert 'Encoding Plan' in out
             assert cap.captured.get('declarai.tool.name') == 'get_encoding_plan'
+            assert cap.captured.get('gen_ai.tool.name') == 'get_encoding_plan'
+            assert cap.captured.get('prometa.tool_name') == 'get_encoding_plan'
             assert cap.captured.get('declarai.tool.file_id') == 60100
             assert cap.captured.get('declarai.tool.args_keys') == 'top_n'
             assert cap.captured.get('declarai.tool.ok') is True
@@ -5885,6 +5887,8 @@ class TestToolCallSpanRename:
         out = execute_tool_call(60101, 'no_such_tool', {})
         assert 'Unknown tool' in out
         assert cap.captured.get('declarai.tool.name') == 'no_such_tool'
+        assert cap.captured.get('gen_ai.tool.name') == 'no_such_tool'
+        assert cap.captured.get('prometa.tool_name') == 'no_such_tool'
         assert cap.captured.get('declarai.tool.unknown') is True
         assert cap.captured.get('declarai.tool.ok') is False
         assert cap.captured.get('declarai.tool.result_chars', 0) > 0
@@ -6525,6 +6529,58 @@ class TestPrometaCorrelationHelpers:
     """``set_customer_id`` and ``set_request_model`` must forward to
     the SDK helpers when available, fall back to ``set_span_attr`` on
     ImportError, and never propagate exceptions."""
+
+    def test_set_span_attr_forwards_to_sdk_set_attribute_when_available(self, monkeypatch):
+        from ai_assistant import prometa_config as pc
+
+        sdk_calls: list[tuple[str, object]] = []
+        fallback_calls: list[tuple[str, object]] = []
+        import prometa
+        monkeypatch.setattr(
+            prometa,
+            'set_attribute',
+            lambda key, value: sdk_calls.append((key, value)),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            pc,
+            '_set_span_attr_direct',
+            lambda key, value: fallback_calls.append((key, value)),
+        )
+
+        pc.set_span_attr('declarai.mcp.operation', 'read_tool')
+
+        assert sdk_calls == [('declarai.mcp.operation', 'read_tool')]
+        assert fallback_calls == []
+
+    def test_set_span_attrs_forwards_to_sdk_set_attributes_when_available(self, monkeypatch):
+        from ai_assistant import prometa_config as pc
+
+        sdk_calls: list[dict] = []
+        fallback_calls: list[tuple[str, object]] = []
+        import prometa
+        monkeypatch.setattr(
+            prometa,
+            'set_attributes',
+            lambda attrs: sdk_calls.append(attrs),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            pc,
+            'set_span_attr',
+            lambda key, value: fallback_calls.append((key, value)),
+        )
+
+        pc.set_span_attrs({
+            'gen_ai.tool.name': 'declarai.get_data_dictionary',
+            'prometa.tool_name': 'declarai.get_data_dictionary',
+        })
+
+        assert sdk_calls == [{
+            'gen_ai.tool.name': 'declarai.get_data_dictionary',
+            'prometa.tool_name': 'declarai.get_data_dictionary',
+        }]
+        assert fallback_calls == []
 
     def test_set_customer_id_forwards_to_sdk_helper_when_available(self, monkeypatch):
         """Happy path: SDK on 0.6.0+ exposes ``set_customer_id``; our
@@ -10042,33 +10098,29 @@ class TestPromptRenderWorkflowWiring:
 
 
 # ---------------------------------------------------------------------------
-# v2.42.0: prometa-sdk version lock — CI guard
+# v2.42.0/v2.46.0: prometa-sdk version floor — CI guard
 # ---------------------------------------------------------------------------
 # Catches future Docker-cache / pip-cache drift like the v0.6.0-in-
-# container situation that hid the A4 truncation bug from us.  The pin
-# in requirements.txt (`prometa-sdk==X.Y.Z`) must match the version
-# actually installed in the environment running the tests.
+# container situation that hid the A4 truncation bug from us.  The lower bound
+# in requirements.txt must be satisfied by the environment running the tests.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 class TestProMetaSdkVersionLock:
-    """Defense against installed-vs-pinned drift.
+    """Defense against installed-vs-required SDK drift.
 
     The bug that motivated v2.42.0 hid for ~24 hours because
     requirements.txt was pinned to >=0.7.1 but the running container
-    was on v0.6.0 (Docker layer cache wasn't invalidated when the pin
-    was bumped).  This test reads the pin from requirements.txt and
-    asserts the installed prometa.__version__ matches EXACTLY.  Fails
-    fast in CI / pre-commit, including on any environment where pip
-    re-resolves into a newer minor release we haven't verified."""
+    was on v0.6.0 (Docker layer cache wasn't invalidated when the floor
+    was bumped).  This test reads the requirement from requirements.txt and
+    asserts the installed prometa.__version__ satisfies it."""
 
-    def _read_pin(self) -> str:
-        """Return the version literal pinned in requirements.txt.
+    def _read_min_version(self) -> str:
+        """Return the minimum version required in requirements.txt.
 
-        Supports the canonical hard-pin form 'prometa-sdk==X.Y.Z'.
-        Any other form (range, no pin) is a deliberate refusal — we
-        want this lock to be obvious to readers.
+        Supports `prometa-sdk>=X.Y.Z` and treats `==X.Y.Z` as an equivalent
+        floor for older lock-file shapes.
         """
         from pathlib import Path
         import re
@@ -10077,28 +10129,35 @@ class TestProMetaSdkVersionLock:
         for line in req.splitlines():
             line = line.strip()
             if line.startswith('prometa-sdk'):
-                m = re.match(r'^prometa-sdk==([0-9]+\.[0-9]+\.[0-9]+)\s*$', line)
+                m = re.match(r'^prometa-sdk(?:==|>=)([0-9]+\.[0-9]+\.[0-9]+)\s*$', line)
                 assert m, (
-                    f"prometa-sdk must be HARD-PINNED in requirements.txt "
-                    f"(form: prometa-sdk==X.Y.Z); found: {line!r}"
+                    f"prometa-sdk must declare an explicit minimum version "
+                    f"(form: prometa-sdk>=X.Y.Z); found: {line!r}"
                 )
                 return m.group(1)
         raise AssertionError(
             "prometa-sdk entry not found in requirements.txt — "
-            "the version lock test cannot run without a pin."
+            "the version-floor test cannot run without a requirement."
         )
 
-    def test_installed_prometa_sdk_matches_requirements_pin(self):
+    @staticmethod
+    def _version_tuple(value: str) -> tuple[int, int, int]:
+        import re
+        match = re.match(r'^([0-9]+)\.([0-9]+)\.([0-9]+)', value)
+        assert match, f"Unsupported prometa-sdk version string: {value!r}"
+        return tuple(int(part) for part in match.groups())
+
+    def test_installed_prometa_sdk_satisfies_requirements_floor(self):
         import prometa
         installed = prometa.__version__
-        pinned = self._read_pin()
-        assert installed == pinned, (
+        required = self._read_min_version()
+        assert self._version_tuple(installed) >= self._version_tuple(required), (
             f"prometa-sdk version drift detected: installed={installed!r} "
-            f"but requirements.txt pins =={pinned!r}.  Rebuild the "
+            f"but requirements.txt requires >={required!r}.  Rebuild the "
             f"backend Docker image with --no-cache or re-run "
             f"`pip install -r requirements.txt` to align.  This drift "
             f"is precisely what hid the v2.41.x AML A4 truncation bug "
-            f"from us for ~24h — keep it locked."
+            f"from us for ~24h."
         )
 
     def test_prompt_render_helper_is_importable_on_pinned_version(self):

--- a/docs/ai-assistant-tools-and-mcp-integration.md
+++ b/docs/ai-assistant-tools-and-mcp-integration.md
@@ -801,7 +801,10 @@ The emitted attributes include `declarai.mcp.operation`,
 `declarai.mcp.required_scopes`, `declarai.mcp.risk`,
 `declarai.mcp.side_effects`, `declarai.mcp.destructive`,
 `declarai.mcp.approval_id`, `declarai.mcp.ok`,
-`declarai.mcp.result_chars`, and elapsed timing attributes.
+`declarai.mcp.result_chars`, and elapsed timing attributes. MCP tool spans
+also stamp `gen_ai.tool.name` and `prometa.tool_name` for Prometa's
+tenant-neutral tool classification, while `mcp.tool.name` remains source
+metadata and `declarai.mcp.*` remains DeclarAI-owned producer metadata.
 
 Optional deployment labels can be supplied with:
 

--- a/docs/prometa-onprem-bundle-runner.md
+++ b/docs/prometa-onprem-bundle-runner.md
@@ -115,22 +115,35 @@ python manage.py run_prometa_bundle \
 
 ## Telemetry Correlation
 
-The runner stamps Prometa bundle identity into the active MCP spans:
+The runner stamps Prometa bundle identity into the active MCP spans. When the
+bundle carries both `solutionId` and `solutionName`, `prometa.solution_id` uses
+`solutionName` because Prometa's fallback resolver keys by solution name.
 
 ```text
 gen_ai.agent.id
+gen_ai.agent.name
 prometa.agent.id
 prometa.agent_id
 prometa.solution.id
 prometa.solution_id
+prometa.agent_name
 declarai.prometa.bundle.agent_id
 declarai.prometa.bundle.solution_id
+declarai.prometa.bundle.solution_name
 ```
 
 The existing MCP spans keep emitting:
 
 ```text
 declarai.mcp.*
+```
+
+They also emit tenant-neutral tool classifier/source keys:
+
+```text
+gen_ai.tool.name
+prometa.tool_name
+mcp.tool.name
 ```
 
 This lets Prometa join DeclarAI-run tool calls back to the Agent Registry row


### PR DESCRIPTION
## Summary
- upgrade DeclarAI's Prometa dependency to `prometa-sdk>=0.10.1`
- route custom span metadata through the SDK's public `set_attribute` / `set_attributes` helpers when available
- stamp generic tool classifier keys (`gen_ai.tool.name`, `prometa.tool_name`) on MCP and assistant tool spans while preserving `declarai.*` producer metadata
- stamp runner correlation from signed bundles with `prometa.agent_id`, `prometa.solution_id` from `solutionName` when available, and `gen_ai.agent.name`
- update runner/MCP docs and tests for the tenant-neutral platform classifier path

## Validation
- `pytest tests/test_prometa_bundle_runner.py tests/test_mcp_server.py -q`
- `pytest tests/test_unit.py -q -k 'PrometaCorrelationHelpers or ProMetaSdkVersionLock or ToolCallSpanRename'`
- `python -m compileall ai_assistant/prometa_config.py ai_assistant/mcp_server ai_assistant/prometa_runner ai_assistant/tool_executor.py`
- `git diff --check`
- pre-commit hook: 914 backend tests
- pre-push hook: 914 backend tests, frontend build, 415 Karma specs

Note: a broad local shell pytest run is not meaningful on this Mac environment because `libmagic` is not installed; the repo's Docker hook remains the full-suite gate.