### PR TITLE
[codex] Fix assistant model dropdown behavior

### DIFF
--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.css
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.css
@@ -98,7 +98,10 @@
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
   z-index: 1000;
   min-width: 200px;
-  overflow: hidden;
+  max-height: min(420px, calc(100vh - 96px));
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .model-option {

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.html
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.html
@@ -7,7 +7,7 @@
     </div>
     <div class="chat-header-actions">
       <!-- Model selector -->
-      <div class="model-selector-wrapper">
+      <div class="model-selector-wrapper" #modelSelectorWrapper>
         <button class="chat-action-btn model-selector-btn" (click)="toggleModelSelector()" title="Select model">
           <span class="model-selector-label">{{ getSelectedModelName() }}</span>
           <span class="model-selector-caret">&#9660;</span>

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.spec.ts
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.spec.ts
@@ -59,6 +59,47 @@ describe('AiChatPanelComponent', () => {
     expect(aiService.isPanelOpen()).toBeTrue();
   });
 
+  describe('model selector dropdown', () => {
+    beforeEach(() => {
+      spyOn(dataService, 'getAiModels').and.returnValue(of({
+        models: [
+          { key: 'gpt-5.5', display_name: 'GPT-5.5', provider: 'openai' },
+          { key: 'gemma4:26b', display_name: 'gemma4:26b', provider: 'engine' },
+        ],
+        default: 'gpt-5.5',
+      }));
+    });
+
+    it('should close when clicking outside the selector frame', () => {
+      fixture.detectChanges();
+      component.showModelSelector = true;
+
+      document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(component.showModelSelector).toBeFalse();
+    });
+
+    it('should stay open when clicking inside the selector frame', () => {
+      fixture.detectChanges();
+      component.showModelSelector = true;
+      fixture.detectChanges();
+
+      const wrapper: HTMLElement = fixture.nativeElement.querySelector('.model-selector-wrapper');
+      wrapper.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(component.showModelSelector).toBeTrue();
+    });
+
+    it('should close after selecting a model', () => {
+      component.showModelSelector = true;
+
+      component.selectModel('gemma4:26b');
+
+      expect(component.selectedModel).toBe('gemma4:26b');
+      expect(component.showModelSelector).toBeFalse();
+    });
+  });
+
   it('should forward preclassified button intent labels to /chat/', () => {
     spyOn(dataService, 'getAiModels').and.returnValue(of({
       models: [{ key: 'gpt-5.5', display_name: 'GPT-5.5', provider: 'openai' }],

--- a/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
+++ b/frontend/src/app/ai-chat-panel/ai-chat-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ViewChild, ElementRef, AfterViewChecked } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild, ElementRef, AfterViewChecked, HostListener } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { AiAssistantService, AiAction, AiFeedbackState, AiIntentLabel, ChatMessage } from '../services/ai-assistant.service';
 import { DataService } from '../services/data.service';
@@ -11,6 +11,7 @@ import { SharedService } from '../services/shared.service';
 })
 export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   @ViewChild('chatContainer') chatContainer!: ElementRef;
+  @ViewChild('modelSelectorWrapper') modelSelectorWrapper?: ElementRef<HTMLElement>;
 
   messages: ChatMessage[] = [];
   userInput: string = '';
@@ -832,6 +833,17 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked
 
   toggleModelSelector(): void {
     this.showModelSelector = !this.showModelSelector;
+  }
+
+  @HostListener('document:click', ['$event'])
+  closeModelSelectorOnOutsideClick(event: MouseEvent): void {
+    if (!this.showModelSelector) return;
+
+    const wrapper = this.modelSelectorWrapper?.nativeElement;
+    const target = event.target;
+    if (!wrapper || !(target instanceof Node) || !wrapper.contains(target)) {
+      this.showModelSelector = false;
+    }
   }
 
   selectModel(modelKey: string): void {


### PR DESCRIPTION
## Summary
- Make the AI Assistant model selector dropdown viewport-bounded and independently scrollable for long model catalogs.
- Close the model selector when users click outside its frame while preserving inside-click and model-selection behavior.
- Add focused Angular specs for outside click, inside click, and selection-close behavior.

## Root Cause
The custom selector used `overflow: hidden` with no max height, so long catalogs rendered past the chat panel and viewport. It also only closed when toggled or when a model was selected, leaving the menu open after unrelated clicks.

## Validation
- `npm test -- --watch=false --browsers=ChromeHeadless --include src/app/ai-chat-panel/ai-chat-panel.component.spec.ts` (92 specs passed)
- `npm run build` (passed; existing Angular warnings only)
- Rendered-page Playwright probe on `http://127.0.0.1:4300/model-development` with a mocked 25-model catalog: verified `overflow-y: auto`, capped dropdown height, successful dropdown scroll, and close on outside click
- Pre-commit gate: backend 957 tests passed across 5 categories; frontend build passed; frontend Karma 426 specs passed
- Pre-push gate: backend 957 tests passed across 5 categories; frontend build passed; frontend Karma 426 specs passed