### PR TITLE
[codex] Fix assistant preprocessing option sync

### DIFF
--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.spec.ts
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.spec.ts
@@ -458,6 +458,27 @@ describe('AiChatPanelComponent', () => {
         { column: 'Var_3', value: 'drop' },
       ]);
     });
+
+    it('should mirror preprocessing_options updates into the purifier selector', (done) => {
+      // Regression guard for the 28 -> 29 purifier swap: update_config
+      // can return success, but the left-hand Data Purifier UI must also
+      // receive the new checkbox set.
+      sharedService.purifierSelectionUpdates$.subscribe(received => {
+        expect(received).toEqual({
+          form: 'wholesale',
+          purifier_options: [1, 2, 3, 4, 7, 23, 29, 32],
+          add: [],
+          remove: [],
+        });
+        done();
+      });
+      (component as any)._handleActionResult('update_config', {
+        applied: [
+          { key: 'preprocessing_options', value: [1, 2, 3, 4, 7, 23, 29, 32] },
+        ],
+        errors: [],
+      });
+    });
   });
 
   // ── start_sfs response handling (v2.25.0+) ────────────────────────────

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
@@ -637,9 +637,21 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
           if (upd.reason) entry.reason = String(upd.reason);
           featureUsageBatch.push(entry);
         }
+      } else if (upd.key === 'preprocessing_options') {
+        if (Array.isArray(upd.value)) {
+          const purifierOptions = upd.value
+            .map((id: any) => Number(id))
+            .filter((id: number) => Number.isInteger(id));
+          this.sharedService.emitPurifierSelectionUpdate({
+            form: 'wholesale',
+            purifier_options: purifierOptions,
+            add: [],
+            remove: [],
+          });
+        }
       }
-      // Other config keys (preprocessing_options, split_strategy, etc.) are handled
-      // by triggering a checkpoint which the parent components pick up
+      // Other config keys (split_strategy, etc.) are handled by triggering a
+      // checkpoint which the parent components pick up.
     }
     if (featureUsageBatch.length) {
       this.sharedService.emitFeatureUsageUpdates(featureUsageBatch);


### PR DESCRIPTION
## Summary

- Mirror `update_config` responses for `preprocessing_options` into the existing purifier-selection update stream.
- Add a regression spec for the assistant-driven 28 -> 29 purifier option swap.

## Root Cause

The backend action correctly returned `preprocessing_options` as applied, but the chat panel's generic `update_config` frontend handler only patched `model_usage` and `feature_usage`. The visible Data Purifier selector never received the new option IDs, so chat showed Applied while the left-hand UI stayed stale.

## Validation

- `npx ng test --watch=false --browsers=ChromeHeadless --include=src/app/ai-chat-panel/ai-chat-panel.component.spec.ts` reported 89 successful specs before the local Karma runner was stopped after it did not exit cleanly.
- `npm run build`
- Pre-commit hook: backend 950 tests, frontend build, frontend 421 Karma specs.
- Pre-push hook: backend 950 tests, frontend build, frontend 421 Karma specs.
- Browser sanity check: `http://127.0.0.1:4200/model-development` loaded with no console errors.