### PR TITLE
[codex] Configure AutoML engine bearer secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env for local Docker runs.
+# Keep the real bearer key out of git; obtain it through the approved
+# private secret channel for the declarai-auto-ml engine tenant.
+
+LLM_ENGINE_BASE_URL=http://host.docker.internal:8080/v1
+LLM_ENGINE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -311,6 +311,42 @@ for the chain semantics.
 ### Prerequisites
 - Docker & Docker Compose
 
+### Configure the LLM engine bearer key
+
+DeclarAI AutoML talks to `llm_inference_engine` through the OpenAI-compatible
+`/v1` API. The engine bearer key is tenant-specific and must come from a
+private secret channel, not GitHub issues, pull requests, or committed files.
+
+Copy the example file and fill in the private key:
+
+```bash
+cp .env.example .env
+```
+
+For local Docker-to-host development, keep the base URL as:
+
+```bash
+LLM_ENGINE_BASE_URL=http://host.docker.internal:8080/v1
+```
+
+Set the provisioned DeclarAI AutoML engine key in the same `.env` file or in
+the deployment secret manager:
+
+```bash
+LLM_ENGINE_API_KEY=<provided through secure secret handoff>
+```
+
+After the secret is installed, verify from the backend runtime/container:
+
+```bash
+curl -s "$LLM_ENGINE_BASE_URL/models" \
+  -H "Authorization: Bearer $LLM_ENGINE_API_KEY" | jq .data[0]
+```
+
+Expected result: HTTP 200 with model data. A `401 missing bearer token` or
+`401 invalid api key` means the secret was not passed into AutoML or does not
+match the engine-side key file.
+
 ### Run
 ```bash
 docker compose up --build -d

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -3626,6 +3626,46 @@ class TestModelRegistry:
         for m in models:
             assert 'tool_calling_mode' in m, f"Model '{m['key']}' missing tool_calling_mode in list output"
 
+    def test_fetch_engine_models_uses_configured_bearer_key(self, monkeypatch):
+        """Engine discovery must send the deployment-provided bearer key."""
+        from ai_assistant import model_registry as mr
+        import urllib.request
+
+        captured = {}
+
+        class _FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":[{"id":"llama3.2:3b",'
+                    b'"size_bytes":2147483648}]}'
+                )
+
+        def _fake_urlopen(req, timeout):
+            captured['url'] = req.full_url
+            captured['authorization'] = req.get_header('Authorization')
+            captured['timeout'] = timeout
+            return _FakeResponse()
+
+        monkeypatch.setenv('LLM_ENGINE_BASE_URL', 'http://engine.local:8080/v1/')
+        monkeypatch.setenv('LLM_ENGINE_API_KEY', 'sk-dec-test-key')
+        monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+        monkeypatch.setattr(mr, '_ENGINE_MODELS_TIMEOUT', 12.0)
+
+        models = mr._fetch_engine_models()
+
+        assert captured == {
+            'url': 'http://engine.local:8080/v1/models',
+            'authorization': 'Bearer sk-dec-test-key',
+            'timeout': 12.0,
+        }
+        assert 'engine-llama3.2-3b' in models
+
 
 # ---------------------------------------------------------------------------
 # v2.43.1: Nemotron CoT-leak fix — reasoning-family models must opt into
@@ -3711,7 +3751,8 @@ class TestCallEngineEnableThinking:
                 self.completions = _FakeCompletions()
 
         class _FakeOpenAI:
-            def __init__(self, **_):
+            def __init__(self, **kwargs):
+                captured['init_kwargs'] = kwargs
                 self.chat = _FakeChat()
 
         import openai
@@ -3733,6 +3774,24 @@ class TestCallEngineEnableThinking:
         assert sent.get('extra_body') == {
             'chat_template_kwargs': {'enable_thinking': True}
         }, "reasoning models must opt into enable_thinking via extra_body"
+
+    def test_call_engine_uses_configured_engine_auth(self, monkeypatch, _fake_openai_client):
+        from ai_assistant.model_registry import call_engine
+        monkeypatch.setenv('LLM_ENGINE_BASE_URL', 'http://engine.local:8080/v1')
+        monkeypatch.setenv('LLM_ENGINE_API_KEY', 'sk-dec-test-key')
+        cfg = {
+            'provider': 'engine',
+            'model_id': 'llama3.2:3b',
+            'max_tokens': 4096,
+            'temperature': 0.4,
+            'supports_tools': True,
+            'reasoning': False,
+        }
+
+        call_engine([{'role': 'user', 'content': 'hi'}], cfg)
+
+        assert _fake_openai_client['init_kwargs']['api_key'] == 'sk-dec-test-key'
+        assert _fake_openai_client['init_kwargs']['base_url'] == 'http://engine.local:8080/v1'
 
     def test_non_reasoning_model_omits_extra_body(self, _fake_openai_client):
         from ai_assistant.model_registry import call_engine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     ports:
       - "8001:8001"
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - DJANGO_ALLOWED_HOSTS=*
       - DATQ_MAX_CELLS=20000000
@@ -22,7 +23,9 @@ services:
       # host. Use 8090 if you're running the containerised topology with
       # nginx in front of multiple engine replicas.
       - LLM_ENGINE_BASE_URL=${LLM_ENGINE_BASE_URL:-http://host.docker.internal:8080/v1}
-      - LLM_ENGINE_API_KEY=${LLM_ENGINE_API_KEY:-sk-engine-local}
+      # Required when engine auth is enabled. Do not commit the raw key; set it
+      # in .env or the deployment secret manager for the declarai-auto-ml tenant.
+      - LLM_ENGINE_API_KEY=${LLM_ENGINE_API_KEY:?set LLM_ENGINE_API_KEY from the private engine secret handoff}
     depends_on:
       - redis
     # Mount project root for live-reload development (Django autoreload)


### PR DESCRIPTION
## Summary
- add a checked-in `.env.example` for the LLM engine base URL and private bearer key slot
- make Docker Compose treat `.env` as optional but require `LLM_ENGINE_API_KEY` before starting the backend
- document the secure secret handoff and runtime `/v1/models` verification command
- add unit coverage that engine discovery and chat calls use the configured bearer key

## Why
The dedicated DeclarAI AutoML engine bearer key must be supplied through deployment secrets, not committed defaults. This prevents AutoML deployments from silently using the old local placeholder token when engine auth is enabled.

Closes #40.

## Validation
- `LLM_ENGINE_API_KEY=sk-dec-test-key docker compose config --quiet`
- `docker build -f docker/backend.Dockerfile -t auto-ml-issue-40-backend .`
- `docker run --rm -v /Users/caglarsubasi/.codex/worktrees/auto-ml-issue-40:/app -w /app/backend auto-ml-issue-40-backend python -m pytest tests/test_unit.py::TestModelRegistry tests/test_unit.py::TestCallEngineEnableThinking tests/test_prometa_bundle_runner.py -q` -> 39 passed
- `docker run --rm --network auto-ml_default -e REDIS_URL=redis://auto-ml-redis-1:6379/0 -v /Users/caglarsubasi/.codex/worktrees/auto-ml-issue-40:/app -w /app/backend auto-ml-issue-40-backend python -m pytest tests/test_unit.py::TestPrometaAMLHelpers::test_cache_get_wraps_redis_fetch_in_cache_lookup_with_hit tests/test_unit.py::TestPrometaAMLHelpers::test_cache_get_wraps_redis_fetch_in_cache_lookup_with_miss -q` -> 2 passed

Note: local pre-commit/pre-push hooks are wired to the already-running `auto-ml-backend-1` container from the original checkout; that stale container lacks the `cryptography` dependency already declared in `backend/requirements.txt`, so I validated this branch with a fresh backend image built from the branch instead.