### PR TITLE
Handle FastMCP read results in Prometa runner

### DIFF
--- a/backend/ai_assistant/prometa_runner/runner.py
+++ b/backend/ai_assistant/prometa_runner/runner.py
@@ -177,9 +177,11 @@ class PrometaOnPremBundleRunner:
             )
             try:
                 mcp_server = self._get_mcp_server(operation)
-                content_items, structured = await mcp_server.call_tool(
-                    operation,
-                    call_args,
+                content_items, structured = self._normalize_mcp_result(
+                    await mcp_server.call_tool(
+                        operation,
+                        call_args,
+                    )
                 )
                 stamp_bundle_identity(
                     self.agent_id,
@@ -191,10 +193,7 @@ class PrometaOnPremBundleRunner:
                 return {
                     "operation": operation,
                     "structured": structured,
-                    "content": [
-                        getattr(item, "text", str(item))
-                        for item in (content_items or [])
-                    ],
+                    "content": self._content_texts(content_items),
                 }
             except Exception as exc:
                 set_span_attr("declarai.prometa.bundle.ok", False)
@@ -202,6 +201,28 @@ class PrometaOnPremBundleRunner:
                 raise
             finally:
                 reset_current_bundle_identity(token)
+
+    @staticmethod
+    def _normalize_mcp_result(result: Any) -> tuple[list[Any], Any]:
+        if isinstance(result, tuple) and len(result) == 2:
+            content_items, structured = result
+            return list(content_items or []), structured
+        if isinstance(result, list):
+            return result, None
+        content_items = getattr(result, "content", None)
+        if content_items is not None:
+            structured = (
+                getattr(result, "structuredContent", None)
+                or getattr(result, "structured_content", None)
+            )
+            return list(content_items or []), structured
+        if isinstance(result, Mapping):
+            return [], result
+        return [result], None
+
+    @staticmethod
+    def _content_texts(content_items: list[Any]) -> list[str]:
+        return [getattr(item, "text", str(item)) for item in (content_items or [])]
 
     def _get_mcp_server(self, operation: str):
         needs_direct_actions = operation.startswith("declarai.action.")

--- a/backend/tests/test_prometa_bundle_runner.py
+++ b/backend/tests/test_prometa_bundle_runner.py
@@ -337,3 +337,33 @@ class TestPrometaBundleRunner:
         )
 
         assert captured["arguments"]["approval_id"] == "approval-1"
+
+    def test_runner_handles_fastmcp_read_tool_list_result(self, monkeypatch):
+        pytest.importorskip("mcp")
+        monkeypatch.delenv("DECLARAI_MCP_SCOPES", raising=False)
+        from ai_assistant.prometa_runner.runner import PrometaOnPremBundleRunner
+
+        tool = {
+            "name": "Get pipeline config",
+            "source": "mcp",
+            "operation": "declarai.get_pipeline_config",
+            "sideEffects": "read-only",
+            "riskLevel": "low",
+            "authBinding": "service-account",
+            "scopes": ["declarai.pipeline.read"],
+            "approvalRequired": False,
+            "requiredGuardrails": [],
+        }
+        runner = PrometaOnPremBundleRunner(
+            _signed_envelope(_content(tools=[tool])),
+        )
+
+        result = runner.call_tool(
+            "declarai.get_pipeline_config",
+            {"file_id": 99999},
+        )
+
+        assert result["operation"] == "declarai.get_pipeline_config"
+        assert result["structured"] is None
+        assert result["content"]
+        assert "pipeline configuration" in result["content"][0].lower()


### PR DESCRIPTION
## Summary
- normalize FastMCP `call_tool` return shapes in the Prometa bundle runner
- support both structured `(content, structured)` tuple results and read-tool `list[TextContent]` results
- add a regression test that invokes a real FastMCP read tool through the signed bundle runner

## Validation
- `pytest tests/test_prometa_bundle_runner.py tests/test_mcp_server.py -q`
- `python -m compileall ai_assistant/prometa_runner`
- `git diff --check`
- pre-commit hook: 914 backend tests
- pre-push hook: 914 backend tests, frontend build, 415 Karma specs

This was found during the SDK/platform/DeclarAI smoke trace: `declarai.get_pipeline_config` returned a list from FastMCP, while prepare-action tools return the existing tuple shape.