### PR TITLE
Mark all DeclarAI tool spans for MCP discovery

### DIFF
--- a/backend/ai_assistant/action_executor.py
+++ b/backend/ai_assistant/action_executor.py
@@ -22,7 +22,7 @@ from declaration.models import Declaration, DataDictionary
 
 from .prometa_config import (
     workflow, tool, set_span_attr, set_session_id, set_customer_id,
-    schema_validate, set_input_ref,
+    schema_validate, set_input_ref, stamp_mcp_tool_marker,
 )
 
 
@@ -62,6 +62,14 @@ _SAFE_BUILTINS = {
     'False': False,
     'None': None,
 }
+
+
+def _stamp_action_mcp_marker(action_type: str) -> None:
+    """Mark direct action handler spans with their governed MCP tool name."""
+    stamp_mcp_tool_marker(
+        action_type.replace('_', '-'),
+        mcp_tool_name=f'declarai.action.{action_type}',
+    )
 
 
 def _load_dataframe(file_id: int) -> tuple:
@@ -336,6 +344,7 @@ def execute_code(file_id: int, payload: dict) -> dict:
         "description": "Human-readable summary of what the code does"
     }
     """
+    _stamp_action_mcp_marker('execute_code')
     code = payload.get('code', '').strip()
     description = payload.get('description', '')
     if not code:
@@ -475,6 +484,7 @@ def update_metadata(file_id: int, payload: dict) -> dict:
         "description": "..."
     }
     """
+    _stamp_action_mcp_marker('update_metadata')
     updates = payload.get('updates', [])
     description = payload.get('description', '')
     if not updates:
@@ -536,6 +546,7 @@ def update_config(file_id: int, payload: dict) -> dict:
         "description": "..."
     }
     """
+    _stamp_action_mcp_marker('update_config')
     updates = payload.get('updates', [])
     description = payload.get('description', '')
     if not updates:
@@ -658,6 +669,7 @@ def start_sfs(file_id: int, payload: dict) -> dict:
         "description": "Start backward SFS, excluding Var_3 (VIF=9.39)"
     }
     """
+    _stamp_action_mcp_marker('start_sfs')
     description = payload.get('description', '')
 
     # ── v2.35.0: in-flight guard — refuse to spawn a duplicate run ──
@@ -953,6 +965,7 @@ def start_data_purifier(file_id: int, payload: dict) -> dict:
         "description": "Run preprocessing with default purifier options"
     }
     """
+    _stamp_action_mcp_marker('start_data_purifier')
     description = payload.get('description', '')
 
     # ── purifier_options ───────────────────────────────────────────
@@ -1132,6 +1145,7 @@ def update_purifier_selection(file_id: int, payload: dict) -> dict:
         Action result dict with `applied` shape documented in the
         module-level comment block.
     """
+    _stamp_action_mcp_marker('update_purifier_selection')
     # Imported lazily so importing this module never triggers a Django
     # apps registry walk through preprocessing's own imports.  Matches
     # the lazy-import pattern in _handle_get_purifier_options.
@@ -1422,6 +1436,7 @@ def apply_encoding(file_id: int, payload: dict) -> dict:
         "description": "Apply encoding plan with native library"
     }
     """
+    _stamp_action_mcp_marker('apply_encoding')
     description = payload.get('description', '')
     raw_use_native = payload.get('use_native', True)
     if not isinstance(raw_use_native, bool):
@@ -1489,6 +1504,7 @@ def start_modeling(file_id: int, payload: dict) -> dict:
         "description": "Start modeling with LightGBM"
     }
     """
+    _stamp_action_mcp_marker('start_modeling')
     description = payload.get('description', '')
 
     raw_algo = payload.get('algorithm', None)
@@ -1606,6 +1622,7 @@ def set_ordinal_ranking(file_id: int, payload: dict) -> dict:
     they observe is the encoding-plan dropdown also flipping to
     'Ordinal' when the ranking lands.
     """
+    _stamp_action_mcp_marker('set_ordinal_ranking')
     updates = payload.get('updates', [])
     description = payload.get('description', '')
     if not isinstance(updates, list) or not updates:
@@ -1794,6 +1811,7 @@ def start_hyperparameter(file_id: int, payload: dict) -> dict:
         "description": "Tune depth + learning rate, 60 trials"
     }
     """
+    _stamp_action_mcp_marker('start_hyperparameter')
     description = payload.get('description', '')
 
     # ── in-flight guard — refuse to spawn a duplicate run ──
@@ -1915,6 +1933,7 @@ def update_notes(file_id: int, payload: dict) -> dict:
         "description": "..."
     }
     """
+    _stamp_action_mcp_marker('update_notes')
     action = payload.get('action', 'add')
     position = payload.get('position', '')
     content = payload.get('content', '')

--- a/backend/ai_assistant/cache.py
+++ b/backend/ai_assistant/cache.py
@@ -17,7 +17,13 @@ import logging
 import os
 from typing import Any, Optional
 
-from .prometa_config import child_only_tool, set_span_attr, span_timer, cache_lookup
+from .prometa_config import (
+    child_only_tool,
+    set_span_attr,
+    span_timer,
+    cache_lookup,
+    stamp_mcp_tool_marker,
+)
 
 # ---------------------------------------------------------------------------
 # Tracing policy for cache ops (v2.22.3+)
@@ -105,6 +111,7 @@ def cache_put(file_id: int, artifact: str, data: Any, ttl: int = DEFAULT_TTL) ->
       - declarai.cache.elapsed_ms  elapsed time in milliseconds
     """
     with span_timer('declarai.cache'):
+        stamp_mcp_tool_marker('redis-set')
         set_span_attr('declarai.cache.file_id', file_id)
         set_span_attr('declarai.cache.artifact', artifact)
         set_span_attr('declarai.cache.ttl', ttl)
@@ -156,6 +163,7 @@ def cache_get(file_id: int, artifact: str) -> Optional[Any]:
     # — the existing legacy span shape continues unchanged.
     with cache_lookup('tool_call', key=cache_key) as ch:
         with span_timer('declarai.cache'):
+            stamp_mcp_tool_marker('redis-get')
             set_span_attr('declarai.cache.file_id', file_id)
             set_span_attr('declarai.cache.artifact', artifact)
             r = _get_redis()
@@ -207,6 +215,7 @@ def cache_put_bulk(file_id: int, artifacts: dict[str, Any], ttl: int = DEFAULT_T
       - declarai.cache.elapsed_ms   elapsed time in milliseconds
     """
     with span_timer('declarai.cache'):
+        stamp_mcp_tool_marker('redis-set-bulk')
         set_span_attr('declarai.cache.file_id', file_id)
         set_span_attr('declarai.cache.keys', ','.join(artifacts.keys()))
         set_span_attr('declarai.cache.key_count', len(artifacts))
@@ -248,6 +257,7 @@ def cache_delete(file_id: int, artifact: str) -> bool:
       - declarai.cache.elapsed_ms  elapsed time in milliseconds
     """
     with span_timer('declarai.cache'):
+        stamp_mcp_tool_marker('redis-delete')
         set_span_attr('declarai.cache.file_id', file_id)
         set_span_attr('declarai.cache.artifact', artifact)
         r = _get_redis()
@@ -282,6 +292,7 @@ def cache_list_artifacts(file_id: int) -> list[str]:
       - declarai.cache.elapsed_ms  elapsed time in milliseconds
     """
     with span_timer('declarai.cache'):
+        stamp_mcp_tool_marker('redis-list')
         set_span_attr('declarai.cache.file_id', file_id)
         prefix = f"ai:pipeline:{file_id}:"
         set_span_attr('declarai.cache.prefix', prefix)

--- a/backend/ai_assistant/mcp_server/observability.py
+++ b/backend/ai_assistant/mcp_server/observability.py
@@ -8,6 +8,7 @@ import os
 from collections.abc import Iterable
 
 from ai_assistant.prometa_config import (
+    DEFAULT_DECLARAI_MCP_SERVER_NAME,
     set_customer_id,
     set_session_id,
     set_span_attr,
@@ -39,6 +40,7 @@ def stamp_mcp_context(
     if tool_name:
         set_span_attrs(
             {
+                "mcp.server.name": DEFAULT_DECLARAI_MCP_SERVER_NAME,
                 "declarai.mcp.tool_name": tool_name,
                 "mcp.tool.name": tool_name,
                 "gen_ai.tool.name": tool_name,

--- a/backend/ai_assistant/prometa_config.py
+++ b/backend/ai_assistant/prometa_config.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 # rationale ((orgId, solutionId, agentName) on the auto-register side).
 DEFAULT_PROMETA_SOLUTION_ID = 'declarai-assistant'
 DEFAULT_PROMETA_AGENT_NAME = 'declarai-agent'
+DEFAULT_DECLARAI_MCP_SERVER_NAME = 'declarai'
 
 _prometa = None
 _initialized = False
@@ -200,6 +201,14 @@ def _make_lazy_decorator(kind: str):
     def decorator_factory(name, **kwargs):
         def decorator(fn):
             _traced = [None]  # mutable container for one-time caching
+            traced_fn = fn
+            if kind == 'tool':
+                marker_name = name or getattr(fn, '__name__', 'tool')
+
+                @functools.wraps(fn)
+                def traced_fn(*args, **kw):
+                    stamp_mcp_tool_marker(marker_name)
+                    return fn(*args, **kw)
 
             @functools.wraps(fn)
             def wrapper(*args, **kw):
@@ -207,9 +216,9 @@ def _make_lazy_decorator(kind: str):
                     p = get_prometa()
                     if p:
                         real_decorator = getattr(p, kind)(name=name, **kwargs)
-                        _traced[0] = real_decorator(fn)
+                        _traced[0] = real_decorator(traced_fn)
                     else:
-                        _traced[0] = fn
+                        _traced[0] = traced_fn
                 return _traced[0](*args, **kw)
             return wrapper
         return decorator
@@ -396,6 +405,39 @@ def set_span_attrs(attributes: dict) -> None:
     except Exception:
         for key, value in attributes.items():
             _set_span_attr_direct(key, value)
+
+
+def stamp_mcp_tool_marker(
+    tool_name: str,
+    *,
+    mcp_tool_name: str = None,
+    server_name: str = DEFAULT_DECLARAI_MCP_SERVER_NAME,
+) -> None:
+    """Stamp the standard MCP discovery markers on a tool-like span.
+
+    Prometa's MCP telemetry discovery keys off either ``mcp.*`` attributes or
+    the namespaced ``declarai.mcp.*`` producer metadata.  Use this helper on
+    every DeclarAI tool/cache/skill span, including spans that are reached via
+    the legacy in-process dispatcher rather than an external MCP ``tools/call``.
+
+    ``tool_name`` is the local classifier/display name already used by
+    ``gen_ai.tool.name`` and ``prometa.tool_name``. ``mcp_tool_name`` can be the
+    fully-qualified MCP catalog name when it differs, for example
+    ``declarai.get_pipeline_config`` for the internal ``get_pipeline_config``
+    dispatcher call.
+    """
+    if not tool_name:
+        return
+    resolved_mcp_tool_name = mcp_tool_name or tool_name
+    attrs = {
+        'mcp.server.name': server_name,
+        'mcp.tool.name': resolved_mcp_tool_name,
+        'declarai.mcp.tool_name': resolved_mcp_tool_name,
+        'gen_ai.tool.name': tool_name,
+        'prometa.tool_name': tool_name,
+    }
+    for key, value in attrs.items():
+        set_span_attr(key, value)
 
 
 def stamp_elapsed(prefix: str, t0_ns: int) -> int:

--- a/backend/ai_assistant/tool_executor.py
+++ b/backend/ai_assistant/tool_executor.py
@@ -10,7 +10,12 @@ import json
 import logging
 from typing import Any, Optional
 
-from .prometa_config import tool as prometa_tool, set_span_attr, span_timer
+from .prometa_config import (
+    tool as prometa_tool,
+    set_span_attr,
+    span_timer,
+    stamp_mcp_tool_marker,
+)
 from .skill_registry import get_skill, list_skills
 
 from .cache import (
@@ -47,6 +52,7 @@ def _not_available(name: str) -> str:
 
 def _stamp_read_attrs(artifact: str, data: Any) -> None:
     """Stamp common attributes on a ``cache-read:<artifact>`` span."""
+    stamp_mcp_tool_marker(f'cache-read:{artifact}')
     set_span_attr('declarai.cache.artifact', artifact)
     if data is None:
         set_span_attr('declarai.cache.hit', False)
@@ -208,6 +214,7 @@ def read_sfs_status(file_id: int) -> dict:
     ``modeling.views.SFSStatusView`` so the assistant and the UI agree
     on what state SFS is in.
     """
+    stamp_mcp_tool_marker('state-read:sfs_status')
     # Local import: ``modeling.views`` imports ``ai_assistant.cache``
     # transitively for tracing decorators; importing it at module load
     # would create a circular dependency.  Inside a function call all
@@ -766,6 +773,7 @@ def _load_skill_traced(skill_name: str) -> str:
       - declarai.skill.elapsed_ms   elapsed time in milliseconds
     """
     with span_timer('declarai.skill'):
+        stamp_mcp_tool_marker('skill-invoke', mcp_tool_name='declarai.invoke_skill')
         set_span_attr('declarai.skill.name', skill_name)
         skill = get_skill(skill_name)
         if not skill:
@@ -921,6 +929,7 @@ def _load_skill_file_traced(skill_name: str, rel_path: str) -> str:
       - declarai.skill.elapsed_ms     elapsed time in milliseconds
     """
     with span_timer('declarai.skill'):
+        stamp_mcp_tool_marker('skill-file-read', mcp_tool_name='declarai.get_skill_file')
         set_span_attr('declarai.skill.name', skill_name)
         set_span_attr('declarai.skill.file_path', rel_path)
         skill = get_skill(skill_name)
@@ -1008,9 +1017,9 @@ def execute_tool_call(file_id: int, tool_name: str, arguments: dict) -> str:
         A human-readable string with the tool result.
     """
     with span_timer('declarai.tool'):
+        mcp_tool_name = f'declarai.{tool_name}'
+        stamp_mcp_tool_marker(tool_name, mcp_tool_name=mcp_tool_name)
         set_span_attr('declarai.tool.name', tool_name)
-        set_span_attr('gen_ai.tool.name', tool_name)
-        set_span_attr('prometa.tool_name', tool_name)
         set_span_attr('declarai.tool.file_id', file_id)
         set_span_attr('declarai.tool.args_keys',
                       ','.join(sorted(arguments.keys())) if arguments else '')
@@ -1023,11 +1032,13 @@ def execute_tool_call(file_id: int, tool_name: str, arguments: dict) -> str:
             return result
         try:
             result = handler(file_id, arguments)
+            stamp_mcp_tool_marker(tool_name, mcp_tool_name=mcp_tool_name)
             set_span_attr('declarai.tool.ok', True)
             set_span_attr('declarai.tool.result_chars', len(result))
             logger.info("Tool %s executed for file_id=%s (result length=%d)", tool_name, file_id, len(result))
             return result
         except Exception as exc:
+            stamp_mcp_tool_marker(tool_name, mcp_tool_name=mcp_tool_name)
             set_span_attr('declarai.tool.ok', False)
             set_span_attr('declarai.tool.error', str(exc)[:200])
             logger.error("Tool execution error (%s): %s", tool_name, exc)

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -184,6 +184,7 @@ class TestMcpActionHelpers:
             tool_name="declarai.get_data_dictionary",
         )
 
+        assert captured["mcp.server.name"] == "declarai"
         assert captured["declarai.mcp.tool_name"] == "declarai.get_data_dictionary"
         assert captured["mcp.tool.name"] == "declarai.get_data_dictionary"
         assert captured["gen_ai.tool.name"] == "declarai.get_data_dictionary"

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -4256,14 +4256,20 @@ class TestInvokeSkillTool:
         """The dedicated traced loader stamps declarai.skill.* attributes so
         each skill invocation appears as a distinct child span."""
         from ai_assistant import tool_executor as te
+        from ai_assistant import prometa_config
         captured = {}
 
         def fake_set(key, value):
             captured[key] = value
 
         monkeypatch.setattr(te, 'set_span_attr', fake_set)
+        monkeypatch.setattr(prometa_config, 'set_span_attr', fake_set)
         result = te._load_skill_traced('feature-engineering')
         assert 'BEGIN SKILL CONTENT' in result
+        assert captured.get('mcp.server.name') == 'declarai'
+        assert captured.get('mcp.tool.name') == 'declarai.invoke_skill'
+        assert captured.get('gen_ai.tool.name') == 'skill-invoke'
+        assert captured.get('prometa.tool_name') == 'skill-invoke'
         assert captured.get('declarai.skill.name') == 'feature-engineering'
         assert captured.get('declarai.skill.found') is True
         assert isinstance(captured.get('declarai.skill.body_chars'), int)
@@ -5383,17 +5389,23 @@ class TestGetSkillFileTool:
 
     def test_load_skill_file_traced_sets_span_attributes(self, monkeypatch):
         from ai_assistant import tool_executor as te
+        from ai_assistant import prometa_config
         captured = {}
 
         def fake_set(key, value):
             captured[key] = value
 
         monkeypatch.setattr(te, 'set_span_attr', fake_set)
+        monkeypatch.setattr(prometa_config, 'set_span_attr', fake_set)
         result = te._load_skill_file_traced(
             'feature-engineering',
             'references/feature_engineering_best_practices.md',
         )
         assert 'BEGIN FILE CONTENT' in result
+        assert captured.get('mcp.server.name') == 'declarai'
+        assert captured.get('mcp.tool.name') == 'declarai.get_skill_file'
+        assert captured.get('gen_ai.tool.name') == 'skill-file-read'
+        assert captured.get('prometa.tool_name') == 'skill-file-read'
         assert captured.get('declarai.skill.name') == 'feature-engineering'
         assert captured.get('declarai.skill.file_path') == \
             'references/feature_engineering_best_practices.md'
@@ -5467,6 +5479,10 @@ class TestRedisSpanInstrumentation:
 
         try:
             assert result == {'k': 'v'}
+            assert cap.captured.get('mcp.server.name') == 'declarai'
+            assert cap.captured.get('mcp.tool.name') == 'redis-get'
+            assert cap.captured.get('gen_ai.tool.name') == 'redis-get'
+            assert cap.captured.get('prometa.tool_name') == 'redis-get'
             assert cap.captured.get('declarai.cache.file_id') == 42424
             assert cap.captured.get('declarai.cache.artifact') == 'test_span_artifact'
             assert cap.captured.get('declarai.cache.hit') is True
@@ -5610,6 +5626,10 @@ class TestCacheReadSpans:
             cap.captured.clear()
             data = read_pipeline_config(53000)
             assert data == {'pipeline_type': 'classification'}
+            assert cap.captured.get('mcp.server.name') == 'declarai'
+            assert cap.captured.get('mcp.tool.name') == 'cache-read:pipeline_config'
+            assert cap.captured.get('gen_ai.tool.name') == 'cache-read:pipeline_config'
+            assert cap.captured.get('prometa.tool_name') == 'cache-read:pipeline_config'
             assert cap.captured.get('declarai.cache.artifact') == 'pipeline_config'
             assert cap.captured.get('declarai.cache.hit') is True
             assert cap.captured.get('declarai.cache.shape') == 'dict'
@@ -5924,6 +5944,10 @@ class TestToolCallSpanRename:
             cap.captured.clear()
             out = execute_tool_call(60100, 'get_encoding_plan', {'top_n': 5})
             assert 'Encoding Plan' in out
+            assert cap.captured.get('mcp.server.name') == 'declarai'
+            assert cap.captured.get('mcp.tool.name') == 'declarai.get_encoding_plan'
+            assert cap.captured.get('declarai.mcp.tool_name') == \
+                'declarai.get_encoding_plan'
             assert cap.captured.get('declarai.tool.name') == 'get_encoding_plan'
             assert cap.captured.get('gen_ai.tool.name') == 'get_encoding_plan'
             assert cap.captured.get('prometa.tool_name') == 'get_encoding_plan'
@@ -5945,6 +5969,8 @@ class TestToolCallSpanRename:
 
         out = execute_tool_call(60101, 'no_such_tool', {})
         assert 'Unknown tool' in out
+        assert cap.captured.get('mcp.server.name') == 'declarai'
+        assert cap.captured.get('mcp.tool.name') == 'declarai.no_such_tool'
         assert cap.captured.get('declarai.tool.name') == 'no_such_tool'
         assert cap.captured.get('gen_ai.tool.name') == 'no_such_tool'
         assert cap.captured.get('prometa.tool_name') == 'no_such_tool'
@@ -5977,6 +6003,34 @@ class TestToolCallSpanRename:
         assert 'Error executing get_dq_summary' in out
         assert cap.captured.get('declarai.tool.ok') is False
         assert 'simulated handler failure' in cap.captured.get('declarai.tool.error', '')
+
+
+@pytest.mark.unit
+class TestActionToolMcpMarkers:
+    """Direct action handler spans must point at their governed MCP tools."""
+
+    def test_update_notes_stamps_direct_action_mcp_marker(self, monkeypatch):
+        from ai_assistant.action_executor import update_notes
+
+        cap = _SpanCapture()
+        _patch_span_attr(monkeypatch, 'ai_assistant.action_executor', capture=cap)
+
+        result = update_notes(
+            60104,
+            {
+                'action': 'add',
+                'position': 'after_data_preview',
+                'content': 'Reviewed.',
+            },
+        )
+
+        assert result['status'] == 'success'
+        assert cap.captured.get('mcp.server.name') == 'declarai'
+        assert cap.captured.get('mcp.tool.name') == 'declarai.action.update_notes'
+        assert cap.captured.get('declarai.mcp.tool_name') == \
+            'declarai.action.update_notes'
+        assert cap.captured.get('gen_ai.tool.name') == 'update-notes'
+        assert cap.captured.get('prometa.tool_name') == 'update-notes'
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add a shared MCP telemetry marker helper and apply it through the Prometa tool decorator path
- stamp governed MCP names on legacy chat tools, cache reads, skill reads, and direct action handlers
- add regression coverage for MCP server metadata, cache/read/tool/skill/action marker spans

Closes #45.

## Validation
- python -m compileall backend/ai_assistant
- pytest backend/tests/test_mcp_server.py backend/tests/test_prometa_bundle_runner.py -q
- pytest backend/tests/test_mcp_server.py backend/tests/test_unit.py -q -k "mcp_marker or MpcMarker or Mcp or mcp or ToolCallSpanRename or ActionToolMcpMarkers or SkillTool or SkillFile or RedisSpanInstrumentation or CacheReadSpans"
- .git/hooks/pre-commit: Backend 951 tests passed across 5 categories
- git push pre-push gate: Backend 951 tests passed, frontend build passed, 423 Karma specs passed

Note: local raw pytest backend/tests is blocked on this machine by missing system libmagic; the Docker hook gate passes.