### PR TITLE
[codex] Add hyperparameter results AI support

### DIFF
--- a/frontend/src/app/modeling/modeling.component.html
+++ b/frontend/src/app/modeling/modeling.component.html
@@ -1278,6 +1278,13 @@
               </div>
             </div>
           </div>
+
+          <!-- AI Support trigger for completed Hyperparameter Results -->
+          <div style="margin-top: 16px; display: flex; justify-content: flex-end;">
+            <button class="ai-support-btn" (click)="requestAiSupport(getHyperparamResultsContext(), 'hyperparameter_results', 'Analyze ONLY the completed hyperparameter tuning results below. Compare CV, test, and train metrics for overfitting or shrinkage, explain which hyperparameters drove performance, evaluate the suggested next search space and brushed validation-curve ranges, and recommend the next tuning action. Do NOT re-run tuning unless I explicitly ask.')">
+              <span class="ai-support-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 2L12.5 9.5L20 12L12.5 14.5L10 22L7.5 14.5L0 12L7.5 9.5L10 2Z" fill="currentColor"/><path d="M20 4L21 7L24 8L21 9L20 12L19 9L16 8L19 7L20 4Z" fill="currentColor" opacity="0.7"/><path d="M20 16L20.75 18.25L23 19L20.75 19.75L20 22L19.25 19.75L17 19L19.25 18.25L20 16Z" fill="currentColor" opacity="0.5"/></svg></span> Get AI Support
+            </button>
+          </div>
         </div>
 
         <!-- ===== Configuration / Next-run panel (hidden while running) ===== -->

--- a/frontend/src/app/modeling/modeling.component.spec.ts
+++ b/frontend/src/app/modeling/modeling.component.spec.ts
@@ -1463,6 +1463,51 @@ describe('ModelingComponent', () => {
       expect(component.hpDurationSeconds).toBe(12.3);
     });
 
+    it('getHyperparamResultsContext packages completed results and next-search config', () => {
+      component.hpResults = { status: 'completed', search_method: 'random', feature_count: 12 } as any;
+      component.hpBestPoints = { roc_auc: { params: { max_depth: 4 }, cv_mean: 0.9 } };
+      component.hpValidationCurves = [{ param: 'max_depth', values: [2, 4], cv_mean: [0.8, 0.9] }] as any;
+      component.hpEmphasized = { most_cv_gain: 'max_depth' };
+      component.hpParamImportance = { cv_gain: { max_depth: 0.7 } };
+      component.hpGuidance = [{ param: 'max_depth', type: 'zoom_in', suggested_range: [2, 6], rationale: 'peak' }];
+      component.hpSelectedRanges = { max_depth: [2, 6] };
+      component.hpNIter = 44;
+      component.hpPrimaryMetric = 'roc_auc';
+
+      const ctx = component.getHyperparamResultsContext();
+
+      expect(ctx.hyperparameter_results.search_method).toBe('random');
+      expect(ctx.hyperparameter_results.feature_count).toBe(12);
+      expect(ctx.hyperparameter_results.best_points.roc_auc.cv_mean).toBe(0.9);
+      expect(ctx.hyperparameter_results.validation_curves.length).toBe(1);
+      expect(ctx.hyperparameter_results.selected_next_ranges.max_depth).toEqual([2, 6]);
+      expect(ctx.next_search_config.n_iter).toBe(44);
+      expect(ctx.next_search_config.primary_metric).toBe('roc_auc');
+      expect(ctx.next_search_config.enabled_params.length).toBeGreaterThan(0);
+    });
+
+    it("renders a Hyperparameter Results 'Get AI Support' button and routes the scoped context", () => {
+      spyOn(component, 'requestAiSupport').and.callFake(() => { /* no-op */ });
+      component.modelingStatus = { model: {} } as any;
+      component.hpResults = { status: 'completed', search_method: 'grid', feature_count: 8 } as any;
+      component.hpBestPoints = { roc_auc: { params: { max_depth: 4 }, cv_mean: 0.9 } };
+      component.hpValidationCurves = [{ param: 'max_depth', values: [2, 4], cv_mean: [0.8, 0.9] }] as any;
+      component.hpRunning = false;
+      fixture.detectChanges();
+
+      const btns = fixture.nativeElement.querySelectorAll('.hp-section .ai-support-btn');
+      expect(btns.length).withContext('Only the hyperparameter-results support button should render in hp-section').toBe(1);
+      expect((btns[0].textContent || '').trim()).toContain('Get AI Support');
+
+      (btns[0] as HTMLButtonElement).click();
+
+      const args = (component.requestAiSupport as jasmine.Spy).calls.mostRecent().args;
+      expect(args[1]).toBe('hyperparameter_results');
+      expect(args[0].hyperparameter_results.best_points.roc_auc.cv_mean).toBe(0.9);
+      expect(args[0].hyperparameter_results.validation_curves.length).toBe(1);
+      expect(args[2]).toContain('Analyze ONLY the completed hyperparameter tuning results');
+    });
+
     it('hpBestPointRows returns rows only for present metrics, in metric order', () => {
       component.hpBestPoints = {
         f1: { cv_mean: 0.5 }, roc_auc: { cv_mean: 0.9 },

--- a/frontend/src/app/modeling/modeling.component.ts
+++ b/frontend/src/app/modeling/modeling.component.ts
@@ -3107,6 +3107,38 @@ export class ModelingComponent implements OnInit, AfterViewInit {
       .join(', ');
   }
 
+  /** Context payload for the Hyperparameter Results AI Support button. */
+  getHyperparamResultsContext(): any {
+    return {
+      hyperparameter_results: {
+        status: this.hpResults?.status || 'completed',
+        search_method: this.hpResults?.search_method || this.hpResolvedMethod(),
+        feature_count: this.hpResults?.feature_count ?? this.getFinalSelectedFeatures().length,
+        selected_features: this.getFinalSelectedFeatures(),
+        duration_seconds: this.hpDurationSeconds,
+        best_points: this.hpBestPoints || {},
+        best_point_rows: this.hpBestPointRows(),
+        emphasized: this.hpEmphasized || {},
+        param_importance: this.hpParamImportance || {},
+        guidance: this.hpGuidance || [],
+        validation_curves: this.hpValidationCurves || [],
+        selected_next_ranges: this.hpSelectedRanges || {},
+      },
+      next_search_config: {
+        search_method: this.hpSearchMethod,
+        resolved_method: this.hpResolvedMethod(),
+        recommended_method: this.hpRecommendedMethod(),
+        enabled_params: this.hpParamSpace.filter(r => r.enabled).map(r => r.name),
+        param_space: this.hpParamSpace,
+        n_iter: this.hpNIter,
+        cv_folds: this.hpCvFolds,
+        n_jobs: this.hpNJobs,
+        primary_metric: this.hpPrimaryMetric,
+        validation_curve_points: this.hpValidationCurvePoints,
+      },
+    };
+  }
+
   /** Emphasis badge helpers: which param drives overfitting/CV-gain/shrinkage. */
   hpEmphasisParam(kind: 'most_cv_gain' | 'most_overfitting' | 'most_shrinkage'): string | null {
     return this.hpEmphasized?.[kind] || null;

--- a/frontend/src/app/services/ai-assistant.service.spec.ts
+++ b/frontend/src/app/services/ai-assistant.service.spec.ts
@@ -252,18 +252,20 @@ describe('AiAssistantService', () => {
       expect(after).toBeNull();
     });
 
-    // ── v2.41.0: new section names round-trip through requestSupport() ──
-    // The new 'Get AI Support' buttons (Data Purifier + per-table SFS x3)
+    // ── v2.41.0+: new section names round-trip through requestSupport() ──
+    // The new 'Get AI Support' buttons (Data Purifier + per-table SFS x3
+    // + Hyperparameter Results)
     // each pass a distinct section name.  Pin them here so a future
     // rename in the templates also fails this test, not just a
     // template-render check.  Section name is the only stable handle
     // the backend has to tell which UI surface the user clicked from.
-    it('v2.41.0 section names (data_purifier, sfs_forward, sfs_backward, sfs_forward_from_backward) round-trip', () => {
+    it('v2.41.0+ section names round-trip', () => {
       const cases: Array<[string, string]> = [
         ['data_purifier',             'Analyze the purifier output'],
         ['sfs_forward',               'Analyze ONLY forward'],
         ['sfs_backward',              'Analyze ONLY backward'],
         ['sfs_forward_from_backward', 'Analyze ONLY forward-from-backward'],
+        ['hyperparameter_results',    'Analyze ONLY hyperparameter results'],
       ];
       for (const [section, prompt] of cases) {
         service.requestSupport({ marker: section }, section, prompt);

--- a/frontend/src/app/services/ai-assistant.service.ts
+++ b/frontend/src/app/services/ai-assistant.service.ts
@@ -40,6 +40,7 @@ export const AI_SUPPORT_INTENTS_BY_SECTION: { [section: string]: AiIntentLabel[]
   sfs_forward: ['C'],
   sfs_backward: ['C'],
   sfs_forward_from_backward: ['C'],
+  hyperparameter_results: ['C'],
 };
 
 export interface ChatMessage {


### PR DESCRIPTION
## Summary

- Add a `Get AI Support` button under completed Hyperparameter Tuning results.
- Send a scoped `hyperparameter_results` context with best points, validation curves, emphasized parameters, guidance, selected next ranges, and next-search config.
- Register the new support section so button-triggered assistant turns keep the modeling-analysis intent.
- Add regression coverage for the context payload, rendered button, click wiring, and section-name round trip.

## Validation

- `npx ng test --watch=false --browsers=ChromeHeadless --include=src/app/modeling/modeling.component.spec.ts --include=src/app/services/ai-assistant.service.spec.ts` reached `TOTAL: 110 SUCCESS` before the local Karma runner was stopped after it did not exit cleanly.
- `npm run build`
- Browser sanity check: `http://127.0.0.1:4200/model-development` loaded with no console errors.
- Pre-commit hook: backend 950 tests, frontend build, frontend 423 Karma specs.
- Pre-push hook: backend 950 tests, frontend build, frontend 423 Karma specs.